### PR TITLE
fix(paperless): download NLTK stopwords corpus during deployment

### DIFF
--- a/ansible/roles/paperless/tasks/main.yml
+++ b/ansible/roles/paperless/tasks/main.yml
@@ -217,6 +217,13 @@
       become: true
       become_user: "{{ paperless_sys_user }}"
 
+    - name: Download NLTK stopwords corpus
+      ansible.builtin.command:
+        cmd: >-
+          {{ paperless_install_path }}/venv/bin/python3 -c
+          "import nltk; nltk.download('stopwords', download_dir='/usr/share/nltk_data')"
+        creates: /usr/share/nltk_data/corpora/stopwords
+
     - name: Detect ImageMagick policy path
       ansible.builtin.command: find /etc -maxdepth 2 -name policy.xml -path "*/ImageMagick-*" -print -quit
       register: paperless_imagemagick_policy


### PR DESCRIPTION
## Summary

- Paperless classifier was failing with `Resource stopwords not found` because the NLTK `stopwords` corpus was never downloaded during deployment
- Added an idempotent Ansible task that downloads the corpus to `/usr/share/nltk_data` (the system-wide path paperless searches) using the venv Python
- Uses `creates:` guard so re-running the role skips the download if the corpus already exists

Fixes #209

## Test plan

- [ ] Re-run the paperless Ansible role against the target host
- [ ] Verify `classifier_status` changes from `ERROR` to `OK` in the paperless status endpoint