### PR TITLE
fix(apt): remove obsolete golang-1.24 apt pin

### DIFF
--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -6,7 +6,7 @@
         state: present
         update_cache: true
 
-    - name: Add Debian Testing repository (for specific packages like dasel)
+    - name: Add Debian Testing repository (for specific packages like dasel and bind9)
       when: ansible_distribution == "Debian"
       ansible.builtin.copy:
         content: |
@@ -35,6 +35,7 @@
         group: root
         mode: "0644"
     - name: Remove obsolete golang-1.24 APT pinning (trixie is now stable)
+      when: ansible_distribution == "Debian"
       ansible.builtin.file:
         path: /etc/apt/preferences.d/golang-1.24.pref
         state: absent


### PR DESCRIPTION
## Summary
- Remove the `golang-1.24.pref` apt preferences file that was blocking third-party repos (Tailscale, Adoptium/Java)
- The pin was a leftover from when the VPS ran bookworm and golang-1.24 was cherry-picked from trixie (testing)
- Now that the VPS runs trixie (Debian 13/stable), golang-1.24 already gets priority 900 from the `a=stable` pin in `dasel_pinning.pref`
- The broad `Package: * / Pin: release n=trixie / Pin-Priority: -1` wildcard was catching any third-party repo advertising `trixie` as its release name

## Test plan
- [ ] Run `ansible-playbook -l auberge ansible/playbooks/infrastructure.yml` — apt role removes the stale pref file
- [ ] `ssh auberge 'apt-cache policy tailscale'` — candidate should show version at priority 500 (not -1)
- [ ] `ssh auberge 'apt-cache policy temurin-21-jdk'` — Adoptium also unblocked
- [ ] `ssh auberge 'apt-cache policy golang-1.24'` — still installable at priority 900 from stable

Closes #95