### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/sripwoud/auberge/compare/v0.8.0...v0.8.1) - 2026-04-05
+
+### Fixed
+
+- *(grimmory)* set APP_VERSION in env to show correct version in UI
+- *(grimmory)* raise systemd memory limits to 1200M
+- *(grimmory)* add systemd memory limits to prevent OOM
+- *(grimmory)* use fixed 768MB heap cap instead of RAM percentage
+
 ## [0.8.0](https://github.com/sripwoud/auberge/compare/v0.7.2...v0.8.0) - 2026-04-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.8.0 -> 0.8.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/sripwoud/auberge/compare/v0.8.0...v0.8.1) - 2026-04-05

### Fixed

- *(grimmory)* set APP_VERSION in env to show correct version in UI
- *(grimmory)* raise systemd memory limits to 1200M
- *(grimmory)* add systemd memory limits to prevent OOM
- *(grimmory)* use fixed 768MB heap cap instead of RAM percentage
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).