### PR TITLE
feat: interactively select `dns set` arguments

### DIFF
--- a/src/commands/dns.rs
+++ b/src/commands/dns.rs
@@ -231,8 +231,8 @@ fn resolve_ip(ip: Option<String>) -> Result<String> {
                 .interact_text()?;
             let value = value.trim().to_string();
             value
-                .parse::<std::net::IpAddr>()
-                .map_err(|_| eyre::eyre!("Invalid IP address: {}", value))?;
+                .parse::<std::net::Ipv4Addr>()
+                .map_err(|_| eyre::eyre!("Invalid IPv4 address: {}", value))?;
             Ok(value)
         }
         None => eyre::bail!("IP argument required in non-interactive mode"),


### PR DESCRIPTION
## Summary
- Make `--subdomain` and `--ip` optional on `dns set`
- When missing in a TTY, prompt interactively: fuzzy-search selector for subdomain (from config), text input for IP
- Error with clear message in non-interactive mode

Closes #133

## Test plan
- [x] All 72 existing tests pass
- [ ] Manual: `auberge dns set` with no args → subdomain selector then IP prompt
- [ ] Manual: `auberge dns set --subdomain foo` → only IP prompt
- [ ] Manual: `auberge dns set --subdomain foo --ip 1.2.3.4` → no prompts (unchanged behavior)
- [ ] Manual: `echo | auberge dns set` → non-interactive error