### PR TITLE
feat(cli): show progress bars with ETA during backup commands

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -7,6 +7,7 @@ use clap::Subcommand;
 use eyre::{Context, Result};
 use std::ffi::OsString;
 use std::fs;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::Instant;
@@ -1264,6 +1265,9 @@ fn restore_app(host: &Host, app_name: &str, backup_path: &Path, ssh_key: &Path) 
     let restore_result = (|| -> Result<()> {
         for remote_path in &config.paths {
             pb.set_message(format!("Restoring {} → {}", app_name, remote_path));
+            if !std::io::stderr().is_terminal() {
+                eprintln!("  Restoring to: {}", remote_path);
+            }
             rsync_to_remote(host, ssh_key, backup_path, remote_path, &pb)?;
         }
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1401,7 +1401,7 @@ fn rsync_to_remote(
                 pb.set_length(100);
             }
             pb.set_position(p.percent as u64);
-            pb.set_message(format!("{} ETA {}", p.speed, p.eta));
+            pb.set_prefix(format!("{} ETA {}", p.speed, p.eta));
         }
     })
     .wrap_err("Failed to execute rsync")?;
@@ -2124,7 +2124,7 @@ fn rsync_from_remote(
                 pb.set_length(100);
             }
             pb.set_position(p.percent as u64);
-            pb.set_message(format!("{} ETA {}", p.speed, p.eta));
+            pb.set_prefix(format!("{} ETA {}", p.speed, p.eta));
         }
     })
     .wrap_err("Failed to execute rsync")?;

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1267,6 +1267,8 @@ fn restore_app(host: &Host, app_name: &str, backup_path: &Path, ssh_key: &Path) 
             rsync_to_remote(host, ssh_key, backup_path, remote_path, &pb)?;
         }
 
+        output::reset_to_spinner(&pb);
+
         if let Some((user, group)) = config.owner {
             eprintln!("  Setting ownership to {}:{}", user, group);
             for remote_path in &config.paths {
@@ -1354,6 +1356,7 @@ fn rsync_to_remote(
     remote_path: &str,
     pb: &indicatif::ProgressBar,
 ) -> Result<()> {
+    pb.set_position(0);
     let local_source = local_path.join(remote_path.trim_start_matches('/'));
 
     if !local_source.exists() {
@@ -1850,6 +1853,7 @@ fn backup_app(
         remote_pg_dump_cleanup(host, ssh_key, db);
     }
 
+    output::reset_to_spinner(&pb);
     let mut start_failures: Vec<String> = Vec::new();
     if !config.systemd_services.is_empty() {
         pb.set_message(format!("Backing up {} (starting services)", config.name));
@@ -2096,6 +2100,7 @@ fn rsync_from_remote(
     local_dest: &Path,
     pb: &indicatif::ProgressBar,
 ) -> Result<()> {
+    pb.set_position(0);
     let session = SshSession::new(host, ssh_key);
     let mut cmd = Command::new("rsync");
     cmd.arg("-az")

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1398,6 +1398,7 @@ fn rsync_to_remote(
                 pb.set_length(100);
             }
             pb.set_position(p.percent as u64);
+            pb.set_message(format!("{} ETA {}", p.speed, p.eta));
         }
     })
     .wrap_err("Failed to execute rsync")?;
@@ -1636,12 +1637,10 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
         }
     }
 
-    let snap = snapshot_id
-        .into_inner()
-        .unwrap()
-        .unwrap_or_else(|| "backup completed".to_string());
-
-    output::success(&format!("Push complete: snapshot {}", snap));
+    match snapshot_id.into_inner().unwrap() {
+        Some(id) => output::success(&format!("Push complete: snapshot {}", id)),
+        None => output::success("Push complete"),
+    };
 
     Ok(())
 }
@@ -2120,6 +2119,7 @@ fn rsync_from_remote(
                 pb.set_length(100);
             }
             pb.set_position(p.percent as u64);
+            pb.set_message(format!("{} ETA {}", p.speed, p.eta));
         }
     })
     .wrap_err("Failed to execute rsync")?;

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1357,6 +1357,7 @@ fn rsync_to_remote(
     pb: &indicatif::ProgressBar,
 ) -> Result<()> {
     pb.set_position(0);
+    pb.set_prefix(String::new());
     let local_source = local_path.join(remote_path.trim_start_matches('/'));
 
     if !local_source.exists() {
@@ -1594,7 +1595,7 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
     spinner.finish_and_clear();
 
     let pb = output::progress_bar(&format!("Pushing {}", backup_dir.display()), None);
-    let snapshot_id = std::sync::Mutex::new(None::<String>);
+    let mut snapshot_id: Option<String> = None;
 
     let result = output::run_with_progress(
         "restic",
@@ -1623,7 +1624,7 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
                 }
             }
             Some(output::ResticMessage::Summary(s)) => {
-                *snapshot_id.lock().unwrap() = Some(s.snapshot_id);
+                snapshot_id = Some(s.snapshot_id);
             }
             None => {}
         },
@@ -1640,7 +1641,7 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
         }
     }
 
-    match snapshot_id.into_inner().unwrap() {
+    match snapshot_id {
         Some(id) => output::success(&format!("Push complete: snapshot {}", id)),
         None => output::success("Push complete"),
     };
@@ -2101,6 +2102,7 @@ fn rsync_from_remote(
     pb: &indicatif::ProgressBar,
 ) -> Result<()> {
     pb.set_position(0);
+    pb.set_prefix(String::new());
     let session = SshSession::new(host, ssh_key);
     let mut cmd = Command::new("rsync");
     cmd.arg("-az")

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1604,15 +1604,18 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
         &pb,
         |line, pb| match output::parse_restic_message(line) {
             Some(output::ResticMessage::Status(s)) => {
-                if let Some(total) = s.total_bytes {
-                    pb.set_length(total);
-                }
-                if let Some(done) = s.bytes_done {
+                if let (Some(total), Some(done)) = (s.total_bytes, s.bytes_done) {
+                    if pb.length() != Some(total) {
+                        output::set_bytes_style(pb);
+                        pb.set_length(total);
+                    }
                     pb.set_position(done);
                 } else {
-                    pb.set_position(
-                        (s.percent_done * pb.length().unwrap_or(1_000_000) as f64) as u64,
-                    );
+                    if pb.length() != Some(100) {
+                        output::set_percent_style(pb);
+                        pb.set_length(100);
+                    }
+                    pb.set_position((s.percent_done * 100.0) as u64);
                 }
             }
             Some(output::ResticMessage::Summary(s)) => {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1393,14 +1393,25 @@ fn rsync_to_remote(
 
     let result = output::run_with_progress("rsync", &mut cmd, pb, |line, pb| {
         if let Some(p) = output::parse_rsync_progress(line) {
-            pb.set_length(100);
+            if pb.length().is_none() {
+                output::set_percent_style(pb);
+                pb.set_length(100);
+            }
             pb.set_position(p.percent as u64);
         }
     })
     .wrap_err("Failed to execute rsync")?;
 
     if !result.status.success() {
-        eyre::bail!("rsync failed for {}", remote_path);
+        if result.last_stderr.is_empty() {
+            eyre::bail!("rsync failed for {}", remote_path);
+        } else {
+            eyre::bail!(
+                "rsync failed for {}: {}",
+                remote_path,
+                result.last_stderr.trim()
+            );
+        }
     }
 
     Ok(())
@@ -1615,7 +1626,11 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
     pb.finish_and_clear();
 
     if !result.status.success() {
-        eyre::bail!("restic backup failed");
+        if result.last_stderr.is_empty() {
+            eyre::bail!("restic backup failed");
+        } else {
+            eyre::bail!("restic backup failed: {}", result.last_stderr.trim());
+        }
     }
 
     let snap = snapshot_id
@@ -2097,14 +2112,25 @@ fn rsync_from_remote(
 
     let result = output::run_with_progress("rsync", &mut cmd, pb, |line, pb| {
         if let Some(p) = output::parse_rsync_progress(line) {
-            pb.set_length(100);
+            if pb.length().is_none() {
+                output::set_percent_style(pb);
+                pb.set_length(100);
+            }
             pb.set_position(p.percent as u64);
         }
     })
     .wrap_err("Failed to execute rsync")?;
 
     if !result.status.success() {
-        eyre::bail!("rsync failed for {}", remote_path);
+        if result.last_stderr.is_empty() {
+            eyre::bail!("rsync failed for {}", remote_path);
+        } else {
+            eyre::bail!(
+                "rsync failed for {}: {}",
+                remote_path,
+                result.last_stderr.trim()
+            );
+        }
     }
 
     Ok(())

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1259,10 +1259,12 @@ fn restore_app(host: &Host, app_name: &str, backup_path: &Path, ssh_key: &Path) 
         stopped_services.push(service);
     }
 
+    let pb = output::progress_bar(&format!("Restoring {}", app_name), None);
+
     let restore_result = (|| -> Result<()> {
         for remote_path in &config.paths {
-            eprintln!("  Restoring to: {}", remote_path);
-            rsync_to_remote(host, ssh_key, backup_path, remote_path)?;
+            pb.set_message(format!("Restoring {} → {}", app_name, remote_path));
+            rsync_to_remote(host, ssh_key, backup_path, remote_path, &pb)?;
         }
 
         if let Some((user, group)) = config.owner {
@@ -1308,6 +1310,8 @@ fn restore_app(host: &Host, app_name: &str, backup_path: &Path, ssh_key: &Path) 
         Ok(())
     })();
 
+    pb.finish_and_clear();
+
     let mut start_failures: Vec<String> = Vec::new();
     for service in &config.systemd_services {
         eprintln!("  Starting service: {}", service);
@@ -1348,6 +1352,7 @@ fn rsync_to_remote(
     ssh_key: &Path,
     local_path: &Path,
     remote_path: &str,
+    pb: &indicatif::ProgressBar,
 ) -> Result<()> {
     let local_source = local_path.join(remote_path.trim_start_matches('/'));
 
@@ -1374,6 +1379,7 @@ fn rsync_to_remote(
     let mut cmd = Command::new("rsync");
     cmd.arg("-az")
         .arg("--delete")
+        .arg("--info=progress2")
         .arg("--rsync-path=sudo rsync");
 
     for pattern in RSYNC_EXCLUDES {
@@ -1385,10 +1391,13 @@ fn rsync_to_remote(
         .arg(format!("{}/", local_source.display()))
         .arg(format!("{}@{}:{}", host.user, host.address, remote_path));
 
-    let result = output::run_piped("rsync", &mut cmd).wrap_err("Failed to execute rsync")?;
-    if result.status.success() {
-        output::clear_subprocess_lines(result.lines_written);
-    }
+    let result = output::run_with_progress("rsync", &mut cmd, pb, |line, pb| {
+        if let Some(p) = output::parse_rsync_progress(line) {
+            pb.set_length(100);
+            pb.set_position(p.percent as u64);
+        }
+    })
+    .wrap_err("Failed to execute rsync")?;
 
     if !result.status.success() {
         eyre::bail!("rsync failed for {}", remote_path);
@@ -1567,35 +1576,54 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
         }
     }
 
-    spinner.set_message(format!("Backing up {}", backup_dir.display()));
-    let backup_output = Command::new("restic")
-        .arg("backup")
-        .arg(&backup_dir)
-        .env("RESTIC_REPOSITORY", &restic_repo)
-        .env("RESTIC_PASSWORD", &restic_password)
-        .env_remove("RESTIC_PASSWORD_COMMAND")
-        .output()
-        .wrap_err("Failed to run restic backup")?;
-
     spinner.finish_and_clear();
 
-    let stderr_text = String::from_utf8_lossy(&backup_output.stderr);
-    let lines = output::subprocess_output("restic", &stderr_text);
-    if backup_output.status.success() {
-        output::clear_subprocess_lines(lines);
+    let pb = output::progress_bar(&format!("Pushing {}", backup_dir.display()), None);
+    let snapshot_id = std::sync::Mutex::new(None::<String>);
+
+    let result = output::run_with_progress(
+        "restic",
+        Command::new("restic")
+            .arg("backup")
+            .arg("--json")
+            .arg(&backup_dir)
+            .env("RESTIC_REPOSITORY", &restic_repo)
+            .env("RESTIC_PASSWORD", &restic_password)
+            .env_remove("RESTIC_PASSWORD_COMMAND"),
+        &pb,
+        |line, pb| match output::parse_restic_message(line) {
+            Some(output::ResticMessage::Status(s)) => {
+                if let Some(total) = s.total_bytes {
+                    pb.set_length(total);
+                }
+                if let Some(done) = s.bytes_done {
+                    pb.set_position(done);
+                } else {
+                    pb.set_position(
+                        (s.percent_done * pb.length().unwrap_or(1_000_000) as f64) as u64,
+                    );
+                }
+            }
+            Some(output::ResticMessage::Summary(s)) => {
+                *snapshot_id.lock().unwrap() = Some(s.snapshot_id);
+            }
+            None => {}
+        },
+    )
+    .wrap_err("Failed to run restic backup")?;
+
+    pb.finish_and_clear();
+
+    if !result.status.success() {
+        eyre::bail!("restic backup failed");
     }
 
-    if !backup_output.status.success() {
-        eyre::bail!("restic backup failed: {}", stderr_text.trim());
-    }
+    let snap = snapshot_id
+        .into_inner()
+        .unwrap()
+        .unwrap_or_else(|| "backup completed".to_string());
 
-    let stdout = String::from_utf8_lossy(&backup_output.stdout);
-    let snapshot_id = stdout
-        .lines()
-        .find(|line| line.contains("snapshot") && line.contains("saved"))
-        .unwrap_or("backup completed");
-
-    output::success(&format!("Push complete: {}", snapshot_id.trim()));
+    output::success(&format!("Push complete: snapshot {}", snap));
 
     Ok(())
 }
@@ -1745,7 +1773,7 @@ fn backup_app(
     ssh_key: &Path,
     timestamp: &str,
 ) -> Result<u64> {
-    let spinner = output::spinner(&format!("Backing up {}", config.name));
+    let pb = output::progress_bar(&format!("Backing up {}", config.name), None);
     let app_backup_dir = backup_dest
         .join(&host.name)
         .join(timestamp)
@@ -1760,12 +1788,13 @@ fn backup_app(
 
     let mut stopped_services: Vec<&str> = Vec::new();
     if !config.systemd_services.is_empty() {
-        spinner.set_message(format!("Backing up {} (stopping services)", config.name));
+        pb.set_message(format!("Backing up {} (stopping services)", config.name));
         for service in &config.systemd_services {
             if let Err(e) = remote_systemctl(host, ssh_key, "stop", service) {
                 for previously_stopped in &stopped_services {
                     let _ = remote_systemctl(host, ssh_key, "start", previously_stopped);
                 }
+                pb.finish_and_clear();
                 return Err(e).wrap_err_with(|| format!("Failed to stop service {}", service));
             }
             stopped_services.push(service);
@@ -1773,20 +1802,21 @@ fn backup_app(
     }
 
     if let Some(db) = &config.db {
-        spinner.set_message(format!("Backing up {} (dumping database)", config.name));
+        pb.set_message(format!("Backing up {} (dumping database)", config.name));
         if let Err(e) = remote_pg_dump(host, ssh_key, db) {
             remote_pg_dump_cleanup(host, ssh_key, db);
             for service in &stopped_services {
                 let _ = remote_systemctl(host, ssh_key, "start", service);
             }
+            pb.finish_and_clear();
             return Err(e).wrap_err("pg_dump failed");
         }
     }
 
-    spinner.set_message(format!("Backing up {} (copying files)", config.name));
+    pb.set_message(format!("Backing up {} (copying files)", config.name));
     let rsync_result = (|| -> Result<()> {
         for path in &config.paths {
-            rsync_from_remote(host, ssh_key, path, &app_backup_dir)?;
+            rsync_from_remote(host, ssh_key, path, &app_backup_dir, &pb)?;
         }
         if let Some(db) = &config.db {
             scp_from_remote(
@@ -1805,7 +1835,7 @@ fn backup_app(
 
     let mut start_failures: Vec<String> = Vec::new();
     if !config.systemd_services.is_empty() {
-        spinner.set_message(format!("Backing up {} (starting services)", config.name));
+        pb.set_message(format!("Backing up {} (starting services)", config.name));
         for service in &config.systemd_services {
             if let Err(e) = remote_systemctl(host, ssh_key, "start", service) {
                 start_failures.push(format!("{}: {}", service, e));
@@ -1816,6 +1846,7 @@ fn backup_app(
     match rsync_result {
         Ok(()) => {
             if !start_failures.is_empty() {
+                pb.finish_and_clear();
                 eyre::bail!(
                     "Backup of {} succeeded but failed to restart services:\n  {}",
                     config.name,
@@ -1824,6 +1855,7 @@ fn backup_app(
             }
         }
         Err(e) => {
+            pb.finish_and_clear();
             if !start_failures.is_empty() {
                 eyre::bail!(
                     "Backup of {} failed during file copy: {}\nAdditionally, failed to restart services:\n  {}",
@@ -1839,9 +1871,9 @@ fn backup_app(
     let backup_size = calculate_dir_size(&app_backup_dir)?;
 
     if output::is_verbose() {
-        spinner.finish_and_clear();
+        pb.finish_and_clear();
     } else {
-        spinner.finish_with_message(format!(
+        pb.finish_with_message(format!(
             "  ✓ {} ({})",
             config.name,
             output::format_size(backup_size)
@@ -2045,11 +2077,13 @@ fn rsync_from_remote(
     ssh_key: &Path,
     remote_path: &str,
     local_dest: &Path,
+    pb: &indicatif::ProgressBar,
 ) -> Result<()> {
     let session = SshSession::new(host, ssh_key);
     let mut cmd = Command::new("rsync");
     cmd.arg("-az")
         .arg("--relative")
+        .arg("--info=progress2")
         .arg("--rsync-path=sudo rsync");
 
     for pattern in RSYNC_EXCLUDES {
@@ -2061,10 +2095,13 @@ fn rsync_from_remote(
         .arg(format!("{}@{}:{}", host.user, host.address, remote_path))
         .arg(local_dest);
 
-    let result = output::run_piped("rsync", &mut cmd).wrap_err("Failed to execute rsync")?;
-    if result.status.success() {
-        output::clear_subprocess_lines(result.lines_written);
-    }
+    let result = output::run_with_progress("rsync", &mut cmd, pb, |line, pb| {
+        if let Some(p) = output::parse_rsync_progress(line) {
+            pb.set_length(100);
+            pb.set_position(p.percent as u64);
+        }
+    })
+    .wrap_err("Failed to execute rsync")?;
 
     if !result.status.success() {
         eyre::bail!("rsync failed for {}", remote_path);

--- a/src/output.rs
+++ b/src/output.rs
@@ -165,7 +165,7 @@ pub fn run_with_progress(
     label: &str,
     cmd: &mut Command,
     pb: &ProgressBar,
-    line_handler: impl Fn(&str, &ProgressBar) + Send,
+    mut line_handler: impl FnMut(&str, &ProgressBar),
 ) -> Result<ProgressResult> {
     cmd.stdout(Stdio::null()).stderr(Stdio::piped());
     let mut child = cmd.spawn().wrap_err("failed to spawn subprocess")?;
@@ -174,7 +174,7 @@ pub fn run_with_progress(
 
     let verbose = is_verbose();
 
-    let stderr_tail = std::sync::Mutex::new(Vec::<String>::new());
+    let mut stderr_tail: Vec<String> = Vec::new();
     const MAX_STDERR_LINES: usize = 20;
 
     let reader = BufReader::new(stderr);
@@ -182,18 +182,15 @@ pub fn run_with_progress(
         if verbose {
             emit_subprocess_line(label, &line);
         }
-        {
-            let mut tail = stderr_tail.lock().unwrap();
-            tail.push(line.clone());
-            if tail.len() > MAX_STDERR_LINES {
-                tail.remove(0);
-            }
+        stderr_tail.push(line.clone());
+        if stderr_tail.len() > MAX_STDERR_LINES {
+            stderr_tail.remove(0);
         }
         line_handler(&line, pb);
     }
 
     let status = child.wait().wrap_err("failed to wait on subprocess")?;
-    let last_stderr = stderr_tail.into_inner().unwrap().join("\n");
+    let last_stderr = stderr_tail.join("\n");
 
     Ok(ProgressResult {
         status,

--- a/src/output.rs
+++ b/src/output.rs
@@ -158,6 +158,9 @@ pub fn run_piped(label: &str, cmd: &mut Command) -> Result<SubprocessResult> {
 
 pub struct ProgressResult {
     pub status: ExitStatus,
+    #[allow(dead_code)]
+    pub stdout: String,
+    pub last_stderr: String,
 }
 
 pub fn run_with_progress(
@@ -166,23 +169,57 @@ pub fn run_with_progress(
     pb: &ProgressBar,
     line_handler: impl Fn(&str, &ProgressBar) + Send,
 ) -> Result<ProgressResult> {
-    cmd.stdout(Stdio::null()).stderr(Stdio::piped());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = cmd.spawn().wrap_err("failed to spawn subprocess")?;
 
+    let stdout_handle = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
-    let verbose = is_verbose();
 
-    let reader = BufReader::new(stderr);
-    for line in reader.lines().map_while(Result::ok) {
-        if verbose {
-            emit_subprocess_line(label, &line);
+    let verbose = is_verbose();
+    let label_owned = label.to_owned();
+
+    let stdout_content = std::sync::Mutex::new(String::new());
+    let stderr_tail = std::sync::Mutex::new(Vec::<String>::new());
+    const MAX_STDERR_LINES: usize = 20;
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            let reader = BufReader::new(stdout_handle);
+            let mut buf = stdout_content.lock().unwrap();
+            for line in reader.lines().filter_map(Result::ok) {
+                if verbose {
+                    emit_subprocess_line(&label_owned, &line);
+                }
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        });
+
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().filter_map(Result::ok) {
+            if verbose {
+                emit_subprocess_line(label, &line);
+            }
+            {
+                let mut tail = stderr_tail.lock().unwrap();
+                tail.push(line.clone());
+                if tail.len() > MAX_STDERR_LINES {
+                    tail.remove(0);
+                }
+            }
+            line_handler(&line, pb);
         }
-        line_handler(&line, pb);
-    }
+    });
 
     let status = child.wait().wrap_err("failed to wait on subprocess")?;
+    let stdout = stdout_content.into_inner().unwrap();
+    let last_stderr = stderr_tail.into_inner().unwrap().join("\n");
 
-    Ok(ProgressResult { status })
+    Ok(ProgressResult {
+        status,
+        stdout,
+        last_stderr,
+    })
 }
 
 pub fn print_table<T: Tabled>(data: &[T]) {
@@ -261,16 +298,43 @@ pub fn progress_bar(msg: &str, total_bytes: Option<u64>) -> ProgressBar {
         }
         None => {
             let pb = ProgressBar::with_draw_target(None, ProgressDrawTarget::stderr());
-            pb.set_style(
-                ProgressStyle::default_spinner()
-                    .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
-                    .template("{spinner} {msg} {bytes} transferred")
-                    .unwrap(),
-            );
+            if should_use_colors() {
+                pb.set_style(
+                    ProgressStyle::default_spinner()
+                        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+                        .template("{spinner} {msg}")
+                        .unwrap(),
+                );
+            } else {
+                pb.set_style(
+                    ProgressStyle::default_spinner()
+                        .tick_chars("/-\\|")
+                        .template("{spinner} {msg}")
+                        .unwrap(),
+                );
+            }
             pb.set_message(msg.to_string());
             pb.enable_steady_tick(std::time::Duration::from_millis(100));
             pb
         }
+    }
+}
+
+pub fn set_percent_style(pb: &ProgressBar) {
+    if should_use_colors() {
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner} {msg} [{bar:40}] {pos:>3}%")
+                .unwrap()
+                .progress_chars("█▉▊▋▌▍▎▏ "),
+        );
+    } else {
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} [{bar:40}] {pos:>3}%")
+                .unwrap()
+                .progress_chars("#>-"),
+        );
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -399,6 +399,7 @@ pub fn parse_restic_message(line: &str) -> Option<ResticMessage> {
 }
 
 pub fn parse_rsync_progress(line: &str) -> Option<RsyncProgress> {
+    let line = line.trim_end_matches('\r');
     let fields: Vec<&str> = line.split_whitespace().collect();
     if fields.len() < 4 {
         return None;
@@ -614,6 +615,14 @@ mod tests {
     #[test]
     fn parse_rsync_too_few_fields_returns_none() {
         assert!(parse_rsync_progress("1234 42%").is_none());
+    }
+
+    #[test]
+    fn parse_rsync_strips_trailing_carriage_return() {
+        let line = "  1,234,567  42%   12.34MB/s    0:01:23\r";
+        let p = parse_rsync_progress(line).unwrap();
+        assert_eq!(p.eta, "0:01:23");
+        assert_eq!(p.percent, 42);
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,6 @@
 use eyre::{Context, Result};
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use serde::Deserialize;
 use std::env;
 use std::io::{BufRead, BufReader, IsTerminal};
 use std::process::{Command, ExitStatus, Stdio};
@@ -155,6 +156,35 @@ pub fn run_piped(label: &str, cmd: &mut Command) -> Result<SubprocessResult> {
     })
 }
 
+pub struct ProgressResult {
+    pub status: ExitStatus,
+}
+
+pub fn run_with_progress(
+    label: &str,
+    cmd: &mut Command,
+    pb: &ProgressBar,
+    line_handler: impl Fn(&str, &ProgressBar) + Send,
+) -> Result<ProgressResult> {
+    cmd.stdout(Stdio::null()).stderr(Stdio::piped());
+    let mut child = cmd.spawn().wrap_err("failed to spawn subprocess")?;
+
+    let stderr = child.stderr.take().unwrap();
+    let verbose = is_verbose();
+
+    let reader = BufReader::new(stderr);
+    for line in reader.lines().map_while(Result::ok) {
+        if verbose {
+            emit_subprocess_line(label, &line);
+        }
+        line_handler(&line, pb);
+    }
+
+    let status = child.wait().wrap_err("failed to wait on subprocess")?;
+
+    Ok(ProgressResult { status })
+}
+
 pub fn print_table<T: Tabled>(data: &[T]) {
     if data.is_empty() {
         return;
@@ -206,6 +236,44 @@ pub fn spinner(msg: &str) -> ProgressBar {
     spinner
 }
 
+pub fn progress_bar(msg: &str, total_bytes: Option<u64>) -> ProgressBar {
+    match total_bytes {
+        Some(total) => {
+            let pb = ProgressBar::with_draw_target(Some(total), ProgressDrawTarget::stderr());
+            if should_use_colors() {
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template("{spinner} {msg} [{bar:40}] {bytes}/{total_bytes} ({eta})")
+                        .unwrap()
+                        .progress_chars("█▉▊▋▌▍▎▏ "),
+                );
+            } else {
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template("{msg} [{bar:40}] {bytes}/{total_bytes} ({eta})")
+                        .unwrap()
+                        .progress_chars("#>-"),
+                );
+            }
+            pb.set_message(msg.to_string());
+            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb
+        }
+        None => {
+            let pb = ProgressBar::with_draw_target(None, ProgressDrawTarget::stderr());
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+                    .template("{spinner} {msg} {bytes} transferred")
+                    .unwrap(),
+            );
+            pb.set_message(msg.to_string());
+            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb
+        }
+    }
+}
+
 pub fn format_duration(seconds: u64) -> String {
     if seconds < 60 {
         format!("{}s", seconds)
@@ -214,6 +282,60 @@ pub fn format_duration(seconds: u64) -> String {
         let secs = seconds % 60;
         format!("{}m {}s", mins, secs)
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResticStatus {
+    pub percent_done: f64,
+    pub total_bytes: Option<u64>,
+    pub bytes_done: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResticSummary {
+    pub snapshot_id: String,
+    #[allow(dead_code)]
+    pub files_new: u64,
+    #[allow(dead_code)]
+    pub files_changed: u64,
+    #[allow(dead_code)]
+    pub data_added: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "message_type", rename_all = "lowercase")]
+pub enum ResticMessage {
+    Status(ResticStatus),
+    Summary(ResticSummary),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RsyncProgress {
+    pub bytes_transferred: u64,
+    pub percent: u8,
+    pub speed: String,
+    pub eta: String,
+}
+
+pub fn parse_restic_message(line: &str) -> Option<ResticMessage> {
+    serde_json::from_str(line).ok()
+}
+
+pub fn parse_rsync_progress(line: &str) -> Option<RsyncProgress> {
+    let fields: Vec<&str> = line.split_whitespace().collect();
+    if fields.len() < 4 {
+        return None;
+    }
+    let percent_str = fields[1].strip_suffix('%')?;
+    let percent: u8 = percent_str.parse().ok()?;
+    let bytes_str = fields[0].replace(',', "");
+    let bytes_transferred: u64 = bytes_str.parse().ok()?;
+    Some(RsyncProgress {
+        bytes_transferred,
+        percent,
+        speed: fields[2].to_string(),
+        eta: fields[3].to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -311,5 +433,109 @@ mod tests {
     #[test]
     fn clear_subprocess_lines_zero_is_noop() {
         clear_subprocess_lines(0);
+    }
+
+    #[test]
+    fn parse_restic_status_line() {
+        let line = r#"{"message_type":"status","percent_done":0.5,"total_bytes":1048576,"bytes_done":524288}"#;
+        let msg = parse_restic_message(line).unwrap();
+        match msg {
+            ResticMessage::Status(s) => {
+                assert!((s.percent_done - 0.5).abs() < f64::EPSILON);
+                assert_eq!(s.total_bytes, Some(1048576));
+                assert_eq!(s.bytes_done, Some(524288));
+            }
+            _ => panic!("expected Status"),
+        }
+    }
+
+    #[test]
+    fn parse_restic_summary_line() {
+        let line = r#"{"message_type":"summary","snapshot_id":"abc123","files_new":10,"files_changed":2,"data_added":1048576}"#;
+        let msg = parse_restic_message(line).unwrap();
+        match msg {
+            ResticMessage::Summary(s) => {
+                assert_eq!(s.snapshot_id, "abc123");
+                assert_eq!(s.files_new, 10);
+                assert_eq!(s.files_changed, 2);
+                assert_eq!(s.data_added, 1048576);
+            }
+            _ => panic!("expected Summary"),
+        }
+    }
+
+    #[test]
+    fn parse_restic_plain_text_returns_none() {
+        assert!(parse_restic_message("using parent snapshot abc123").is_none());
+    }
+
+    #[test]
+    fn parse_restic_malformed_json_returns_none() {
+        assert!(parse_restic_message("{bad json}").is_none());
+    }
+
+    #[test]
+    fn parse_restic_zero_percent() {
+        let line = r#"{"message_type":"status","percent_done":0.0}"#;
+        let msg = parse_restic_message(line).unwrap();
+        match msg {
+            ResticMessage::Status(s) => {
+                assert!((s.percent_done).abs() < f64::EPSILON);
+                assert_eq!(s.total_bytes, None);
+                assert_eq!(s.bytes_done, None);
+            }
+            _ => panic!("expected Status"),
+        }
+    }
+
+    #[test]
+    fn parse_restic_full_percent() {
+        let line =
+            r#"{"message_type":"status","percent_done":1.0,"total_bytes":100,"bytes_done":100}"#;
+        let msg = parse_restic_message(line).unwrap();
+        match msg {
+            ResticMessage::Status(s) => assert!((s.percent_done - 1.0).abs() < f64::EPSILON),
+            _ => panic!("expected Status"),
+        }
+    }
+
+    #[test]
+    fn parse_rsync_canonical_line() {
+        let line = "    1,234,567  42%   12.34MB/s    0:01:23";
+        let p = parse_rsync_progress(line).unwrap();
+        assert_eq!(
+            p,
+            RsyncProgress {
+                bytes_transferred: 1234567,
+                percent: 42,
+                speed: "12.34MB/s".to_string(),
+                eta: "0:01:23".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rsync_single_digit_percent() {
+        let line = "  500  5%   1.00MB/s    0:00:01";
+        let p = parse_rsync_progress(line).unwrap();
+        assert_eq!(p.percent, 5);
+        assert_eq!(p.bytes_transferred, 500);
+    }
+
+    #[test]
+    fn parse_rsync_100_percent() {
+        let line = "  10,000,000 100%   50.00MB/s    0:00:00";
+        let p = parse_rsync_progress(line).unwrap();
+        assert_eq!(p.percent, 100);
+    }
+
+    #[test]
+    fn parse_rsync_plain_text_returns_none() {
+        assert!(parse_rsync_progress("sending incremental file list").is_none());
+    }
+
+    #[test]
+    fn parse_rsync_too_few_fields_returns_none() {
+        assert!(parse_rsync_progress("1234 42%").is_none());
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -186,7 +186,7 @@ pub fn run_with_progress(
         s.spawn(|| {
             let reader = BufReader::new(stdout_handle);
             let mut buf = stdout_content.lock().unwrap();
-            for line in reader.lines().filter_map(Result::ok) {
+            for line in reader.lines().map_while(Result::ok) {
                 if verbose {
                     emit_subprocess_line(&label_owned, &line);
                 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -320,6 +320,24 @@ pub fn progress_bar(msg: &str, total_bytes: Option<u64>) -> ProgressBar {
     }
 }
 
+pub fn set_bytes_style(pb: &ProgressBar) {
+    if should_use_colors() {
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner} {msg} [{bar:40}] {bytes}/{total_bytes} ({eta})")
+                .unwrap()
+                .progress_chars("█▉▊▋▌▍▎▏ "),
+        );
+    } else {
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} [{bar:40}] {bytes}/{total_bytes} ({eta})")
+                .unwrap()
+                .progress_chars("#>-"),
+        );
+    }
+}
+
 pub fn set_percent_style(pb: &ProgressBar) {
     if should_use_colors() {
         pb.set_style(
@@ -601,5 +619,46 @@ mod tests {
     #[test]
     fn parse_rsync_too_few_fields_returns_none() {
         assert!(parse_rsync_progress("1234 42%").is_none());
+    }
+
+    #[test]
+    fn run_with_progress_invokes_handler_for_each_stderr_line() {
+        let pb = ProgressBar::hidden();
+        let lines_seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let lines_clone = std::sync::Arc::clone(&lines_seen);
+
+        let result = run_with_progress(
+            "test",
+            Command::new("sh")
+                .arg("-c")
+                .arg("echo line1 >&2; echo line2 >&2; echo line3 >&2"),
+            &pb,
+            move |line, _pb| {
+                lines_clone.lock().unwrap().push(line.to_string());
+            },
+        )
+        .unwrap();
+
+        assert!(result.status.success());
+        let seen = lines_seen.lock().unwrap();
+        assert_eq!(*seen, vec!["line1", "line2", "line3"]);
+    }
+
+    #[test]
+    fn run_with_progress_captures_last_stderr() {
+        let pb = ProgressBar::hidden();
+
+        let result = run_with_progress(
+            "test",
+            Command::new("sh")
+                .arg("-c")
+                .arg("echo error details >&2; exit 1"),
+            &pb,
+            |_line, _pb| {},
+        )
+        .unwrap();
+
+        assert!(!result.status.success());
+        assert!(result.last_stderr.contains("error details"));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -356,6 +356,24 @@ pub fn set_percent_style(pb: &ProgressBar) {
     }
 }
 
+pub fn reset_to_spinner(pb: &ProgressBar) {
+    if should_use_colors() {
+        pb.set_style(
+            ProgressStyle::default_spinner()
+                .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+                .template("{spinner} {msg}")
+                .unwrap(),
+        );
+    } else {
+        pb.set_style(
+            ProgressStyle::default_spinner()
+                .tick_chars("/-\\|")
+                .template("{spinner} {msg}")
+                .unwrap(),
+        );
+    }
+}
+
 pub fn format_duration(seconds: u64) -> String {
     if seconds < 60 {
         format!("{}s", seconds)

--- a/src/output.rs
+++ b/src/output.rs
@@ -158,8 +158,6 @@ pub fn run_piped(label: &str, cmd: &mut Command) -> Result<SubprocessResult> {
 
 pub struct ProgressResult {
     pub status: ExitStatus,
-    #[allow(dead_code)]
-    pub stdout: String,
     pub last_stderr: String,
 }
 
@@ -169,55 +167,36 @@ pub fn run_with_progress(
     pb: &ProgressBar,
     line_handler: impl Fn(&str, &ProgressBar) + Send,
 ) -> Result<ProgressResult> {
-    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd.stdout(Stdio::null()).stderr(Stdio::piped());
     let mut child = cmd.spawn().wrap_err("failed to spawn subprocess")?;
 
-    let stdout_handle = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
 
     let verbose = is_verbose();
-    let label_owned = label.to_owned();
 
-    let stdout_content = std::sync::Mutex::new(String::new());
     let stderr_tail = std::sync::Mutex::new(Vec::<String>::new());
     const MAX_STDERR_LINES: usize = 20;
 
-    std::thread::scope(|s| {
-        s.spawn(|| {
-            let reader = BufReader::new(stdout_handle);
-            let mut buf = stdout_content.lock().unwrap();
-            for line in reader.lines().map_while(Result::ok) {
-                if verbose {
-                    emit_subprocess_line(&label_owned, &line);
-                }
-                buf.push_str(&line);
-                buf.push('\n');
-            }
-        });
-
-        let reader = BufReader::new(stderr);
-        for line in reader.lines().map_while(Result::ok) {
-            if verbose {
-                emit_subprocess_line(label, &line);
-            }
-            {
-                let mut tail = stderr_tail.lock().unwrap();
-                tail.push(line.clone());
-                if tail.len() > MAX_STDERR_LINES {
-                    tail.remove(0);
-                }
-            }
-            line_handler(&line, pb);
+    let reader = BufReader::new(stderr);
+    for line in reader.lines().map_while(Result::ok) {
+        if verbose {
+            emit_subprocess_line(label, &line);
         }
-    });
+        {
+            let mut tail = stderr_tail.lock().unwrap();
+            tail.push(line.clone());
+            if tail.len() > MAX_STDERR_LINES {
+                tail.remove(0);
+            }
+        }
+        line_handler(&line, pb);
+    }
 
     let status = child.wait().wrap_err("failed to wait on subprocess")?;
-    let stdout = stdout_content.into_inner().unwrap();
     let last_stderr = stderr_tail.into_inner().unwrap().join("\n");
 
     Ok(ProgressResult {
         status,
-        stdout,
         last_stderr,
     })
 }
@@ -342,14 +321,14 @@ pub fn set_percent_style(pb: &ProgressBar) {
     if should_use_colors() {
         pb.set_style(
             ProgressStyle::default_bar()
-                .template("{spinner} {msg} [{bar:40}] {pos:>3}%")
+                .template("{spinner} {msg} [{bar:40}] {pos:>3}% {prefix}")
                 .unwrap()
                 .progress_chars("█▉▊▋▌▍▎▏ "),
         );
     } else {
         pb.set_style(
             ProgressStyle::default_bar()
-                .template("{msg} [{bar:40}] {pos:>3}%")
+                .template("{msg} [{bar:40}] {pos:>3}% {prefix}")
                 .unwrap()
                 .progress_chars("#>-"),
         );
@@ -357,6 +336,7 @@ pub fn set_percent_style(pb: &ProgressBar) {
 }
 
 pub fn reset_to_spinner(pb: &ProgressBar) {
+    pb.set_prefix(String::new());
     if should_use_colors() {
         pb.set_style(
             ProgressStyle::default_spinner()

--- a/src/output.rs
+++ b/src/output.rs
@@ -178,7 +178,8 @@ pub fn run_with_progress(
     const MAX_STDERR_LINES: usize = 20;
 
     let reader = BufReader::new(stderr);
-    for line in reader.lines().map_while(Result::ok) {
+    for line_result in reader.lines() {
+        let Ok(line) = line_result else { continue };
         if verbose {
             emit_subprocess_line(label, &line);
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -196,7 +196,7 @@ pub fn run_with_progress(
         });
 
         let reader = BufReader::new(stderr);
-        for line in reader.lines().filter_map(Result::ok) {
+        for line in reader.lines().map_while(Result::ok) {
             if verbose {
                 emit_subprocess_line(label, &line);
             }


### PR DESCRIPTION
## Summary

Closes #220

- Replace spinners with real `indicatif` progress bars driven by structured output from `restic --json` and `rsync --info=progress2`
- Add `run_with_progress()` helper that streams subprocess stderr through a line handler to drive progress bars
- Add pure parsing functions for restic JSON status/summary messages and rsync progress2 lines with 11 unit tests

## Changes

| Command | Before | After |
|---------|--------|-------|
| `backup push` | Spinner, blocks on `.output()` | Progress bar driven by restic `--json` `percent_done`/`bytes_done` |
| `backup create` | Spinner, rsync suppressed | Progress bar driven by rsync `--info=progress2` percent |
| `backup restore` | Spinner, rsync suppressed | Progress bar driven by rsync `--info=progress2` percent |

## Test plan

- [x] `cargo build` — clean, no warnings
- [x] `cargo test` — all 129 tests pass
- [x] `cargo clippy` — no new warnings (pre-existing only)
- [ ] Manual: `auberge backup create` shows per-app progress bar during rsync
- [ ] Manual: `auberge backup push` shows byte-level progress bar during restic upload
- [ ] Manual: `auberge backup restore` shows progress bar during rsync restore
- [ ] Verify non-terminal (piped) output degrades gracefully