### PR TITLE
feat: add Hermes Agent deployment role

### DIFF
--- a/ansible/playbooks/apps.yml
+++ b/ansible/playbooks/apps.yml
@@ -15,6 +15,8 @@
           - "{{ paperless_subdomain | default('paperless') }}.{{ domain }}"
     - role: grimmory
       tags: [apps, storage, media, books, grimmory]
+    - role: hermes
+      tags: [apps, ai, hermes]
     - role: cockpit
       tags: [apps, monitoring, cockpit]
       vars:

--- a/ansible/playbooks/hermes.yml
+++ b/ansible/playbooks/hermes.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy Hermes Agent - Personal AI Assistant
+  hosts: vps
+  become: true
+
+  roles:
+    - role: hermes
+      tags: [hermes]

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+hermes_version: "0.9.0"
+hermes_user: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
+hermes_group: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
+hermes_home: "/home/{{ hermes_user }}"
+hermes_config_dir: "{{ hermes_home }}/.hermes"
+
+hermes_model: "anthropic/claude-sonnet-4-6"
+hermes_model_provider: "openrouter"
+hermes_gateway_platform: "telegram"
+hermes_memory_mode: "local"
+hermes_extras: "messaging,cron"

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-hermes_version: "v0.9.0"
+hermes_version: "v2026.4.13"
 hermes_uv_version: "0.7.0"
 hermes_user: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_group: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -1,13 +1,15 @@
 ---
-hermes_version: "0.9.0"
+hermes_version: "v0.9.0"
 hermes_uv_version: "0.7.0"
 hermes_user: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_group: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_home: "/home/{{ hermes_user }}"
 hermes_config_dir: "{{ hermes_home }}/.hermes"
+hermes_install_dir: "{{ hermes_config_dir }}/hermes-agent"
+hermes_venv_dir: "{{ hermes_config_dir }}/venv"
 
 hermes_model: "anthropic/claude-sonnet-4-6"
 hermes_model_provider: "openrouter"
 hermes_gateway_platform: "telegram"
 hermes_memory_mode: "local"
-hermes_extras: "messaging,cron"
+hermes_extras: "all"

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 hermes_version: "0.9.0"
-hermes_uv_version: "0.7"
+hermes_uv_version: "0.7.0"
 hermes_user: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_group: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_home: "/home/{{ hermes_user }}"

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 hermes_version: "0.9.0"
+hermes_uv_version: "0.7"
 hermes_user: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_group: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_home: "/home/{{ hermes_user }}"

--- a/ansible/roles/hermes/handlers/main.yml
+++ b/ansible/roles/hermes/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Reload systemd user
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.systemd:
+    daemon_reload: true
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ hermes_user_uid.stdout }}"
+
+- name: Restart hermes gateway
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.systemd:
+    name: hermes-gateway
+    state: restarted
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ hermes_user_uid.stdout }}"

--- a/ansible/roles/hermes/handlers/main.yml
+++ b/ansible/roles/hermes/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Reload systemd user
+- name: Reload hermes systemd user
   become: true
   become_user: "{{ hermes_user }}"
   ansible.builtin.systemd:

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -182,7 +182,7 @@
     group: "{{ hermes_group }}"
     mode: "0644"
   notify:
-    - Reload systemd user
+    - Reload hermes systemd user
     - Restart hermes gateway
 
 - name: Enable and start Hermes gateway service

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -69,45 +69,60 @@
     state: absent
   when: hermes_uv_tmpdir.path is defined
 
-- name: Check installed hermes version
+- name: Clone hermes-agent repository
   become: true
   become_user: "{{ hermes_user }}"
-  ansible.builtin.command: "{{ hermes_home }}/.local/bin/hermes version"
-  register: hermes_version_check
-  changed_when: false
-  failed_when: false
+  ansible.builtin.git:
+    repo: https://github.com/NousResearch/hermes-agent.git
+    dest: "{{ hermes_install_dir }}"
+    version: "{{ hermes_version }}"
+    recursive: true
+    force: false
   environment:
     HOME: "{{ hermes_home }}"
+  register: hermes_git_result
 
-- name: Remove outdated hermes-agent
-  become: true
-  become_user: "{{ hermes_user }}"
-  ansible.builtin.command: "{{ hermes_home }}/.local/bin/uv tool uninstall hermes-agent"
-  when:
-    - hermes_version_check.rc == 0
-    - hermes_version not in hermes_version_check.stdout
-  changed_when: true
-  environment:
-    HOME: "{{ hermes_home }}"
-
-- name: Install hermes-agent {{ hermes_version }}
+- name: Create Python venv
   become: true
   become_user: "{{ hermes_user }}"
   ansible.builtin.command: >
-    {{ hermes_home }}/.local/bin/uv tool install
-    'hermes-agent[{{ hermes_extras }}]=={{ hermes_version }}'
-  when: hermes_version_check.rc != 0 or hermes_version not in hermes_version_check.stdout
-  changed_when: true
+    {{ hermes_home }}/.local/bin/uv venv {{ hermes_venv_dir }} --python 3.11
+  args:
+    creates: "{{ hermes_venv_dir }}/bin/python"
   environment:
     HOME: "{{ hermes_home }}"
 
-- name: Verify hermes binary in PATH
+- name: Install hermes-agent into venv
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.command: >
+    {{ hermes_home }}/.local/bin/uv pip install -e ".[{{ hermes_extras }}]"
+  args:
+    chdir: "{{ hermes_install_dir }}"
+  when: hermes_git_result.changed or not hermes_venv_dir ~ '/bin/hermes' is file
+  changed_when: true
+  environment:
+    HOME: "{{ hermes_home }}"
+    VIRTUAL_ENV: "{{ hermes_venv_dir }}"
+
+- name: Symlink hermes binary
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.file:
+    src: "{{ hermes_venv_dir }}/bin/hermes"
+    dest: "{{ hermes_home }}/.local/bin/hermes"
+    state: link
+    force: true
+
+- name: Verify hermes binary
   become: true
   become_user: "{{ hermes_user }}"
   ansible.builtin.command: "{{ hermes_home }}/.local/bin/hermes version"
   register: hermes_installed_version
   changed_when: false
   failed_when: hermes_installed_version.rc != 0
+  environment:
+    HOME: "{{ hermes_home }}"
 
 - name: Display hermes version
   ansible.builtin.debug:
@@ -188,6 +203,7 @@
       - "Hermes Agent Deployment Complete!"
       - "==================================="
       - "Config Dir: {{ hermes_config_dir }}"
+      - "Install Dir: {{ hermes_install_dir }}"
       - "Model: {{ hermes_model }}"
       - "Provider: {{ hermes_model_provider }}"
       - "Platform: {{ hermes_gateway_platform }}"

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -99,7 +99,7 @@
     {{ hermes_home }}/.local/bin/uv pip install -e ".[{{ hermes_extras }}]"
   args:
     chdir: "{{ hermes_install_dir }}"
-  when: hermes_git_result.changed or not hermes_venv_dir ~ '/bin/hermes' is file
+  when: hermes_git_result.changed or (hermes_venv_dir ~ '/bin/hermes') is not file
   changed_when: true
   environment:
     HOME: "{{ hermes_home }}"

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: Download uv install script
   ansible.builtin.get_url:
-    url: https://astral.sh/uv/install.sh
+    url: "https://astral.sh/uv/{{ hermes_uv_version }}/install.sh"
     dest: /tmp/uv-install.sh
     mode: "0755"
   when: hermes_uv_check.rc != 0
@@ -50,7 +50,7 @@
   environment:
     HOME: "{{ hermes_home }}"
 
-- name: Check if hermes is installed
+- name: Check installed hermes version
   become: true
   become_user: "{{ hermes_user }}"
   ansible.builtin.command: "{{ hermes_home }}/.local/bin/hermes version"
@@ -60,13 +60,24 @@
   environment:
     HOME: "{{ hermes_home }}"
 
-- name: Install hermes-agent
+- name: Remove outdated hermes-agent
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.command: "{{ hermes_home }}/.local/bin/uv tool uninstall hermes-agent"
+  when:
+    - hermes_version_check.rc == 0
+    - hermes_version not in hermes_version_check.stdout
+  changed_when: true
+  environment:
+    HOME: "{{ hermes_home }}"
+
+- name: Install hermes-agent {{ hermes_version }}
   become: true
   become_user: "{{ hermes_user }}"
   ansible.builtin.command: >
     {{ hermes_home }}/.local/bin/uv tool install
-    'hermes-agent[{{ hermes_extras }}]'
-  when: hermes_version_check.rc != 0
+    'hermes-agent[{{ hermes_extras }}]=={{ hermes_version }}'
+  when: hermes_version_check.rc != 0 or hermes_version not in hermes_version_check.stdout
   changed_when: true
   environment:
     HOME: "{{ hermes_home }}"
@@ -136,7 +147,9 @@
     owner: "{{ hermes_user }}"
     group: "{{ hermes_group }}"
     mode: "0644"
-  notify: Reload systemd user
+  notify:
+    - Reload systemd user
+    - Restart hermes gateway
 
 - name: Enable and start Hermes gateway service
   become: true

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -1,0 +1,171 @@
+---
+- name: Install system dependencies
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - git
+      - ripgrep
+      - ffmpeg
+    state: present
+
+- name: Get user UID
+  ansible.builtin.command: id -u {{ hermes_user }}
+  register: hermes_user_uid
+  changed_when: false
+
+- name: Check if linger is already enabled for user
+  ansible.builtin.stat:
+    path: "/var/lib/systemd/linger/{{ hermes_user }}"
+  register: hermes_linger_file
+
+- name: Enable linger for user
+  ansible.builtin.command: loginctl enable-linger {{ hermes_user }}
+  when: not hermes_linger_file.stat.exists
+  changed_when: true
+
+- name: Check if uv is installed
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.command: "{{ hermes_home }}/.local/bin/uv --version"
+  register: hermes_uv_check
+  changed_when: false
+  failed_when: false
+  environment:
+    HOME: "{{ hermes_home }}"
+
+- name: Download uv install script
+  ansible.builtin.get_url:
+    url: https://astral.sh/uv/install.sh
+    dest: /tmp/uv-install.sh
+    mode: "0755"
+  when: hermes_uv_check.rc != 0
+
+- name: Install uv package manager
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.command: /tmp/uv-install.sh
+  when: hermes_uv_check.rc != 0
+  changed_when: true
+  environment:
+    HOME: "{{ hermes_home }}"
+
+- name: Check if hermes is installed
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.command: "{{ hermes_home }}/.local/bin/hermes version"
+  register: hermes_version_check
+  changed_when: false
+  failed_when: false
+  environment:
+    HOME: "{{ hermes_home }}"
+
+- name: Install hermes-agent
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.command: >
+    {{ hermes_home }}/.local/bin/uv tool install
+    'hermes-agent[{{ hermes_extras }}]'
+  when: hermes_version_check.rc != 0
+  changed_when: true
+  environment:
+    HOME: "{{ hermes_home }}"
+
+- name: Verify hermes binary in PATH
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.command: "{{ hermes_home }}/.local/bin/hermes version"
+  register: hermes_installed_version
+  changed_when: false
+  failed_when: hermes_installed_version.rc != 0
+
+- name: Display hermes version
+  ansible.builtin.debug:
+    msg: "Hermes version: {{ hermes_installed_version.stdout }}"
+
+- name: Create systemd user directory
+  ansible.builtin.file:
+    path: "{{ hermes_home }}/.config/systemd/user"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0755"
+
+- name: Create Hermes config directory
+  ansible.builtin.file:
+    path: "{{ hermes_config_dir }}"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0750"
+
+- name: Validate required Hermes secrets
+  ansible.builtin.assert:
+    that:
+      - hermes_openrouter_api_key | default('') | length > 0
+      - hermes_telegram_bot_token | default('') | length > 0
+    fail_msg: |
+      Required Hermes secrets are not set or empty.
+      Set them with:
+        auberge config set hermes_openrouter_api_key <VALUE>
+        auberge config set hermes_telegram_bot_token <VALUE>
+
+- name: Deploy Hermes environment file
+  ansible.builtin.template:
+    src: env.j2
+    dest: "{{ hermes_config_dir }}/.env"
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0600"
+  no_log: true
+  notify: Restart hermes gateway
+
+- name: Deploy Hermes config
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ hermes_config_dir }}/config.yaml"
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0640"
+  notify: Restart hermes gateway
+
+- name: Deploy Hermes gateway systemd service
+  ansible.builtin.template:
+    src: hermes-gateway.service.j2
+    dest: "{{ hermes_home }}/.config/systemd/user/hermes-gateway.service"
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_group }}"
+    mode: "0644"
+  notify: Reload systemd user
+
+- name: Enable and start Hermes gateway service
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.systemd:
+    name: hermes-gateway
+    enabled: true
+    state: started
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ hermes_user_uid.stdout }}"
+
+- name: Display deployment summary
+  ansible.builtin.debug:
+    msg:
+      - "==================================="
+      - "Hermes Agent Deployment Complete!"
+      - "==================================="
+      - "Config Dir: {{ hermes_config_dir }}"
+      - "Model: {{ hermes_model }}"
+      - "Provider: {{ hermes_model_provider }}"
+      - "Platform: {{ hermes_gateway_platform }}"
+      - ""
+      - "Next steps:"
+      - "1. Check service: systemctl --user status hermes-gateway"
+      - "2. View logs: journalctl --user -u hermes-gateway -f"
+      - "3. SSH to VPS: ssh {{ hermes_user }}@{{ inventory_hostname }}"
+      - "4. Test: send a message to your Telegram bot"
+      - ""
+      - "Optional post-deploy (via SSH):"
+      - "  hermes claw migrate    # migrate OpenClaw data"
+      - "  hermes skills           # browse available skills"

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -34,21 +34,34 @@
   environment:
     HOME: "{{ hermes_home }}"
 
+- name: Create secure temp directory for uv installer
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: _uv_install
+  register: hermes_uv_tmpdir
+  when: hermes_uv_check.rc != 0
+
 - name: Download uv install script
   ansible.builtin.get_url:
     url: "https://astral.sh/uv/{{ hermes_uv_version }}/install.sh"
-    dest: /tmp/uv-install.sh
+    dest: "{{ hermes_uv_tmpdir.path }}/install.sh"
     mode: "0755"
   when: hermes_uv_check.rc != 0
 
 - name: Install uv package manager
   become: true
   become_user: "{{ hermes_user }}"
-  ansible.builtin.command: /tmp/uv-install.sh
+  ansible.builtin.command: "{{ hermes_uv_tmpdir.path }}/install.sh"
   when: hermes_uv_check.rc != 0
   changed_when: true
   environment:
     HOME: "{{ hermes_home }}"
+
+- name: Clean up uv installer
+  ansible.builtin.file:
+    path: "{{ hermes_uv_tmpdir.path }}"
+    state: absent
+  when: hermes_uv_tmpdir.path is defined
 
 - name: Check installed hermes version
   become: true

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -35,6 +35,8 @@
     HOME: "{{ hermes_home }}"
 
 - name: Create secure temp directory for uv installer
+  become: true
+  become_user: "{{ hermes_user }}"
   ansible.builtin.tempfile:
     state: directory
     suffix: _uv_install
@@ -42,6 +44,8 @@
   when: hermes_uv_check.rc != 0
 
 - name: Download uv install script
+  become: true
+  become_user: "{{ hermes_user }}"
   ansible.builtin.get_url:
     url: "https://astral.sh/uv/{{ hermes_uv_version }}/install.sh"
     dest: "{{ hermes_uv_tmpdir.path }}/install.sh"
@@ -58,6 +62,8 @@
     HOME: "{{ hermes_home }}"
 
 - name: Clean up uv installer
+  become: true
+  become_user: "{{ hermes_user }}"
   ansible.builtin.file:
     path: "{{ hermes_uv_tmpdir.path }}"
     state: absent

--- a/ansible/roles/hermes/templates/config.yaml.j2
+++ b/ansible/roles/hermes/templates/config.yaml.j2
@@ -1,0 +1,14 @@
+model:
+  default: {{ hermes_model }}
+  provider: {{ hermes_model_provider }}
+
+gateway:
+  platforms:
+    - {{ hermes_gateway_platform }}
+
+memory:
+  mode: {{ hermes_memory_mode }}
+
+terminal:
+  backend: local
+  timeout: 120

--- a/ansible/roles/hermes/templates/config.yaml.j2
+++ b/ansible/roles/hermes/templates/config.yaml.j2
@@ -1,13 +1,13 @@
 model:
-  default: {{ hermes_model }}
-  provider: {{ hermes_model_provider }}
+  default: "{{ hermes_model }}"
+  provider: "{{ hermes_model_provider }}"
 
 gateway:
   platforms:
-    - {{ hermes_gateway_platform }}
+    - "{{ hermes_gateway_platform }}"
 
 memory:
-  mode: {{ hermes_memory_mode }}
+  mode: "{{ hermes_memory_mode }}"
 
 terminal:
   backend: local

--- a/ansible/roles/hermes/templates/env.j2
+++ b/ansible/roles/hermes/templates/env.j2
@@ -1,0 +1,7 @@
+HOME={{ hermes_home }}
+TERM=xterm-256color
+OPENROUTER_API_KEY={{ hermes_openrouter_api_key | quote }}
+TELEGRAM_BOT_TOKEN={{ hermes_telegram_bot_token | quote }}
+{% if hermes_exa_api_key is defined and hermes_exa_api_key %}
+EXA_API_KEY={{ hermes_exa_api_key | quote }}
+{% endif %}

--- a/ansible/roles/hermes/templates/env.j2
+++ b/ansible/roles/hermes/templates/env.j2
@@ -1,4 +1,4 @@
-HOME={{ hermes_home }}
+HOME="{{ hermes_home }}"
 TERM=xterm-256color
 OPENROUTER_API_KEY={{ hermes_openrouter_api_key | quote }}
 TELEGRAM_BOT_TOKEN={{ hermes_telegram_bot_token | quote }}

--- a/ansible/roles/hermes/templates/hermes-gateway.service.j2
+++ b/ansible/roles/hermes/templates/hermes-gateway.service.j2
@@ -5,9 +5,10 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory={{ hermes_config_dir }}
-Environment="PATH={{ hermes_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="PATH={{ hermes_venv_dir }}/bin:{{ hermes_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="VIRTUAL_ENV={{ hermes_venv_dir }}"
 EnvironmentFile={{ hermes_config_dir }}/.env
-ExecStart={{ hermes_home }}/.local/bin/hermes gateway
+ExecStart={{ hermes_venv_dir }}/bin/hermes gateway
 Restart=always
 RestartSec=10
 

--- a/ansible/roles/hermes/templates/hermes-gateway.service.j2
+++ b/ansible/roles/hermes/templates/hermes-gateway.service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=Hermes Agent Gateway - Personal AI Assistant
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ hermes_config_dir }}
+Environment="PATH={{ hermes_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+EnvironmentFile={{ hermes_config_dir }}/.env
+ExecStart={{ hermes_home }}/.local/bin/hermes gateway
+Restart=always
+RestartSec=10
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/config.example.toml
+++ b/config.example.toml
@@ -32,6 +32,10 @@ headscale_subdomain = ""
 
 navidrome_subdomain = ""
 
+hermes_exa_api_key = ""
+hermes_openrouter_api_key = ""
+hermes_telegram_bot_token = ""
+
 openclaw_claude_ai_session_key = ""
 openclaw_claude_web_cookie = ""
 openclaw_claude_web_session_key = ""

--- a/docs/applications/apps/hermes.md
+++ b/docs/applications/apps/hermes.md
@@ -1,0 +1,202 @@
+# Hermes Agent Deployment
+
+Hermes Agent is a self-improving personal AI assistant by Nous Research. It connects to messaging platforms (Telegram, Discord, etc.) and learns from interactions via a closed learning loop.
+
+## Architecture
+
+```
+Your Phone (Telegram)
+    ↓ (outbound HTTPS polling)
+Your VPS (Hermes Gateway)
+    ↓ (outbound API calls)
+OpenRouter → Claude/GPT/etc
+```
+
+Unlike OpenClaw, Hermes gateway connects **outbound** to Telegram's API. No inbound port exposure needed.
+
+## Prerequisites
+
+1. **Bootstrap layer** must be run first (users, SSH, firewall)
+2. **Infrastructure layer** with Tailscale (for SSH access to VPS)
+3. **API keys** set in config (see Configuration below)
+
+## Configuration
+
+### Required Config Values
+
+```bash
+auberge config set hermes_openrouter_api_key <VALUE>
+auberge config set hermes_telegram_bot_token <VALUE>
+```
+
+### Optional Config Values
+
+```bash
+auberge config set hermes_exa_api_key <VALUE>
+```
+
+### Get API Keys
+
+**OpenRouter:**
+
+1. Sign up at https://openrouter.ai
+2. Go to https://openrouter.ai/keys
+3. Create API key and add credits
+
+**Telegram Bot:**
+
+1. Message @BotFather on Telegram
+2. Send `/newbot` and follow prompts
+3. Copy the bot token
+
+**Exa (optional, free tier):**
+
+1. Sign up at https://exa.ai
+2. Go to dashboard → API keys
+3. Copy API key (1,000 free searches/month)
+
+## Deployment
+
+### Deploy Hermes Only
+
+```bash
+auberge deploy hermes
+```
+
+### Deploy with Infrastructure
+
+```bash
+auberge deploy infrastructure hermes
+```
+
+### Check Mode (Dry Run)
+
+```bash
+auberge deploy hermes --check
+```
+
+## Post-Deployment Setup
+
+### 1. Verify Service
+
+```bash
+ssh user@your-vps
+systemctl --user status hermes-gateway
+```
+
+### 2. Test Telegram Bot
+
+Send a message to your bot on Telegram. It should respond.
+
+### 3. Migrate from OpenClaw (Optional)
+
+```bash
+ssh user@your-vps
+hermes claw migrate
+```
+
+This migrates SOUL.md, MEMORY.md, USER.md, and skills from OpenClaw.
+
+## Service Management
+
+### Check Status
+
+```bash
+systemctl --user status hermes-gateway
+```
+
+### View Logs
+
+```bash
+journalctl --user -u hermes-gateway -f
+```
+
+### Restart Service
+
+```bash
+systemctl --user restart hermes-gateway
+```
+
+### Stop Service
+
+```bash
+systemctl --user stop hermes-gateway
+```
+
+## Daily Usage
+
+Message your Telegram bot. Hermes:
+
+- Remembers context across sessions (SQLite FTS5)
+- Creates reusable skills from complex tasks
+- Supports slash commands (`/new`, `/model`, `/compress`, `/skills`)
+- Transcribes voice memos
+- Searches the web (with Exa API key)
+
+## Security
+
+- **No public ports**: Gateway polls Telegram outbound only
+- **Secrets**: Stored in `~/.hermes/.env` with mode `0600`
+- **Command approval**: Hermes prompts before running dangerous commands (133 patterns)
+- **Prompt injection scanning**: Detects hidden content and Unicode tricks
+
+## Troubleshooting
+
+### Service Won't Start
+
+```bash
+journalctl --user -u hermes-gateway -n 50
+```
+
+Check for:
+
+- Missing API keys (OpenRouter, Telegram)
+- Python/uv not installed
+- Network connectivity
+
+### Bot Not Responding
+
+```bash
+journalctl --user -u hermes-gateway -f
+```
+
+Check for:
+
+- Invalid Telegram bot token
+- OpenRouter API key out of credits
+- Rate limiting
+
+## Updates
+
+### Update via SSH
+
+```bash
+ssh user@your-vps
+~/.local/bin/uv tool upgrade hermes-agent
+systemctl --user restart hermes-gateway
+```
+
+### Update via Ansible
+
+```bash
+auberge deploy hermes
+```
+
+## Removal
+
+```bash
+ssh user@your-vps
+systemctl --user stop hermes-gateway
+systemctl --user disable hermes-gateway
+~/.local/bin/uv tool uninstall hermes-agent
+rm -rf ~/.hermes
+rm ~/.config/systemd/user/hermes-gateway.service
+systemctl --user daemon-reload
+```
+
+## References
+
+- [Hermes Agent Docs](https://hermes-agent.nousresearch.com/docs)
+- [GitHub](https://github.com/NousResearch/hermes-agent)
+- [OpenRouter](https://openrouter.ai)
+- [Telegram BotFather](https://t.me/BotFather)

--- a/docs/applications/apps/hermes.md
+++ b/docs/applications/apps/hermes.md
@@ -172,7 +172,9 @@ Check for:
 
 ```bash
 ssh user@your-vps
-~/.local/bin/uv tool upgrade hermes-agent
+cd ~/.hermes/hermes-agent
+git fetch && git checkout <new-tag>
+VIRTUAL_ENV=~/.hermes/venv uv pip install -e ".[all]"
 systemctl --user restart hermes-gateway
 ```
 
@@ -188,9 +190,9 @@ auberge deploy hermes
 ssh user@your-vps
 systemctl --user stop hermes-gateway
 systemctl --user disable hermes-gateway
-~/.local/bin/uv tool uninstall hermes-agent
 rm -rf ~/.hermes
-rm ~/.config/systemd/user/hermes-gateway.service
+rm -f ~/.local/bin/hermes
+rm -f ~/.config/systemd/user/hermes-gateway.service
 systemctl --user daemon-reload
 ```
 

--- a/docs/applications/overview.md
+++ b/docs/applications/overview.md
@@ -36,6 +36,12 @@ Auberge deploys a curated stack of self-hosted FOSS applications. All services r
 | [WebDAV](apps/webdav.md)           | File sharing and synchronization        |
 | [YOURLS](apps/yourls.md)           | URL shortener                           |
 
+## AI
+
+| Application                    | Description                          |
+| ------------------------------ | ------------------------------------ |
+| [Hermes Agent](apps/hermes.md) | Self-improving personal AI assistant |
+
 ## Deployment
 
 All applications are deployed via Ansible playbooks. See [Running Playbooks](../deployment/running-playbooks.md) for details.

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -90,6 +90,14 @@ pub fn required_config_keys(playbook_name: &str, tags: Option<&[String]>) -> Vec
         "apps.yml" => {
             keys.extend(["admin_user_name", "domain", "cloudflare_dns_api_token"]);
         }
+        "hermes.yml" => {
+            keys.extend([
+                "admin_user_name",
+                "domain",
+                "hermes_openrouter_api_key",
+                "hermes_telegram_bot_token",
+            ]);
+        }
         "openclaw.yml" => {
             keys.extend([
                 "admin_user_name",
@@ -302,6 +310,15 @@ mod tests {
     fn test_required_config_keys_hardening_is_empty() {
         let keys = required_config_keys("hardening.yml", None);
         assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn test_required_config_keys_hermes() {
+        let keys = required_config_keys("hermes.yml", None);
+        assert!(keys.contains(&"admin_user_name"));
+        assert!(keys.contains(&"domain"));
+        assert!(keys.contains(&"hermes_openrouter_api_key"));
+        assert!(keys.contains(&"hermes_telegram_bot_token"));
     }
 
     #[test]

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -72,6 +72,7 @@ fn write_inventory_file(host: &InventoryHost) -> Result<tempfile::NamedTempFile>
 fn tag_required_keys(tag: &str) -> &[&'static str] {
     match tag {
         "colporteur" => &["colporteur_subdomain"],
+        "hermes" => &["hermes_openrouter_api_key", "hermes_telegram_bot_token"],
         _ => &[],
     }
 }
@@ -290,6 +291,15 @@ mod tests {
         let keys = required_config_keys("apps.yml", Some(&tags));
         assert!(keys.contains(&"cloudflare_dns_api_token"));
         assert!(keys.contains(&"colporteur_subdomain"));
+    }
+
+    #[test]
+    fn test_required_config_keys_apps_with_hermes_tag() {
+        let tags = vec!["hermes".to_string()];
+        let keys = required_config_keys("apps.yml", Some(&tags));
+        assert!(keys.contains(&"cloudflare_dns_api_token"));
+        assert!(keys.contains(&"hermes_openrouter_api_key"));
+        assert!(keys.contains(&"hermes_telegram_bot_token"));
     }
 
     #[test]

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -43,6 +43,10 @@ headscale_subdomain = ""
 
 navidrome_subdomain = ""
 
+hermes_exa_api_key = ""
+hermes_openrouter_api_key = ""
+hermes_telegram_bot_token = ""
+
 openclaw_claude_ai_session_key = ""
 openclaw_claude_web_cookie = ""
 openclaw_claude_web_session_key = ""


### PR DESCRIPTION
## Summary

- Add new `hermes` Ansible role to deploy [Hermes Agent](https://hermes-agent.nousresearch.com) as a replacement for OpenClaw's stateless architecture
- Hermes provides persistent memory (SQLite FTS5), a closed learning loop (auto-created skills), and proper API key auth (OpenRouter) instead of browser session scraping
- Installs via `uv`, runs as systemd user service with Telegram gateway
- OpenClaw role kept in codebase (not removed)

### Changes
- **New role**: `ansible/roles/hermes/` (defaults, tasks, handlers, templates)
- **New playbook**: `ansible/playbooks/hermes.yml`
- **apps.yml**: added hermes role with `[apps, ai, hermes]` tags
- **Rust CLI**: added `hermes_openrouter_api_key`, `hermes_telegram_bot_token`, `hermes_exa_api_key` config keys + required key validation + test
- **Docs**: `docs/applications/apps/hermes.md` + AI section in overview

### Config keys
| Key | Required | Description |
|-----|----------|-------------|
| `hermes_openrouter_api_key` | Yes | OpenRouter API key |
| `hermes_telegram_bot_token` | Yes | Telegram bot token from @BotFather |
| `hermes_exa_api_key` | No | Exa web search (free tier: 1K/month) |

## Test plan
- [ ] `cargo test` passes (164 tests, including new `test_required_config_keys_hermes`)
- [ ] `ansible-lint` passes on all new YAML files
- [ ] Set config keys and run `auberge deploy hermes` against openclaw VPS
- [ ] Verify hermes-gateway systemd service starts and connects to Telegram
- [ ] Send test message to Telegram bot and confirm response
- [ ] Optionally run `hermes claw migrate` to carry over OpenClaw data