### PR TITLE
docs: add pre-compiled binary install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Auberge is a CLI tool for managing self-hosted infrastructure using Ansible auto
 
 ## Quick Start
 
-Install Auberge:
+Install Auberge from a [pre-compiled binary](https://github.com/sripwoud/auberge/releases/latest) or via cargo:
 
 ```bash
 cargo install auberge
@@ -61,7 +61,6 @@ Full documentation available at [auberge.sripwoud.xyz](https://auberge.sripwoud.
 
 ## Requirements
 
-- Rust/Cargo for installation
 - A VPS with root/sudo access
 - SSH connectivity to your VPS
 - (Optional) Cloudflare account for DNS management

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,21 +2,18 @@
 
 ## Prerequisites
 
-- Rust and Cargo (latest stable)
 - A VPS with root/sudo access
 - SSH connectivity to your VPS
 
-## Install Rust
+## Pre-compiled binaries
 
-If you don't have Rust installed:
+Download a binary for your platform from the [latest release](https://github.com/sripwoud/auberge/releases/latest). Binaries are available for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon), and Windows (x64).
 
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
+Extract it somewhere on your `PATH`, e.g. `~/.local/bin`.
 
-Follow the prompts and restart your shell.
+## Install from crates.io
 
-## Install Auberge
+Requires [Rust](https://rustup.rs/).
 
 ```bash
 cargo install auberge


### PR DESCRIPTION
## Summary
- Adds pre-compiled binary download instructions as the primary install method in README and docs
- Removes Rust/Cargo as a hard requirement
- Links to GitHub releases page for binary downloads