### PR TITLE
fix: clear skim terminal artifacts after interactive select

### DIFF
--- a/src/selector.rs
+++ b/src/selector.rs
@@ -7,7 +7,7 @@ pub fn has_skim_support() -> bool {
     std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
 }
 
-pub fn select_with_skim(items: &[String], prompt: &str) -> Option<String> {
+fn select_with_skim(items: &[String], prompt: &str) -> Option<String> {
     if items.is_empty() {
         return None;
     }
@@ -45,7 +45,7 @@ pub fn select_with_skim(items: &[String], prompt: &str) -> Option<String> {
         .map(|item| item.output().to_string())
 }
 
-pub fn select_with_dialoguer(items: &[String], prompt: &str) -> Option<String> {
+fn select_with_dialoguer(items: &[String], prompt: &str) -> Option<String> {
     if items.is_empty() {
         return None;
     }


### PR DESCRIPTION
## Summary
- Skim's inline `height("40%")` mode leaves phantom blank lines and its background highlight color set after exiting
- Emit `\x1b[0m` (SGR reset) + `\x1b[J` (erase to end of screen) on a locked stderr handle immediately after `Skim::run_with()` to clear leftover artifacts and color bleed
- Without the SGR reset, subsequent terminal output renders with dark background bands from skim's highlight color

## Test plan
- [ ] Run `auberge dns set` without arguments to trigger interactive subdomain select, verify output lines appear directly below the prompt with no gap or colored bands
- [ ] Run any other command that triggers `selector::select()` (e.g. `auberge ssh keygen`, `auberge config set`) and verify clean rendering
- [ ] Abort the skim prompt (Esc) and verify no artifacts remain

Closes #140