### PR TITLE
chore: release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/sripwoud/auberge/compare/v0.8.2...v0.8.3) - 2026-04-06
+
+### Added
+
+- *(cli)* stream ansible task names during deploy and ansible subcommands ([#228](https://github.com/sripwoud/auberge/pull/228))
+- *(cli)* show progress bars with ETA during backup commands ([#226](https://github.com/sripwoud/auberge/pull/226))
+- *(cli)* add verbose mode with dimmed subprocess output ([#224](https://github.com/sripwoud/auberge/pull/224))
+
+### Fixed
+
+- *(cli)* read rsync and restic progress from stdout not stderr ([#229](https://github.com/sripwoud/auberge/pull/229))
+- *(cockpit)* set NetworkManager as netplan renderer for PackageKit ([#227](https://github.com/sripwoud/auberge/pull/227))
+
+### Other
+
+- fix sidebar missing pages and broken link
+- *(backup)* add sync subcommand to sidebar navigation
+
 ## [0.8.2](https://github.com/sripwoud/auberge/compare/v0.8.1...v0.8.2) - 2026-04-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.8.2 -> 0.8.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.3](https://github.com/sripwoud/auberge/compare/v0.8.2...v0.8.3) - 2026-04-06

### Added

- *(cli)* stream ansible task names during deploy and ansible subcommands ([#228](https://github.com/sripwoud/auberge/pull/228))
- *(cli)* show progress bars with ETA during backup commands ([#226](https://github.com/sripwoud/auberge/pull/226))
- *(cli)* add verbose mode with dimmed subprocess output ([#224](https://github.com/sripwoud/auberge/pull/224))

### Fixed

- *(cli)* read rsync and restic progress from stdout not stderr ([#229](https://github.com/sripwoud/auberge/pull/229))
- *(cockpit)* set NetworkManager as netplan renderer for PackageKit ([#227](https://github.com/sripwoud/auberge/pull/227))

### Other

- fix sidebar missing pages and broken link
- *(backup)* add sync subcommand to sidebar navigation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).