### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sripwoud/auberge/compare/v0.8.6...v0.9.0) - 2026-04-15
+
+### Added
+
+- [**breaking**] remove openclaw feature ([#237](https://github.com/sripwoud/auberge/pull/237))
+
+### Other
+
+- add Hermes Agent to sidebar, READMEs, and fix 404
+
 ## [0.8.6](https://github.com/sripwoud/auberge/compare/v0.8.5...v0.8.6) - 2026-04-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.8.6 -> 0.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/sripwoud/auberge/compare/v0.8.6...v0.9.0) - 2026-04-15

### Added

- [**breaking**] remove openclaw feature ([#237](https://github.com/sripwoud/auberge/pull/237))

### Other

- add Hermes Agent to sidebar, READMEs, and fix 404
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).