### PR TITLE
chore: release v0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6](https://github.com/sripwoud/auberge/compare/v0.8.5...v0.8.6) - 2026-04-14
+
+### Added
+
+- add Hermes Agent deployment role ([#235](https://github.com/sripwoud/auberge/pull/235))
+
 ## [0.8.5](https://github.com/sripwoud/auberge/compare/v0.8.4...v0.8.5) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.8.5 -> 0.8.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.6](https://github.com/sripwoud/auberge/compare/v0.8.5...v0.8.6) - 2026-04-14

### Added

- add Hermes Agent deployment role ([#235](https://github.com/sripwoud/auberge/pull/235))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).