### PR TITLE
feat(ci): add release-plz workflow for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: release-pr
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      contains(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow for automated releases using release-plz
- Workflow creates release PRs based on conventional commits
- Automatically publishes to crates.io and creates GitHub releases

## Details
The workflow has two jobs:
1. **release-pr**: Runs on every push to master, analyzes conventional commits, updates version and changelog, creates/updates release PR
2. **release**: Triggers when release PR is merged, publishes to crates.io and creates GitHub release

## Test plan
- [x] Add `CARGO_REGISTRY_TOKEN` secret to repository
- [ ] Merge this PR
- [ ] Verify release-plz creates a release PR on next push to master
- [ ] Merge release PR and verify crates.io publication