### PR TITLE
feat(hermes): add TELEGRAM_ALLOWED_USERS env var support

### DIFF
--- a/ansible/roles/hermes/templates/env.j2
+++ b/ansible/roles/hermes/templates/env.j2
@@ -2,6 +2,9 @@ HOME="{{ hermes_home }}"
 TERM=xterm-256color
 OPENROUTER_API_KEY={{ hermes_openrouter_api_key | quote }}
 TELEGRAM_BOT_TOKEN={{ hermes_telegram_bot_token | quote }}
+{% if hermes_telegram_allowed_users is defined and hermes_telegram_allowed_users %}
+TELEGRAM_ALLOWED_USERS={{ hermes_telegram_allowed_users | quote }}
+{% endif %}
 {% if hermes_exa_api_key is defined and hermes_exa_api_key %}
 EXA_API_KEY={{ hermes_exa_api_key | quote }}
 {% endif %}

--- a/config.example.toml
+++ b/config.example.toml
@@ -34,6 +34,7 @@ navidrome_subdomain = ""
 
 hermes_exa_api_key = ""
 hermes_openrouter_api_key = ""
+hermes_telegram_allowed_users = ""
 hermes_telegram_bot_token = ""
 
 paperless_admin_password = ""

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -66,6 +66,7 @@
     - [keygen](cli-reference/ssh/keygen.md)
     - [add-key](cli-reference/ssh/add-key.md)
   - Sync
+    - [hermes](cli-reference/sync/hermes.md)
     - [music](cli-reference/sync/music.md)
   - DNS
     - [list](cli-reference/dns/list.md)

--- a/docs/applications/apps/hermes.md
+++ b/docs/applications/apps/hermes.md
@@ -32,7 +32,10 @@ auberge config set hermes_telegram_bot_token <VALUE>
 
 ```bash
 auberge config set hermes_exa_api_key <VALUE>
+auberge config set hermes_telegram_allowed_users <YOUR_TELEGRAM_USER_ID>
 ```
+
+`hermes_telegram_allowed_users` restricts bot access to the specified Telegram user IDs (comma-separated). Without this, any Telegram user who knows the bot token can interact with it. Get your user ID by messaging @userinfobot on Telegram.
 
 ### Get API Keys
 
@@ -121,6 +124,7 @@ Message your Telegram bot. Hermes:
 
 - **No public ports**: Gateway polls Telegram outbound only
 - **Secrets**: Stored in `~/.hermes/.env` with mode `0600`
+- **User allowlist**: Set `hermes_telegram_allowed_users` to restrict bot access to specific Telegram user IDs
 - **Command approval**: Hermes prompts before running dangerous commands (133 patterns)
 - **Prompt injection scanning**: Detects hidden content and Unicode tricks
 

--- a/docs/cli-reference/sync/hermes.md
+++ b/docs/cli-reference/sync/hermes.md
@@ -1,0 +1,101 @@
+# auberge sync hermes
+
+Synchronize Hermes gateway config to remote host
+
+## Synopsis
+
+```bash
+auberge sync hermes [OPTIONS]
+```
+
+## Alias
+
+`auberge sy h`
+
+## Description
+
+Syncs `~/.config/hermes/config.yaml` to `~/.hermes/config.yaml` on the remote VPS and restarts `hermes-gateway`.
+
+Creates `~/.hermes/` on the remote if it does not already exist.
+
+Uses the SSH key configured for the target host in `~/.config/auberge/hosts.toml`.
+
+Pass `--pull` to reverse the direction: downloads the remote config to the local source path without restarting the service.
+
+## Options
+
+| Option            | Description                                                              | Default                      |
+| ----------------- | ------------------------------------------------------------------------ | ---------------------------- |
+| -H, --host HOST   | Target host                                                              | Interactive selection        |
+| -s, --source PATH | Config file path: source when pushing, destination when pulling          | ~/.config/hermes/config.yaml |
+| -n, --dry-run     | Preview without syncing (incompatible with --pull)                       | false                        |
+| -p, --pull        | Pull config from remote to local instead of pushing (no service restart) | false                        |
+
+## Examples
+
+```bash
+# Sync to remote (interactive host selection)
+auberge sync hermes
+
+# Sync to specific host
+auberge sync hermes --host myserver
+
+# Dry run to preview changes
+auberge sync hermes --host myserver --dry-run
+
+# Pull remote config down to local
+auberge sync hermes --host myserver --pull
+
+# Pull to a custom local path
+auberge sync hermes --host myserver --pull --source /tmp/hermes-config.yaml
+```
+
+## Sync Details
+
+**Direction (push, default)**: `~/.config/hermes/config.yaml` → `~/.hermes/config.yaml` on remote
+
+**Direction (pull)**: `~/.hermes/config.yaml` on remote → `~/.config/hermes/config.yaml` locally
+
+After a push the remote `hermes-gateway` systemd user service is restarted automatically. Pull does not restart any service.
+
+## Prerequisites
+
+1. **SSH key configured** for the target host in `~/.config/auberge/hosts.toml`
+2. **Hermes deployed** on the remote host:
+   ```bash
+   auberge deploy hermes
+   ```
+3. **Local config exists** at the source path (push) or remote config exists (pull)
+
+## Troubleshooting
+
+**SSH key not found**:
+
+- Verify the host entry in `~/.config/auberge/hosts.toml` has the correct key path
+- Generate a key if needed:
+  ```bash
+  auberge ssh keygen --host myserver
+  ```
+
+**Remote directory missing**:
+
+- The command creates `~/.hermes/` automatically; if it still fails check remote disk space and user permissions
+
+**Service fails to restart after sync**:
+
+```bash
+ssh user@your-vps 'journalctl --user -u hermes-gateway -n 50'
+```
+
+**--dry-run with --pull**:
+
+- These flags are mutually exclusive; run without `--dry-run` when pulling
+
+## Related Commands
+
+- [auberge deploy hermes](../../applications/apps/hermes.md) - Deploy or update Hermes on the VPS
+- [auberge config set](../config/overview.md) - Set Hermes config values
+
+## See Also
+
+- [Hermes Agent](../../applications/apps/hermes.md)


### PR DESCRIPTION
## Summary
Restricts Hermes bot access to explicitly allowed Telegram user IDs via `TELEGRAM_ALLOWED_USERS`.

## Changes
- `ansible/roles/hermes/templates/env.j2`: conditionally inject `TELEGRAM_ALLOWED_USERS` when `hermes_telegram_allowed_users` is set
- `config.example.toml`: add `hermes_telegram_allowed_users` field

## Usage
```bash
auberge config set hermes_telegram_allowed_users <your_telegram_id>
auberge ansible run -H <host> -p hermes
```