### PR TITLE
feat(cli): stream ansible task names during deploy and ansible subcommands

### DIFF
--- a/src/commands/ansible.rs
+++ b/src/commands/ansible.rs
@@ -256,11 +256,20 @@ fn run_auto_resolved(
         )?;
 
         if !result.success {
-            eyre::bail!(
-                "{} failed with exit code {}",
-                playbook.name,
-                result.exit_code
-            );
+            if result.last_output.is_empty() {
+                eyre::bail!(
+                    "{} failed with exit code {}",
+                    playbook.name,
+                    result.exit_code
+                );
+            } else {
+                eyre::bail!(
+                    "{} failed with exit code {}:\n{}",
+                    playbook.name,
+                    result.exit_code,
+                    result.last_output.trim()
+                );
+            }
         }
 
         output::success(&format!("{} completed successfully", playbook.name));
@@ -349,8 +358,14 @@ fn run_single_playbook(
     if result.success {
         output::success("Playbook completed successfully");
         Ok(())
-    } else {
+    } else if result.last_output.is_empty() {
         eyre::bail!("Playbook failed with exit code {}", result.exit_code)
+    } else {
+        eyre::bail!(
+            "Playbook failed with exit code {}:\n{}",
+            result.exit_code,
+            result.last_output.trim()
+        )
     }
 }
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -270,11 +270,20 @@ pub fn run_deploy(cmd: DeployCmd) -> Result<()> {
         )?;
 
         if !result.success {
-            eyre::bail!(
-                "{} failed with exit code {}",
-                playbook.name,
-                result.exit_code
-            );
+            if result.last_output.is_empty() {
+                eyre::bail!(
+                    "{} failed with exit code {}",
+                    playbook.name,
+                    result.exit_code
+                );
+            } else {
+                eyre::bail!(
+                    "{} failed with exit code {}:\n{}",
+                    playbook.name,
+                    result.exit_code,
+                    result.last_output.trim()
+                );
+            }
         }
 
         output::success(&format!("{} completed successfully", playbook.name));

--- a/src/output.rs
+++ b/src/output.rs
@@ -423,30 +423,42 @@ pub fn run_with_stdout_progress(
     pb: &ProgressBar,
     mut line_handler: impl FnMut(&str, &ProgressBar),
 ) -> Result<ProgressResult> {
-    cmd.stdout(Stdio::piped()).stderr(Stdio::null());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = cmd.spawn().wrap_err("failed to spawn subprocess")?;
     let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
     let verbose = is_verbose();
 
-    let mut last_lines: Vec<String> = Vec::new();
+    let mut last_stdout: Vec<String> = Vec::new();
     const MAX_LINES: usize = 20;
 
-    for line_result in BufReader::new(stdout).lines() {
-        let Ok(line) = line_result else { continue };
-        if verbose {
-            emit_subprocess_line(label, &line);
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            for line_result in BufReader::new(stderr).lines() {
+                let Ok(line) = line_result else { continue };
+                if verbose {
+                    emit_subprocess_line(label, &line);
+                }
+            }
+        });
+
+        for line_result in BufReader::new(stdout).lines() {
+            let Ok(line) = line_result else { continue };
+            if verbose {
+                emit_subprocess_line(label, &line);
+            }
+            last_stdout.push(line.clone());
+            if last_stdout.len() > MAX_LINES {
+                last_stdout.remove(0);
+            }
+            line_handler(&line, pb);
         }
-        last_lines.push(line.clone());
-        if last_lines.len() > MAX_LINES {
-            last_lines.remove(0);
-        }
-        line_handler(&line, pb);
-    }
+    });
 
     let status = child.wait().wrap_err("failed to wait on subprocess")?;
     Ok(ProgressResult {
         status,
-        last_stderr: last_lines.join("\n"),
+        last_stderr: last_stdout.join("\n"),
     })
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -405,6 +405,18 @@ pub fn parse_ansible_task(line: &str) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
+pub fn format_ansible_task(task: &str) -> String {
+    if let Some((role, name)) = task.split_once(" : ") {
+        if should_use_colors() {
+            format!("{DIM}{}:{RESET} {}", role, name)
+        } else {
+            format!("{}: {}", role, name)
+        }
+    } else {
+        task.to_string()
+    }
+}
+
 pub fn run_with_stdout_progress(
     label: &str,
     cmd: &mut Command,
@@ -662,6 +674,28 @@ mod tests {
     #[test]
     fn parse_ansible_task_empty_returns_none() {
         assert!(parse_ansible_task("").is_none());
+    }
+
+    #[test]
+    fn format_ansible_task_dims_role_prefix() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        set_verbose(false);
+        let formatted = format_ansible_task("nginx : Install package");
+        assert!(formatted.contains("nginx:"));
+        assert!(formatted.contains("Install package"));
+    }
+
+    #[test]
+    fn format_ansible_task_no_role_returns_unchanged() {
+        let formatted = format_ansible_task("Gathering Facts");
+        assert_eq!(formatted, "Gathering Facts");
+    }
+
+    #[test]
+    fn format_ansible_task_nested_role_splits_on_first_separator() {
+        let formatted = format_ansible_task("role : sub : detail");
+        assert!(formatted.contains("role:"));
+        assert!(formatted.contains("sub : detail"));
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -399,6 +399,45 @@ pub fn parse_restic_message(line: &str) -> Option<ResticMessage> {
     serde_json::from_str(line).ok()
 }
 
+pub fn parse_ansible_task(line: &str) -> Option<String> {
+    let rest = line.trim().strip_prefix("TASK [")?;
+    let end = rest.find(']')?;
+    Some(rest[..end].to_string())
+}
+
+pub fn run_with_stdout_progress(
+    label: &str,
+    cmd: &mut Command,
+    pb: &ProgressBar,
+    mut line_handler: impl FnMut(&str, &ProgressBar),
+) -> Result<ProgressResult> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::null());
+    let mut child = cmd.spawn().wrap_err("failed to spawn subprocess")?;
+    let stdout = child.stdout.take().unwrap();
+    let verbose = is_verbose();
+
+    let mut last_lines: Vec<String> = Vec::new();
+    const MAX_LINES: usize = 20;
+
+    for line_result in BufReader::new(stdout).lines() {
+        let Ok(line) = line_result else { continue };
+        if verbose {
+            emit_subprocess_line(label, &line);
+        }
+        last_lines.push(line.clone());
+        if last_lines.len() > MAX_LINES {
+            last_lines.remove(0);
+        }
+        line_handler(&line, pb);
+    }
+
+    let status = child.wait().wrap_err("failed to wait on subprocess")?;
+    Ok(ProgressResult {
+        status,
+        last_stderr: last_lines.join("\n"),
+    })
+}
+
 pub fn parse_rsync_progress(line: &str) -> Option<RsyncProgress> {
     let line = line.trim_end_matches('\r');
     let fields: Vec<&str> = line.split_whitespace().collect();
@@ -576,6 +615,94 @@ mod tests {
             ResticMessage::Status(s) => assert!((s.percent_done - 1.0).abs() < f64::EPSILON),
             _ => panic!("expected Status"),
         }
+    }
+
+    #[test]
+    fn parse_ansible_task_extracts_name() {
+        assert_eq!(
+            parse_ansible_task("TASK [Install nginx] ***************************"),
+            Some("Install nginx".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ansible_task_with_role_prefix() {
+        assert_eq!(
+            parse_ansible_task("TASK [role : subtask name] ****"),
+            Some("role : subtask name".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ansible_task_gathering_facts() {
+        assert_eq!(
+            parse_ansible_task("TASK [Gathering Facts] *****"),
+            Some("Gathering Facts".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ansible_task_strips_leading_whitespace() {
+        assert_eq!(
+            parse_ansible_task("  TASK [Install nginx] ****"),
+            Some("Install nginx".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ansible_task_play_line_returns_none() {
+        assert!(parse_ansible_task("PLAY [all] ****").is_none());
+    }
+
+    #[test]
+    fn parse_ansible_task_ok_line_returns_none() {
+        assert!(parse_ansible_task("ok: [hostname]").is_none());
+    }
+
+    #[test]
+    fn parse_ansible_task_empty_returns_none() {
+        assert!(parse_ansible_task("").is_none());
+    }
+
+    #[test]
+    fn run_with_stdout_progress_invokes_handler_for_each_line() {
+        let pb = ProgressBar::hidden();
+        let lines_seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let lines_clone = std::sync::Arc::clone(&lines_seen);
+
+        let result = run_with_stdout_progress(
+            "test",
+            Command::new("sh")
+                .arg("-c")
+                .arg("echo line1; echo line2; echo line3"),
+            &pb,
+            move |line, _pb| {
+                lines_clone.lock().unwrap().push(line.to_string());
+            },
+        )
+        .unwrap();
+
+        assert!(result.status.success());
+        let seen = lines_seen.lock().unwrap();
+        assert_eq!(*seen, vec!["line1", "line2", "line3"]);
+    }
+
+    #[test]
+    fn run_with_stdout_progress_captures_last_lines_on_failure() {
+        let pb = ProgressBar::hidden();
+
+        let result = run_with_stdout_progress(
+            "test",
+            Command::new("sh")
+                .arg("-c")
+                .arg("echo output details; exit 1"),
+            &pb,
+            |_line, _pb| {},
+        )
+        .unwrap();
+
+        assert!(!result.status.success());
+        assert!(result.last_stderr.contains("output details"));
     }
 
     #[test]

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -203,7 +203,7 @@ pub fn run_playbook(
     let spinner = output::spinner(&format!("Running {}...", playbook_label));
     let result = output::run_with_stdout_progress("ansible", &mut cmd, &spinner, |line, pb| {
         if let Some(task) = output::parse_ansible_task(line) {
-            pb.set_message(format!("Running: {}", task));
+            pb.set_message(format!("Running: {}", output::format_ansible_task(&task)));
         }
     })
     .wrap_err("Failed to execute ansible-playbook")?;

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -194,11 +194,18 @@ pub fn run_playbook(
         });
     }
 
-    let result =
-        output::run_piped("ansible", &mut cmd).wrap_err("Failed to execute ansible-playbook")?;
-    if result.status.success() {
-        output::clear_subprocess_lines(result.lines_written);
-    }
+    let playbook_label = playbook
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or("ansible");
+    let spinner = output::spinner(&format!("Running {}...", playbook_label));
+    let result = output::run_with_stdout_progress("ansible", &mut cmd, &spinner, |line, pb| {
+        if let Some(task) = output::parse_ansible_task(line) {
+            pb.set_message(format!("Running: {}", task));
+        }
+    })
+    .wrap_err("Failed to execute ansible-playbook")?;
+    spinner.finish_and_clear();
 
     Ok(AnsibleResult {
         success: result.status.success(),

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 pub struct AnsibleResult {
     pub success: bool,
     pub exit_code: i32,
+    pub last_output: String,
 }
 
 pub struct InventoryHost {
@@ -191,6 +192,7 @@ pub fn run_playbook(
         return Ok(AnsibleResult {
             success: status.success(),
             exit_code: status.code().unwrap_or(-1),
+            last_output: String::new(),
         });
     }
 
@@ -210,6 +212,7 @@ pub fn run_playbook(
     Ok(AnsibleResult {
         success: result.status.success(),
         exit_code: result.status.code().unwrap_or(-1),
+        last_output: result.last_stderr,
     })
 }
 
@@ -242,6 +245,7 @@ pub fn run_bootstrap(playbook: &Path, host: &InventoryHost) -> Result<AnsibleRes
     Ok(AnsibleResult {
         success: status.success(),
         exit_code: status.code().unwrap_or(-1),
+        last_output: String::new(),
     })
 }
 


### PR DESCRIPTION
Closes #222

## Summary
- Adds `parse_ansible_task()` in `output.rs` to extract task names from ansible stdout lines (`TASK [name] ***...`)
- Adds `run_with_stdout_progress()` in `output.rs` — mirrors `run_with_progress()` (used by restic/rsync) but reads stdout instead of stderr, since ansible writes TASK/PLAY output to stdout
- Wires both into `run_playbook()`'s non-tty path: creates a spinner that updates its message to `Running: <task name>` as each task starts

## Behaviour
- **Non-tty path** (`deploy`, `ansible run` without `--ask-pass`/`--ask-vault-pass`): spinner shows current TASK name in real time
- **Tty path** (`--ask-pass`, `--ask-vault-pass`, bootstrap): unchanged — still uses `.status()` for full stdin/stdout/stderr passthrough so interactive prompts work

## Test plan
- [ ] `parse_ansible_task` unit tests cover task lines, role-prefixed tasks, PLAY lines (→ None), empty input (→ None)
- [ ] `run_with_stdout_progress` integration test verifies handler is called for each stdout line and failure output is captured
- [ ] `cargo test` — 141 tests pass