### PR TITLE
ci: add retry logic for ansible-galaxy install

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,8 +39,21 @@ jobs:
             "pipx:ansible-lint" = "latest"
       - run: mise settings experimental=true
 
-      - run: ansible-galaxy collection install -r requirements.yml
+      - name: Install Ansible collections with retry
         working-directory: ansible
+        shell: bash
+        run: |
+          max_attempts=3
+          attempt=1
+          until ansible-galaxy collection install -r requirements.yml || [ $attempt -eq $max_attempts ]; do
+            echo "Attempt $attempt failed. Retrying in 10 seconds..."
+            sleep 10
+            attempt=$((attempt + 1))
+          done
+          if [ $attempt -eq $max_attempts ]; then
+            echo "Failed after $max_attempts attempts"
+            exit 1
+          fi
 
       - run: mise r check
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
   - name: community.general
-    version: ">=10.0.0"
+    version: ">=10.0.0,<13.0.0"
   - name: ansible.posix
     version: ">=2.0.0"


### PR DESCRIPTION
## Summary
- Adds retry logic (3 attempts with 10s delay) to `ansible-galaxy collection install` in CI workflow
- Updates `community.general` version constraint to `>=10.0.0,<13.0.0`

## Problem
Ansible Galaxy API has been experiencing intermittent 500 errors when fetching collection metadata, causing CI failures with:
```
Error when getting collection version metadata for community.general:12.2.0 from default (https://galaxy.ansible.com/api/) (HTTP Code: 500, Message: Internal Server Error Code: Unknown)
```

## Solution
This is a known issue with Galaxy API ([ansible/galaxy#3086](https://github.com/ansible/galaxy/issues/3086), [ansible/galaxy#3345](https://github.com/ansible/galaxy/issues/3345)). The retry logic makes the CI more resilient to these transient failures.

## Test plan
- [x] Tested retry logic locally
- [ ] Verify CI passes on this PR

Closes #34