### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/sripwoud/auberge/compare/v0.7.0...v0.7.1) - 2026-03-20
+
+### Fixed
+
+- *(paperless)* download NLTK stopwords corpus during deployment ([#210](https://github.com/sripwoud/auberge/pull/210))
+
 ## [0.7.0](https://github.com/sripwoud/auberge/compare/v0.6.17...v0.7.0) - 2026-03-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.1](https://github.com/sripwoud/auberge/compare/v0.7.0...v0.7.1) - 2026-03-20

### Fixed

- *(paperless)* download NLTK stopwords corpus during deployment ([#210](https://github.com/sripwoud/auberge/pull/210))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).