### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sripwoud/auberge/compare/v0.7.2...v0.8.0) - 2026-04-05
+
+### Added
+
+- [**breaking**] replace booklore with grimmory ([#214](https://github.com/sripwoud/auberge/pull/214))
+
+### Fixed
+
+- *(grimmory)* let gradle processResources handle frontend assets
+- *(grimmory)* clear static dir before copying frontend build output
+- *(grimmory)* fix build workflow for v2.3.0 source structure
+
 ## [0.7.2](https://github.com/sripwoud/auberge/compare/v0.7.1...v0.7.2) - 2026-03-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.7.2 -> 0.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/sripwoud/auberge/compare/v0.7.2...v0.8.0) - 2026-04-05

### Added

- [**breaking**] replace booklore with grimmory ([#214](https://github.com/sripwoud/auberge/pull/214))

### Fixed

- *(grimmory)* let gradle processResources handle frontend assets
- *(grimmory)* clear static dir before copying frontend build output
- *(grimmory)* fix build workflow for v2.3.0 source structure
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).