### PR TITLE
feat(hermes): add --pull flag to `sync` command

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -27,10 +27,15 @@ pub enum SyncCommands {
         #[arg(
             short,
             long,
-            help = "Source config file [default: ~/.config/hermes/config.yaml]"
+            help = "Config file path: source when pushing, destination when pulling [default: ~/.config/hermes/config.yaml]"
         )]
         source: Option<PathBuf>,
-        #[arg(short = 'n', long, help = "Dry run (don't actually sync)")]
+        #[arg(
+            short = 'n',
+            long,
+            help = "Dry run (don't actually sync)",
+            conflicts_with = "pull"
+        )]
         dry_run: bool,
         #[arg(
             short = 'p',
@@ -166,6 +171,10 @@ pub fn run_sync_hermes(
             .ok_or_else(|| eyre::eyre!("No SSH key configured for host '{}'", xdg_host.name))?;
         if !ssh_key.exists() {
             eyre::bail!("SSH key not found: {}", ssh_key.display());
+        }
+        if let Some(parent) = local_dest.parent() {
+            std::fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("Failed to create directory: {}", parent.display()))?;
         }
         let session = SshSession::new(&xdg_host, &ssh_key);
         output::info(&format!(

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -32,6 +32,12 @@ pub enum SyncCommands {
         source: Option<PathBuf>,
         #[arg(short = 'n', long, help = "Dry run (don't actually sync)")]
         dry_run: bool,
+        #[arg(
+            short = 'p',
+            long,
+            help = "Pull config from remote to local instead of pushing"
+        )]
+        pull: bool,
     },
 }
 
@@ -129,6 +135,7 @@ pub fn run_sync_hermes(
     host_arg: Option<String>,
     source: Option<PathBuf>,
     dry_run: bool,
+    pull: bool,
 ) -> Result<()> {
     let xdg_host = match host_arg {
         Some(name) => HostManager::get_host(&name)?,
@@ -142,6 +149,33 @@ pub fn run_sync_hermes(
             .ok_or_else(|| eyre::eyre!("No host selected"))?
         }
     };
+
+    if pull {
+        let local_dest = match source {
+            Some(s) => s,
+            None => dirs::home_dir()
+                .map(|h| h.join(".config/hermes/config.yaml"))
+                .ok_or_else(|| {
+                    eyre::eyre!("Could not determine home directory for Hermes config")
+                })?,
+        };
+        let ssh_key = xdg_host
+            .ssh_key
+            .as_ref()
+            .map(PathBuf::from)
+            .ok_or_else(|| eyre::eyre!("No SSH key configured for host '{}'", xdg_host.name))?;
+        if !ssh_key.exists() {
+            eyre::bail!("SSH key not found: {}", ssh_key.display());
+        }
+        let session = SshSession::new(&xdg_host, &ssh_key);
+        output::info(&format!(
+            "Pulling hermes config from remote to {}",
+            local_dest.display()
+        ));
+        session.scp_from(".hermes/config.yaml", &local_dest)?;
+        output::success("Hermes config pulled");
+        return Ok(());
+    }
 
     let config_source = match source {
         Some(s) => s,

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,8 @@ async fn main() -> Result<()> {
                 host,
                 source,
                 dry_run,
-            } => run_sync_hermes(host, source, dry_run),
+                pull,
+            } => run_sync_hermes(host, source, dry_run, pull),
         },
         Commands::Dns(cmd) => match cmd {
             DnsCommands::List {


### PR DESCRIPTION
## Summary
Adds `--pull` / `-p` flag to `auberge sync hermes` to pull the remote config back to local.

## Why
After Hermes writes `thread_id`s back to `~/.hermes/config.yaml` on the VPS (e.g. after topic creation), pulling the config preserves those IDs so subsequent pushes don't trigger duplicate topic creation.

## Changes
- `src/commands/sync.rs`: added `--pull` flag to `run_sync_hermes`
- `src/main.rs`: wired up `pull` arg

## Usage
```bash
auberge sync hermes --pull -H openclaw   # pull remote config to local
auberge sync hermes -H openclaw          # push local config and restart
```