### PR TITLE
refactor(ansible): migrate deprecated facts to `ansible_facts` dict

### DIFF
--- a/ansible/roles/apt/tasks/main.yml
+++ b/ansible/roles/apt/tasks/main.yml
@@ -7,7 +7,7 @@
         update_cache: true
 
     - name: Add Debian Testing repository (for specific packages like dasel and bind9)
-      when: ansible_distribution == "Debian"
+      when: ansible_facts['distribution'] == "Debian"
       ansible.builtin.copy:
         content: |
           deb http://deb.debian.org/debian/ testing main contrib non-free non-free-firmware
@@ -16,7 +16,7 @@
         group: root
         mode: "0644"
     - name: Configure APT pinning for dasel (prefer testing over stable)
-      when: ansible_distribution == "Debian"
+      when: ansible_facts['distribution'] == "Debian"
       ansible.builtin.copy:
         content: |
           Package: *
@@ -35,12 +35,12 @@
         group: root
         mode: "0644"
     - name: Remove obsolete golang-1.24 APT pinning (trixie is now stable)
-      when: ansible_distribution == "Debian"
+      when: ansible_facts['distribution'] == "Debian"
       ansible.builtin.file:
         path: /etc/apt/preferences.d/golang-1.24.pref
         state: absent
     - name: Set up APT pinning for bind9 packages
-      when: ansible_distribution == "Debian"
+      when: ansible_facts['distribution'] == "Debian"
       ansible.builtin.copy:
         content: |
           Package: bind9-libs bind9-dnsutils bind9-host

--- a/ansible/roles/ssh/tasks/validate.yml
+++ b/ansible/roles/ssh/tasks/validate.yml
@@ -22,7 +22,7 @@
     - name: Wait for SSH to be available on new port
       ansible.builtin.wait_for:
         port: "{{ ssh_port }}"
-        host: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"
+        host: "{{ ansible_facts['default_ipv4']['address'] | default(ansible_facts['all_ipv4_addresses'][0]) }}"
         delay: 2
         timeout: 30
         state: started

--- a/ansible/roles/tailscale/defaults/main.yml
+++ b/ansible/roles/tailscale/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Tailscale configuration
 tailscale_authkey: "" # Required for initial auth — set in config.toml
-tailscale_hostname: "{{ ansible_hostname }}" # Hostname to use in tailnet
+tailscale_hostname: "{{ ansible_facts['hostname'] }}" # Hostname to use in tailnet
 tailscale_accept_routes: false # Accept subnet routes advertised by other nodes
 tailscale_advertise_exit_node: false # Advertise as exit node
 tailscale_accept_dns: true # Accept DNS configuration from admin console

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -3,7 +3,7 @@
   block:
     - name: Download and add Tailscale GPG key
       ansible.builtin.get_url:
-        url: https://pkgs.tailscale.com/stable/debian/{{ ansible_distribution_release }}.noarmor.gpg
+        url: https://pkgs.tailscale.com/stable/debian/{{ ansible_facts['distribution_release'] }}.noarmor.gpg
         dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
         mode: "0644"
 
@@ -11,7 +11,7 @@
       ansible.builtin.apt_repository:
         repo: >-
           deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg]
-          https://pkgs.tailscale.com/stable/debian {{ ansible_distribution_release }} main
+          https://pkgs.tailscale.com/stable/debian {{ ansible_facts['distribution_release'] }} main
         state: present
         filename: tailscale
 


### PR DESCRIPTION
## Summary
- Replace `ansible_distribution`, `ansible_hostname`, `ansible_distribution_release`, and `ansible_default_ipv4` with `ansible_facts['...']` syntax
- Silences ansible-core 2.24 deprecation warnings about `INJECT_FACTS_AS_VARS` removal
- Affects roles: apt, tailscale, ssh

## Test plan
- [ ] Run `auberge ansible run --playbook playbooks/infrastructure.yml` — no deprecation warnings
- [ ] Tailscale installs and authenticates correctly
- [ ] SSH validation still works with the new facts syntax