### PR TITLE
fix(hermes): add missing playwright chromium dependencies

### DIFF
--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -7,6 +7,8 @@
       - git
       - ripgrep
       - ffmpeg
+      - libnspr4
+      - libnss3
     state: present
 
 - name: Get user UID


### PR DESCRIPTION
## Summary
Adds `libnspr4` and `libnss3` system packages required by Playwright/Chromium for browser-based web search.

All other Chromium dependencies are already present on the system.