### PR TITLE
feat(backup): failsafe service restart during backup

### DIFF
--- a/docs/troubleshooting/backup-restore-issues.md
+++ b/docs/troubleshooting/backup-restore-issues.md
@@ -51,6 +51,10 @@ auberge backup create --host my-vps
 # (already excluded by default)
 ```
 
+> **Note:** If a backup is interrupted (network drop, process killed), stopped services
+> are automatically restarted via a remote failsafe timer (30-minute timeout). You can
+> verify with `ssh ansible@vps "systemctl list-timers | grep auberge-backup-failsafe"`.
+
 ### "Permission denied" during backup
 
 **Problem:** Insufficient permissions to read service files.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1630,6 +1630,61 @@ fn default_backup_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("~/.local/share/auberge/backups"))
 }
 
+struct ServiceGuard<'a> {
+    host: &'a Host,
+    ssh_key: &'a Path,
+    services: Vec<&'a str>,
+    armed: bool,
+}
+
+impl<'a> ServiceGuard<'a> {
+    fn new(host: &'a Host, ssh_key: &'a Path) -> Self {
+        Self {
+            host,
+            ssh_key,
+            services: Vec::new(),
+            armed: false,
+        }
+    }
+
+    fn stop_service(&mut self, service: &'a str) -> Result<()> {
+        if let Err(e) = remote_systemctl(self.host, self.ssh_key, "stop", service) {
+            for previously_stopped in &self.services {
+                let _ = remote_systemctl(self.host, self.ssh_key, "start", previously_stopped);
+            }
+            return Err(e).wrap_err_with(|| format!("Failed to stop service {}", service));
+        }
+        self.services.push(service);
+        self.armed = true;
+        Ok(())
+    }
+
+    fn restart_all(&mut self) -> Vec<String> {
+        self.services
+            .iter()
+            .filter_map(|service| {
+                remote_systemctl(self.host, self.ssh_key, "start", service)
+                    .err()
+                    .map(|e| format!("{}: {}", service, e))
+            })
+            .collect()
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ServiceGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed && !self.services.is_empty() {
+            for service in &self.services {
+                let _ = remote_systemctl(self.host, self.ssh_key, "start", service);
+            }
+        }
+    }
+}
+
 fn backup_app(
     host: &Host,
     config: &AppBackupConfig,
@@ -1650,18 +1705,15 @@ fn backup_app(
         )
     })?;
 
-    let mut stopped_services: Vec<&str> = Vec::new();
+    let mut guard = ServiceGuard::new(host, ssh_key);
+
     if !config.systemd_services.is_empty() {
         pb.set_message(format!("Backing up {} (stopping services)", config.name));
         for service in &config.systemd_services {
-            if let Err(e) = remote_systemctl(host, ssh_key, "stop", service) {
-                for previously_stopped in &stopped_services {
-                    let _ = remote_systemctl(host, ssh_key, "start", previously_stopped);
-                }
+            if let Err(e) = guard.stop_service(service) {
                 pb.finish_and_clear();
-                return Err(e).wrap_err_with(|| format!("Failed to stop service {}", service));
+                return Err(e);
             }
-            stopped_services.push(service);
         }
     }
 
@@ -1669,9 +1721,6 @@ fn backup_app(
         pb.set_message(format!("Backing up {} (dumping database)", config.name));
         if let Err(e) = remote_pg_dump(host, ssh_key, db) {
             remote_pg_dump_cleanup(host, ssh_key, db);
-            for service in &stopped_services {
-                let _ = remote_systemctl(host, ssh_key, "start", service);
-            }
             pb.finish_and_clear();
             return Err(e).wrap_err("pg_dump failed");
         }
@@ -1698,15 +1747,15 @@ fn backup_app(
     }
 
     output::reset_to_spinner(&pb);
-    let mut start_failures: Vec<String> = Vec::new();
-    if !config.systemd_services.is_empty() {
+    let start_failures = if !config.systemd_services.is_empty() {
         pb.set_message(format!("Backing up {} (starting services)", config.name));
-        for service in &config.systemd_services {
-            if let Err(e) = remote_systemctl(host, ssh_key, "start", service) {
-                start_failures.push(format!("{}: {}", service, e));
-            }
-        }
-    }
+        let failures = guard.restart_all();
+        guard.disarm();
+        failures
+    } else {
+        guard.disarm();
+        Vec::new()
+    };
 
     match rsync_result {
         Ok(()) => {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1665,7 +1665,7 @@ impl<'a> ServiceGuard<'a> {
         let unit = format!("auberge-backup-failsafe-{}", app_name);
         let services_arg = self.services.join(" ");
         let cmd = format!(
-            "systemd-run --unit={} --on-active=15min /bin/bash -c 'systemctl start {}'",
+            "sudo systemd-run --unit={} --on-active=15min /bin/bash -c 'systemctl start {}'",
             unit, services_arg
         );
         if remote_ssh_command(self.host, self.ssh_key, &cmd).is_ok() {
@@ -1676,10 +1676,10 @@ impl<'a> ServiceGuard<'a> {
     fn cancel_remote_failsafe(&mut self) {
         if let Some(ref unit) = self.remote_timer_unit.take() {
             let cmd = format!(
-                "systemctl stop {}.timer 2>/dev/null; systemctl reset-failed {}.timer 2>/dev/null",
+                "sudo systemctl stop {}.timer 2>/dev/null; sudo systemctl reset-failed {}.timer 2>/dev/null",
                 unit, unit
             );
-            let _ = remote_ssh_command(self.host, self.ssh_key, &cmd);
+            let _ = remote_ssh_command_unchecked(self.host, self.ssh_key, &cmd);
         }
     }
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -2493,4 +2493,57 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_service_guard_tracks_stopped_services() {
+        let host = test_host();
+        let mut guard = ServiceGuard {
+            host: &host,
+            ssh_key: Path::new("/dev/null"),
+            services: Vec::new(),
+            remote_timer_unit: None,
+            armed: false,
+        };
+        guard.services.push("svc-a");
+        guard.services.push("svc-b");
+        assert_eq!(guard.services, vec!["svc-a", "svc-b"]);
+        assert!(!guard.armed);
+    }
+
+    #[test]
+    fn test_service_guard_disarm_prevents_restart() {
+        let host = test_host();
+        let mut guard = ServiceGuard {
+            host: &host,
+            ssh_key: Path::new("/dev/null"),
+            services: vec!["svc-a"],
+            remote_timer_unit: None,
+            armed: false,
+        };
+        assert!(!guard.armed);
+        guard.armed = false;
+        assert!(!guard.armed);
+    }
+
+    #[test]
+    fn test_service_guard_failsafe_timer_unit_name() {
+        let app_name = "paperless-ngx";
+        let unit = format!("auberge-backup-failsafe-{}", app_name);
+        assert_eq!(unit, "auberge-backup-failsafe-paperless-ngx");
+    }
+
+    #[test]
+    fn test_service_guard_empty_services_is_noop() {
+        let host = test_host();
+        let guard = ServiceGuard {
+            host: &host,
+            ssh_key: Path::new("/dev/null"),
+            services: Vec::new(),
+            remote_timer_unit: None,
+            armed: false,
+        };
+        assert!(guard.services.is_empty());
+        assert!(!guard.armed);
+        drop(guard);
+    }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1665,19 +1665,28 @@ impl<'a> ServiceGuard<'a> {
         let unit = format!("auberge-backup-failsafe-{}", app_name);
         let services_arg = self.services.join(" ");
         let cmd = format!(
-            "sudo systemd-run --unit={} --on-active=15min /bin/bash -c 'systemctl start {}'",
+            "sudo systemd-run --collect --unit={} --on-active=30min /bin/bash -c 'systemctl start {}'",
             unit, services_arg
         );
-        if remote_ssh_command(self.host, self.ssh_key, &cmd).is_ok() {
-            self.remote_timer_unit = Some(unit);
+        match remote_ssh_command(self.host, self.ssh_key, &cmd) {
+            Ok(_) => {
+                self.remote_timer_unit = Some(unit);
+            }
+            Err(e) => {
+                output::warn(&format!(
+                    "Failed to arm remote failsafe timer '{}' on '{}': {}",
+                    unit, self.host.name, e
+                ));
+            }
         }
     }
 
     fn cancel_remote_failsafe(&mut self) {
         if let Some(ref unit) = self.remote_timer_unit.take() {
             let cmd = format!(
-                "sudo systemctl stop {}.timer 2>/dev/null; sudo systemctl reset-failed {}.timer 2>/dev/null",
-                unit, unit
+                "sudo systemctl stop {u}.timer {u}.service 2>/dev/null; \
+                 sudo systemctl reset-failed {u}.timer {u}.service 2>/dev/null",
+                u = unit
             );
             let _ = remote_ssh_command_unchecked(self.host, self.ssh_key, &cmd);
         }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1634,6 +1634,7 @@ struct ServiceGuard<'a> {
     host: &'a Host,
     ssh_key: &'a Path,
     services: Vec<&'a str>,
+    remote_timer_unit: Option<String>,
     armed: bool,
 }
 
@@ -1643,6 +1644,7 @@ impl<'a> ServiceGuard<'a> {
             host,
             ssh_key,
             services: Vec::new(),
+            remote_timer_unit: None,
             armed: false,
         }
     }
@@ -1659,6 +1661,28 @@ impl<'a> ServiceGuard<'a> {
         Ok(())
     }
 
+    fn schedule_remote_failsafe(&mut self, app_name: &str) {
+        let unit = format!("auberge-backup-failsafe-{}", app_name);
+        let services_arg = self.services.join(" ");
+        let cmd = format!(
+            "systemd-run --unit={} --on-active=15min /bin/bash -c 'systemctl start {}'",
+            unit, services_arg
+        );
+        if remote_ssh_command(self.host, self.ssh_key, &cmd).is_ok() {
+            self.remote_timer_unit = Some(unit);
+        }
+    }
+
+    fn cancel_remote_failsafe(&mut self) {
+        if let Some(ref unit) = self.remote_timer_unit.take() {
+            let cmd = format!(
+                "systemctl stop {}.timer 2>/dev/null; systemctl reset-failed {}.timer 2>/dev/null",
+                unit, unit
+            );
+            let _ = remote_ssh_command(self.host, self.ssh_key, &cmd);
+        }
+    }
+
     fn restart_all(&mut self) -> Vec<String> {
         self.services
             .iter()
@@ -1672,6 +1696,7 @@ impl<'a> ServiceGuard<'a> {
 
     fn disarm(&mut self) {
         self.armed = false;
+        self.cancel_remote_failsafe();
     }
 }
 
@@ -1681,6 +1706,7 @@ impl Drop for ServiceGuard<'_> {
             for service in &self.services {
                 let _ = remote_systemctl(self.host, self.ssh_key, "start", service);
             }
+            self.cancel_remote_failsafe();
         }
     }
 }
@@ -1715,6 +1741,7 @@ fn backup_app(
                 return Err(e);
             }
         }
+        guard.schedule_remote_failsafe(config.name);
     }
 
     if let Some(db) = &config.db {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1786,7 +1786,9 @@ fn backup_app(
     let start_failures = if !config.systemd_services.is_empty() {
         pb.set_message(format!("Backing up {} (starting services)", config.name));
         let failures = guard.restart_all();
-        guard.disarm();
+        if failures.is_empty() {
+            guard.disarm();
+        }
         failures
     } else {
         guard.disarm();


### PR DESCRIPTION
## Summary
- Add `ServiceGuard` RAII struct that automatically restarts stopped services on `Drop` (covers panics, early error returns)
- Add remote systemd transient timer (dead-man switch) that restarts services after 30 minutes if the local CLI process dies (covers SIGKILL, OOM, network drops)
- Refactor `backup_app()` to use `ServiceGuard` instead of manual `stopped_services` tracking

## Context
During a backup run, paperless-ngx services were stopped for rsync but the CLI process died mid-transfer (likely network timeout on large media directory). Since there was no failsafe, the 4 paperless services stayed dead until manually restarted.

## Two-layer protection
1. **Rust Drop guard** — `ServiceGuard` tracks stopped services and restarts them in its `Drop` impl if not explicitly disarmed
2. **Remote systemd timer** — `sudo systemd-run --collect --on-active=30min` creates a transient timer that fires independently on the server, restarting services even if the local process is SIGKILL'd

## Test plan
- [x] `mise run test` — 163 tests pass (4 new ServiceGuard tests)
- [x] `mise run lint-rust` — no new warnings
- [x] `mise run lint-ansible` — clean
- [x] `mise run fmt` — clean
- [ ] Manual: run `auberge backup create --apps paperless`, kill process mid-rsync, verify services restart within 30 minutes via remote timer