### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/sripwoud/auberge/compare/v0.6.17...v0.7.0) - 2026-03-19
+
+### Added
+
+- [**breaking**] remove vdirsyncer role and all related code
+
 ## [0.6.17](https://github.com/sripwoud/auberge/compare/v0.6.16...v0.6.17) - 2026-03-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.6.17"
+version = "0.7.0"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.6.17"
+version = "0.7.0"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.6.17 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/sripwoud/auberge/compare/v0.6.17...v0.7.0) - 2026-03-19

### Added

- [**breaking**] remove vdirsyncer role and all related code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).