### PR TITLE
refactor: move ensure_collections to playbook execution sites

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,23 +73,11 @@ enum Commands {
     Config(ConfigCommands),
 }
 
-fn needs_ansible(command: &Commands) -> bool {
-    matches!(
-        command,
-        Commands::Deploy(_) | Commands::Ansible(_) | Commands::Backup(_)
-    )
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
     let cli = Cli::parse();
-
-    if needs_ansible(&cli.command) {
-        let assets = ansible_assets::AnsibleAssets::prepare()?;
-        assets.ensure_collections()?;
-    }
 
     match cli.command {
         Commands::Deploy(cmd) => run_deploy(cmd),

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -97,9 +97,9 @@ pub fn run_playbook(
     ask_vault_pass: bool,
     ask_pass: bool,
 ) -> Result<AnsibleResult> {
-    let ansible_dir = crate::ansible_assets::AnsibleAssets::prepare()?
-        .ansible_dir()
-        .to_path_buf();
+    let assets = crate::ansible_assets::AnsibleAssets::prepare()?;
+    assets.ensure_collections()?;
+    let ansible_dir = assets.ansible_dir().to_path_buf();
     let vars_file = write_extra_vars_file()?;
     let inventory_file = write_inventory_file(host)?;
 
@@ -164,9 +164,9 @@ pub fn run_playbook(
 }
 
 pub fn run_bootstrap(playbook: &Path, host: &InventoryHost) -> Result<AnsibleResult> {
-    let ansible_dir = crate::ansible_assets::AnsibleAssets::prepare()?
-        .ansible_dir()
-        .to_path_buf();
+    let assets = crate::ansible_assets::AnsibleAssets::prepare()?;
+    assets.ensure_collections()?;
+    let ansible_dir = assets.ansible_dir().to_path_buf();
     let vars_file = write_extra_vars_file()?;
     let inventory_file = write_inventory_file(host)?;
 


### PR DESCRIPTION
## Summary
- Removes centralized `needs_ansible()` preflight from `main.rs`
- Calls `ensure_collections()` inside `run_playbook()` and `run_bootstrap()` instead
- Backup subcommands that never run playbooks (`list`, `prune`, `push`, `create`) no longer trigger unnecessary `ansible-galaxy` calls

Closes #149

## Test plan
- [x] `cargo test` — all 84 tests pass
- [x] `cargo clippy` — no new warnings