### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/sripwoud/auberge/compare/v0.8.1...v0.8.2) - 2026-04-05
+
+### Added
+
+- *(cli)* add `sync` subcommand for full backup pipeline ([#217](https://github.com/sripwoud/auberge/pull/217))
+
+### Fixed
+
+- *(cli)* resolve `!` commands in restic config values ([#218](https://github.com/sripwoud/auberge/pull/218))
+
 ## [0.8.1](https://github.com/sripwoud/auberge/compare/v0.8.0...v0.8.1) - 2026-04-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.8.1 -> 0.8.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.2](https://github.com/sripwoud/auberge/compare/v0.8.1...v0.8.2) - 2026-04-05

### Added

- *(cli)* add `sync` subcommand for full backup pipeline ([#217](https://github.com/sripwoud/auberge/pull/217))

### Fixed

- *(cli)* resolve `!` commands in restic config values ([#218](https://github.com/sripwoud/auberge/pull/218))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).