### PR TITLE
feat: add port 853 warning for blocky DNS over TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ Backup operations support flexible SSH key configuration. See [docs/ssh.md](docs
 | [fail2ban](https://github.com/fail2ban/fail2ban) | Intrusion prevention system        |
 | [UFW](https://launchpad.net/ufw)                 | Uncomplicated firewall             |
 
+**Required VPS Provider Firewall Ports:**
+
+- **Custom SSH port**: Set via `SSH_PORT` environment variable (shown in CLI warnings)
+- **80 (HTTP)**: For HTTP traffic and ACME challenges
+- **443 (HTTPS)**: For HTTPS traffic
+- **853 (DNS over TLS)**: For Blocky DNS service
+
 ### Apps
 
 | Category      | Name                                        | Description                          |

--- a/src/commands/ansible.rs
+++ b/src/commands/ansible.rs
@@ -155,6 +155,30 @@ pub fn run_ansible_run(
             eprintln!("\nAborted. Configure Cloudflare API token first, then re-run.");
             std::process::exit(1);
         }
+
+        eprintln!("\n⚠️  IMPORTANT: VPS Provider Firewall - Port 853 Required");
+        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        eprintln!("For DNS over TLS with Blocky, your VPS provider's firewall");
+        eprintln!("must allow incoming TCP connections on port 853.");
+        eprintln!();
+        eprintln!("Required steps:");
+        eprintln!("  1. Log into your VPS provider dashboard (IONOS, etc.)");
+        eprintln!("  2. Navigate to firewall or security settings");
+        eprintln!("  3. Add firewall rule: Allow TCP on port 853");
+        eprintln!("  4. Save and confirm the rule is active");
+        eprintln!();
+        eprintln!("Without this, DNS over TLS will not be accessible!");
+        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+        print!("Have you opened port 853 in your provider's firewall? [y/N]: ");
+        io::stdout().flush()?;
+        let mut port_response = String::new();
+        io::stdin().read_line(&mut port_response)?;
+
+        if !port_response.trim().eq_ignore_ascii_case("y") {
+            eprintln!("\nAborted. Open port 853 in provider firewall first, then re-run.");
+            std::process::exit(1);
+        }
     }
 
     eprintln!(


### PR DESCRIPTION
## Summary
- Add CLI warning when running `apps.yml` or `auberge.yml` playbooks to ensure users open port 853 in their VPS provider firewall for Blocky DNS over TLS
- Document all required VPS provider firewall ports in README
- Created issue #37 to track future enhancement for showing warnings only once per host/playbook combination

## Changes
- `src/commands/ansible.rs`: Add port 853 firewall warning that prompts user before running apps playbook
- `README.md`: Add "Required VPS Provider Firewall Ports" section documenting all necessary ports (SSH, 80, 443, 853)

## Test plan
- [x] Run `auberge ansible run` and select `apps.yml` or `auberge.yml` playbook
- [x] Verify port 853 warning appears after Cloudflare API token warning
- [x] Verify warning includes clear instructions for opening port 853
- [x] Verify answering "N" aborts the playbook
- [x] Verify answering "y" proceeds with playbook execution

Fixes #30