### PR TITLE
chore: release v0.6.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.15](https://github.com/sripwoud/auberge/compare/v0.6.14...v0.6.15) - 2026-03-18
+
+### Added
+
+- *(config)* support shell command values with `!` prefix ([#200](https://github.com/sripwoud/auberge/pull/200))
+
+### Fixed
+
+- *(release)* use PAT for release-plz PR to trigger required CI checks
+
+### Other
+
+- *(vdirsyncer)* derive calendar ID from URL ([#197](https://github.com/sripwoud/auberge/pull/197))
+
 ## [0.6.14](https://github.com/sripwoud/auberge/compare/v0.6.13...v0.6.14) - 2026-03-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.6.14 -> 0.6.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.15](https://github.com/sripwoud/auberge/compare/v0.6.14...v0.6.15) - 2026-03-18

### Added

- *(config)* support shell command values with `!` prefix ([#200](https://github.com/sripwoud/auberge/pull/200))

### Fixed

- *(release)* use PAT for release-plz PR to trigger required CI checks

### Other

- *(vdirsyncer)* derive calendar ID from URL ([#197](https://github.com/sripwoud/auberge/pull/197))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).