### PR TITLE
fix(cockpit): set NetworkManager as netplan renderer for PackageKit

### DIFF
--- a/ansible/playbooks/apps.yml
+++ b/ansible/playbooks/apps.yml
@@ -17,6 +17,8 @@
       tags: [apps, storage, media, books, grimmory]
     - role: cockpit
       tags: [apps, monitoring, cockpit]
+      vars:
+        cockpit_configure_nm_renderer: true
     - role: colporteur
       tags: [apps, web, rss, colporteur]
     - role: freshrss

--- a/ansible/roles/cockpit/defaults/main.yml
+++ b/ansible/roles/cockpit/defaults/main.yml
@@ -2,3 +2,4 @@
 cockpit_port: 9090
 cockpit_subdomain: cockpit
 cockpit_domain: "{{ cockpit_subdomain }}.{{ domain }}"
+cockpit_configure_nm_renderer: false

--- a/ansible/roles/cockpit/handlers/main.yml
+++ b/ansible/roles/cockpit/handlers/main.yml
@@ -5,6 +5,11 @@
     state: restarted
     daemon_reload: true
 
+- name: Apply netplan
+  ansible.builtin.command:
+    cmd: netplan apply
+  changed_when: true
+
 - name: Restart caddy
   ansible.builtin.systemd_service:
     name: caddy

--- a/ansible/roles/cockpit/handlers/main.yml
+++ b/ansible/roles/cockpit/handlers/main.yml
@@ -8,6 +8,8 @@
 - name: Apply netplan
   ansible.builtin.command:
     cmd: netplan apply
+  async: 120
+  poll: 0
   changed_when: true
 
 - name: Restart caddy

--- a/ansible/roles/cockpit/handlers/main.yml
+++ b/ansible/roles/cockpit/handlers/main.yml
@@ -5,13 +5,6 @@
     state: restarted
     daemon_reload: true
 
-- name: Apply netplan
-  ansible.builtin.command:
-    cmd: netplan apply
-  async: 120
-  poll: 0
-  changed_when: true
-
 - name: Restart caddy
   ansible.builtin.systemd_service:
     name: caddy

--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -122,38 +122,39 @@
       when: cockpit_configure_nm_renderer and cockpit_netplan_bin.stat.exists
       register: cockpit_netplan_renderer
 
-    - name: Validate netplan config before applying
-      ansible.builtin.command: /usr/sbin/netplan generate
-      changed_when: false
-      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+    - name: Apply netplan renderer change
+      when:
+        - cockpit_netplan_renderer is defined
+        - cockpit_netplan_renderer.changed
+        - not ansible_check_mode
+      block:
+        - name: Validate netplan config before applying
+          ansible.builtin.command: /usr/sbin/netplan generate
+          changed_when: false
 
-    - name: Start netplan apply
-      ansible.builtin.command: /usr/sbin/netplan apply
-      async: 60
-      poll: 0
-      register: cockpit_netplan_apply_job
-      changed_when: true
-      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+        - name: Start netplan apply
+          ansible.builtin.command: /usr/sbin/netplan apply
+          async: 60
+          poll: 0
+          register: cockpit_netplan_apply_job
+          changed_when: true
 
-    - name: Give netplan apply time to interrupt networking
-      ansible.builtin.pause:
-        seconds: 2
-      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+        - name: Give netplan apply time to interrupt networking
+          ansible.builtin.pause:
+            seconds: 2
 
-    - name: Wait for SSH to return after netplan apply
-      ansible.builtin.wait_for_connection:
-        delay: 2
-        timeout: 60
-      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+        - name: Wait for SSH to return after netplan apply
+          ansible.builtin.wait_for_connection:
+            delay: 2
+            timeout: 60
 
-    - name: Wait for netplan apply to finish
-      ansible.builtin.async_status:
-        jid: "{{ cockpit_netplan_apply_job.ansible_job_id }}"
-      register: cockpit_netplan_apply_status
-      until: cockpit_netplan_apply_status.finished
-      retries: 12
-      delay: 5
-      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+        - name: Wait for netplan apply to finish
+          ansible.builtin.async_status:
+            jid: "{{ cockpit_netplan_apply_job.ansible_job_id }}"
+          register: cockpit_netplan_apply_status
+          until: cockpit_netplan_apply_status.finished
+          retries: 12
+          delay: 5
 
     - name: Validate Cloudflare API token for Caddy DNS-01 challenge
       ansible.builtin.assert:

--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -85,16 +85,16 @@
         state: started
         daemon_reload: true
 
-    - name: Check if netplan is in use
+    - name: Check if netplan binary is present
       ansible.builtin.stat:
-        path: /etc/netplan
-      register: cockpit_netplan_dir
+        path: /usr/sbin/netplan
+      register: cockpit_netplan_bin
 
     - name: Ensure NetworkManager is installed
       ansible.builtin.apt:
         name: network-manager
         state: present
-      when: cockpit_netplan_dir.stat.exists
+      when: cockpit_netplan_bin.stat.exists
 
     - name: Set NetworkManager as netplan renderer
       # The server uses netplan with the default networkd renderer, so NM has no
@@ -111,18 +111,35 @@
         owner: root
         group: root
         mode: "0600"
-      when: cockpit_netplan_dir.stat.exists
+      when: cockpit_netplan_bin.stat.exists
       register: cockpit_netplan_renderer
-      notify: Apply netplan
 
-    - name: Flush handlers to apply netplan before continuing
-      ansible.builtin.meta: flush_handlers
+    - name: Start netplan apply
+      ansible.builtin.command: netplan apply
+      async: 60
+      poll: 0
+      register: cockpit_netplan_apply_job
+      changed_when: true
+      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+
+    - name: Give netplan apply time to interrupt networking
+      ansible.builtin.pause:
+        seconds: 2
       when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
 
     - name: Wait for SSH to return after netplan apply
       ansible.builtin.wait_for_connection:
         delay: 2
         timeout: 60
+      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+
+    - name: Wait for netplan apply to finish
+      ansible.builtin.async_status:
+        jid: "{{ cockpit_netplan_apply_job.ansible_job_id }}"
+      register: cockpit_netplan_apply_status
+      until: cockpit_netplan_apply_status.finished
+      retries: 12
+      delay: 5
       when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
 
     - name: Validate Cloudflare API token for Caddy DNS-01 challenge

--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -85,6 +85,17 @@
         state: started
         daemon_reload: true
 
+    - name: Check if netplan is in use
+      ansible.builtin.stat:
+        path: /etc/netplan
+      register: cockpit_netplan_dir
+
+    - name: Ensure NetworkManager is installed
+      ansible.builtin.apt:
+        name: network-manager
+        state: present
+      when: cockpit_netplan_dir.stat.exists
+
     - name: Set NetworkManager as netplan renderer
       # The server uses netplan with the default networkd renderer, so NM has no
       # managed interfaces and reports "connected (local only)". PackageKit checks
@@ -100,7 +111,19 @@
         owner: root
         group: root
         mode: "0600"
+      when: cockpit_netplan_dir.stat.exists
+      register: cockpit_netplan_renderer
       notify: Apply netplan
+
+    - name: Flush handlers to apply netplan before continuing
+      ansible.builtin.meta: flush_handlers
+      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+
+    - name: Wait for SSH to return after netplan apply
+      ansible.builtin.wait_for_connection:
+        delay: 2
+        timeout: 60
+      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
 
     - name: Validate Cloudflare API token for Caddy DNS-01 challenge
       ansible.builtin.assert:

--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -97,12 +97,19 @@
         state: present
       when: cockpit_configure_nm_renderer and cockpit_netplan_bin.stat.exists
 
+    - name: Ensure NetworkManager is enabled and running
+      ansible.builtin.systemd_service:
+        name: NetworkManager
+        enabled: true
+        state: started
+      when: cockpit_configure_nm_renderer and cockpit_netplan_bin.stat.exists
+
     - name: Set NetworkManager as netplan renderer
       # The server uses netplan with the default networkd renderer, so NM has no
       # managed interfaces and reports "connected (local only)". PackageKit checks
       # NM state and treats anything below "connected (global)" as offline, breaking
-      # Cockpit's software updates page. Switching the renderer lets NM manage ens6
-      # and properly detect internet connectivity.
+      # Cockpit's software updates page. Switching the renderer lets NM manage the
+      # primary network interface and properly detect internet connectivity.
       ansible.builtin.copy:
         content: |
           network:

--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -89,12 +89,13 @@
       ansible.builtin.stat:
         path: /usr/sbin/netplan
       register: cockpit_netplan_bin
+      when: cockpit_configure_nm_renderer
 
     - name: Ensure NetworkManager is installed
       ansible.builtin.apt:
         name: network-manager
         state: present
-      when: cockpit_netplan_bin.stat.exists
+      when: cockpit_configure_nm_renderer and cockpit_netplan_bin.stat.exists
 
     - name: Set NetworkManager as netplan renderer
       # The server uses netplan with the default networkd renderer, so NM has no
@@ -111,11 +112,16 @@
         owner: root
         group: root
         mode: "0600"
-      when: cockpit_netplan_bin.stat.exists
+      when: cockpit_configure_nm_renderer and cockpit_netplan_bin.stat.exists
       register: cockpit_netplan_renderer
 
+    - name: Validate netplan config before applying
+      ansible.builtin.command: /usr/sbin/netplan generate
+      changed_when: false
+      when: cockpit_netplan_renderer is defined and cockpit_netplan_renderer.changed
+
     - name: Start netplan apply
-      ansible.builtin.command: netplan apply
+      ansible.builtin.command: /usr/sbin/netplan apply
       async: 60
       poll: 0
       register: cockpit_netplan_apply_job

--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -134,7 +134,7 @@
 
         - name: Start netplan apply
           ansible.builtin.command: /usr/sbin/netplan apply
-          async: 60
+          async: 180
           poll: 0
           register: cockpit_netplan_apply_job
           changed_when: true
@@ -153,7 +153,7 @@
             jid: "{{ cockpit_netplan_apply_job.ansible_job_id }}"
           register: cockpit_netplan_apply_status
           until: cockpit_netplan_apply_status.finished
-          retries: 12
+          retries: 24
           delay: 5
 
     - name: Validate Cloudflare API token for Caddy DNS-01 challenge

--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -85,6 +85,23 @@
         state: started
         daemon_reload: true
 
+    - name: Set NetworkManager as netplan renderer
+      # The server uses netplan with the default networkd renderer, so NM has no
+      # managed interfaces and reports "connected (local only)". PackageKit checks
+      # NM state and treats anything below "connected (global)" as offline, breaking
+      # Cockpit's software updates page. Switching the renderer lets NM manage ens6
+      # and properly detect internet connectivity.
+      ansible.builtin.copy:
+        content: |
+          network:
+            version: 2
+            renderer: NetworkManager
+        dest: /etc/netplan/99-nm-renderer.yaml
+        owner: root
+        group: root
+        mode: "0600"
+      notify: Apply netplan
+
     - name: Validate Cloudflare API token for Caddy DNS-01 challenge
       ansible.builtin.assert:
         that:


### PR DESCRIPTION
## Summary
- Cockpit's software updates page showed "Loading available updates failed / Cannot refresh cache whilst offline"
- Root cause: server uses netplan with default `networkd` renderer — NM has no managed interfaces and reports `connected (local only)`, which PackageKit treats as offline
- Fix: deploy `/etc/netplan/99-nm-renderer.yaml` drop-in to switch renderer to NetworkManager, so NM manages `ens6` and reports `connected (full)`

## Test plan
- [ ] Run `auberge deploy cockpit`
- [ ] SSH to server: `nmcli general status` → STATE should be `connected`, CONNECTIVITY `full`
- [ ] SSH to server: `sudo pkcon refresh` → should succeed
- [ ] Cockpit software updates page loads without error