### PR TITLE
test: inject dev-mode flag to eliminate env var mutation

### DIFF
--- a/src/ansible_assets.rs
+++ b/src/ansible_assets.rs
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_uses_dev_mode() {
+    fn test_prepare_impl_uses_dev_mode() {
         let assets = AnsibleAssets::prepare_impl(true).unwrap();
         assert_eq!(assets.ansible_dir(), Path::new("ansible"));
     }


### PR DESCRIPTION
## Summary

- Extracts env var read from `prepare()` into a `prepare_impl(dev_mode: bool)` internal method
- Test calls `prepare_impl(true)` directly instead of mutating process-global `AUBERGE_DEV`
- Removes all `unsafe` blocks from the test module

## Test plan

- [x] `cargo test` — all 84 tests pass
- [x] `cargo clippy` — no new warnings
- [x] Pre-commit hooks (clippy + dprint) pass

Closes #150