### PR TITLE
ci: harden workflow permissions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,4 +1,6 @@
 name: master
+permissions:
+  contents: read
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/sripwoud/auberge/security/code-scanning/2](https://github.com/sripwoud/auberge/security/code-scanning/2)

In general, this problem is fixed by adding an explicit `permissions:` block either at the workflow root (applies to all jobs) or per job (overrides the root). The block should grant only the minimum scopes needed, typically `contents: read` for workflows that only need to read repository content and do not push commits, create releases, or modify issues/PRs.

For this workflow, none of the jobs perform actions that require write access: they check out code, compute changed files, run tooling via `mise`, install Ansible collections, and run Rust tests. The safest and simplest fix without changing existing functionality is to add a root-level `permissions:` block immediately after the `name: master` line, with `contents: read`. This will constrain the `GITHUB_TOKEN` for all jobs in this workflow to read-only repository contents, which is sufficient for `actions/checkout` and similar steps. No additional methods, definitions, or imports are needed since this is purely a YAML configuration change in `.github/workflows/master.yml`.

Concretely, edit `.github/workflows/master.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: master`). All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
