### PR TITLE
feat(tgtg): add Too Good To Go telegram bot deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ After deployment, your VPS will be running:
 - **Infrastructure**: [Caddy](https://caddyserver.com) (reverse proxy), [fail2ban](https://github.com/fail2ban/fail2ban) (intrusion prevention), [UFW](https://launchpad.net/ufw) (firewall)
 - **Networking**: [Blocky](https://0xerr0r.github.io/blocky) (DNS + ad-blocking), [Headscale](https://headscale.net) (coordination server), [WireGuard](https://wireguard.com), [Tailscale](https://tailscale.com)
 - **Apps**: [Baikal](https://sabre.io/baikal) (calendar/contacts), [Bichon](https://github.com/rustmailer/bichon) (email archiving), [Grimmory](https://grimmory.org) (digital library), [Colporteur](https://github.com/sripwoud/colporteur) (newsletter-to-feed), [FreshRSS](https://freshrss.org) (RSS reader), [Navidrome](https://navidrome.org) (music), [Paperless-ngx](https://docs.paperless-ngx.com) (document management), [Syncthing](https://syncthing.net) (file sync), [WebDAV](https://github.com/hacdias/webdav) (file sharing), [YOURLS](https://yourls.org) (URL shortener)
+- **Notifications**: [TGTG Bot](https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot) (Too Good To Go availability alerts via Telegram)
 - **AI Agents**: [Hermes Agent](https://github.com/NousResearch/hermes-agent) (self-improving personal AI assistant via Telegram)
 
 ## Documentation

--- a/ansible/playbooks/apps.yml
+++ b/ansible/playbooks/apps.yml
@@ -31,6 +31,8 @@
       tags: [apps, storage, documents, paperless]
     - role: syncthing
       tags: [apps, sync, syncthing]
+    - role: tgtg
+      tags: [apps, notifications, tgtg]
     - role: webdav
       tags: [apps, storage, webdav]
     - role: wireguard

--- a/ansible/roles/tgtg/defaults/main.yml
+++ b/ansible/roles/tgtg/defaults/main.yml
@@ -8,5 +8,6 @@ tgtg_sys_group: tgtg
 tgtg_install_dir: /opt/tgtg
 tgtg_data_dir: /var/lib/tgtg
 tgtg_venv_dir: /opt/tgtg/.venv
+tgtg_python_dir: /opt/tgtg/.python
 
 tgtg_proxy: ""

--- a/ansible/roles/tgtg/defaults/main.yml
+++ b/ansible/roles/tgtg/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 tgtg_repo: "https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot.git"
-tgtg_version: "main"
+tgtg_version: "c8bfe46"
 tgtg_uv_version: "0.7.0"
 
 tgtg_sys_user: tgtg

--- a/ansible/roles/tgtg/defaults/main.yml
+++ b/ansible/roles/tgtg/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+tgtg_repo: "https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot.git"
+tgtg_version: "main"
+tgtg_uv_version: "0.7.0"
+
+tgtg_sys_user: tgtg
+tgtg_sys_group: tgtg
+tgtg_install_dir: /opt/tgtg
+tgtg_data_dir: /var/lib/tgtg
+tgtg_venv_dir: /opt/tgtg/.venv
+
+tgtg_proxy: ""

--- a/ansible/roles/tgtg/handlers/main.yml
+++ b/ansible/roles/tgtg/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart tgtg
+  ansible.builtin.systemd_service:
+    name: tgtg
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/tgtg/tasks/main.yml
+++ b/ansible/roles/tgtg/tasks/main.yml
@@ -61,6 +61,13 @@
     state: absent
   when: tgtg_uv_tmpdir.path is defined
 
+- name: Mark install directory as git safe
+  community.general.git_config:
+    name: safe.directory
+    value: "{{ tgtg_install_dir }}"
+    scope: global
+    add_mode: add
+
 - name: Clone TooGoodToGo-TelegramBot repository
   ansible.builtin.git:
     repo: "{{ tgtg_repo }}"

--- a/ansible/roles/tgtg/tasks/main.yml
+++ b/ansible/roles/tgtg/tasks/main.yml
@@ -81,6 +81,8 @@
   ansible.builtin.command: /usr/local/bin/uv venv {{ tgtg_venv_dir }} --python 3.11
   args:
     creates: "{{ tgtg_venv_dir }}/bin/python"
+  environment:
+    UV_PYTHON_INSTALL_DIR: "{{ tgtg_python_dir }}"
 
 - name: Install Python dependencies
   ansible.builtin.command: /usr/local/bin/uv pip install -r {{ tgtg_install_dir }}/requirements.txt
@@ -88,6 +90,7 @@
   changed_when: true
   environment:
     VIRTUAL_ENV: "{{ tgtg_venv_dir }}"
+    UV_PYTHON_INSTALL_DIR: "{{ tgtg_python_dir }}"
 
 - name: Set venv ownership
   ansible.builtin.file:

--- a/ansible/roles/tgtg/tasks/main.yml
+++ b/ansible/roles/tgtg/tasks/main.yml
@@ -1,0 +1,145 @@
+---
+- name: Create tgtg system group
+  ansible.builtin.group:
+    name: "{{ tgtg_sys_group }}"
+    system: true
+
+- name: Create tgtg system user
+  ansible.builtin.user:
+    name: "{{ tgtg_sys_user }}"
+    group: "{{ tgtg_sys_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ tgtg_data_dir }}"
+    create_home: false
+
+- name: Create data directory
+  ansible.builtin.file:
+    path: "{{ tgtg_data_dir }}"
+    state: directory
+    owner: "{{ tgtg_sys_user }}"
+    group: "{{ tgtg_sys_group }}"
+    mode: "0750"
+
+- name: Install system dependencies
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - git
+    state: present
+
+- name: Check if uv is installed
+  ansible.builtin.command: /usr/local/bin/uv --version
+  register: tgtg_uv_check
+  changed_when: false
+  failed_when: false
+
+- name: Create secure temp directory for uv installer
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: _uv_install
+  register: tgtg_uv_tmpdir
+  when: tgtg_uv_check.rc != 0
+
+- name: Download uv install script
+  ansible.builtin.get_url:
+    url: "https://astral.sh/uv/{{ tgtg_uv_version }}/install.sh"
+    dest: "{{ tgtg_uv_tmpdir.path }}/install.sh"
+    mode: "0755"
+  when: tgtg_uv_check.rc != 0
+
+- name: Install uv package manager
+  ansible.builtin.command: "{{ tgtg_uv_tmpdir.path }}/install.sh"
+  when: tgtg_uv_check.rc != 0
+  changed_when: true
+  environment:
+    UV_INSTALL_DIR: /usr/local/bin
+
+- name: Clean up uv installer
+  ansible.builtin.file:
+    path: "{{ tgtg_uv_tmpdir.path }}"
+    state: absent
+  when: tgtg_uv_tmpdir.path is defined
+
+- name: Clone TooGoodToGo-TelegramBot repository
+  ansible.builtin.git:
+    repo: "{{ tgtg_repo }}"
+    dest: "{{ tgtg_install_dir }}"
+    version: "{{ tgtg_version }}"
+    force: false
+  register: tgtg_git_result
+
+- name: Set install directory ownership
+  ansible.builtin.file:
+    path: "{{ tgtg_install_dir }}"
+    state: directory
+    owner: "{{ tgtg_sys_user }}"
+    group: "{{ tgtg_sys_group }}"
+    recurse: true
+
+- name: Create Python venv
+  ansible.builtin.command: /usr/local/bin/uv venv {{ tgtg_venv_dir }} --python 3.11
+  args:
+    creates: "{{ tgtg_venv_dir }}/bin/python"
+
+- name: Install Python dependencies
+  ansible.builtin.command: /usr/local/bin/uv pip install -r {{ tgtg_install_dir }}/requirements.txt
+  when: tgtg_git_result.changed or (tgtg_venv_dir ~ '/lib') is not directory
+  changed_when: true
+  environment:
+    VIRTUAL_ENV: "{{ tgtg_venv_dir }}"
+
+- name: Set venv ownership
+  ansible.builtin.file:
+    path: "{{ tgtg_venv_dir }}"
+    state: directory
+    owner: "{{ tgtg_sys_user }}"
+    group: "{{ tgtg_sys_group }}"
+    recurse: true
+
+- name: Validate required secrets
+  ansible.builtin.assert:
+    that:
+      - tgtg_telegram_bot_token | default('') | length > 0
+    fail_msg: |
+      Required TGTG secret is not set.
+      Set it with:
+        auberge config set tgtg_telegram_bot_token <VALUE>
+
+- name: Deploy config.ini
+  ansible.builtin.template:
+    src: config.ini.j2
+    dest: "{{ tgtg_data_dir }}/config.ini"
+    owner: "{{ tgtg_sys_user }}"
+    group: "{{ tgtg_sys_group }}"
+    mode: "0600"
+  no_log: true
+  notify: Restart tgtg
+
+- name: Deploy tgtg systemd service
+  ansible.builtin.template:
+    src: tgtg.service.j2
+    dest: /etc/systemd/system/tgtg.service
+    mode: "0644"
+  notify: Restart tgtg
+
+- name: Enable and start tgtg service
+  ansible.builtin.systemd_service:
+    name: tgtg
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Display deployment summary
+  ansible.builtin.debug:
+    msg:
+      - "==================================="
+      - "TooGoodToGo Bot Deployment Complete!"
+      - "==================================="
+      - "Install Dir: {{ tgtg_install_dir }}"
+      - "Data Dir: {{ tgtg_data_dir }}"
+      - ""
+      - "Next steps:"
+      - "1. Check service: systemctl status tgtg"
+      - "2. View logs: journalctl -u tgtg -f"
+      - "3. Message your Telegram bot with /start"

--- a/ansible/roles/tgtg/templates/config.ini.j2
+++ b/ansible/roles/tgtg/templates/config.ini.j2
@@ -1,0 +1,5 @@
+[Telegram]
+token = {{ tgtg_telegram_bot_token }}
+
+[TGTG]
+proxy = {{ tgtg_proxy | default('') }}

--- a/ansible/roles/tgtg/templates/tgtg.service.j2
+++ b/ansible/roles/tgtg/templates/tgtg.service.j2
@@ -1,0 +1,26 @@
+[Unit]
+Description=TooGoodToGo Telegram Bot
+After=network.target
+
+[Service]
+Type=simple
+User={{ tgtg_sys_user }}
+Group={{ tgtg_sys_group }}
+WorkingDirectory={{ tgtg_data_dir }}
+Environment="PATH={{ tgtg_venv_dir }}/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="VIRTUAL_ENV={{ tgtg_venv_dir }}"
+ExecStart={{ tgtg_venv_dir }}/bin/python {{ tgtg_install_dir }}/Telegram.py
+Restart=always
+RestartSec=10
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths={{ tgtg_data_dir }}
+ReadOnlyPaths={{ tgtg_install_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -107,6 +107,8 @@
     - [Syncthing](applications/apps/syncthing.md)
     - [YOURLS](applications/apps/yourls.md)
     - [Paperless-ngx](applications/apps/paperless.md)
+  - Notifications
+    - [TGTG Bot](applications/apps/tgtg.md)
   - AI Agent
     - [Hermes Agent](applications/apps/hermes.md)
 

--- a/docs/applications/apps/tgtg.md
+++ b/docs/applications/apps/tgtg.md
@@ -1,0 +1,167 @@
+# TGTG Bot Deployment
+
+TGTG Bot monitors Too Good To Go for available food bags and sends notifications via Telegram. It connects to the TGTG API and Telegram API outbound, requiring no inbound ports.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[Your Phone - Telegram] -->|outbound HTTPS polling| B[Your VPS - TGTG Bot]
+    B -->|outbound API calls| C[Too Good To Go API]
+```
+
+TGTG Bot connects **outbound** to both Telegram's API and the TGTG API. No inbound port exposure needed.
+
+## Prerequisites
+
+1. **Bootstrap layer** must be run first (users, SSH, firewall)
+2. **Telegram bot token** configured (see Configuration below)
+
+## Configuration
+
+### Required Config Values
+
+```bash
+auberge config set tgtg_telegram_bot_token <VALUE>
+```
+
+### Get Telegram Bot Token
+
+1. Message @BotFather on Telegram
+2. Send `/newbot` and follow prompts
+3. Copy the bot token
+
+## Deployment
+
+```bash
+auberge deploy tgtg
+```
+
+Dependency layers (hardening, infrastructure) are resolved and run automatically.
+
+### Check Mode (Dry Run)
+
+```bash
+auberge deploy tgtg --check
+```
+
+## Post-Deployment Setup
+
+### 1. Verify Service
+
+```bash
+ssh user@your-vps
+systemctl status tgtg
+```
+
+### 2. Log In to TGTG
+
+Message your bot on Telegram and use `/login email@example.com` to start the TGTG login flow.
+
+## Service Management
+
+### Check Status
+
+```bash
+systemctl status tgtg
+```
+
+### View Logs
+
+```bash
+journalctl -u tgtg -f
+```
+
+### Restart Service
+
+```bash
+systemctl restart tgtg
+```
+
+### Stop Service
+
+```bash
+systemctl stop tgtg
+```
+
+## Daily Usage
+
+Message your Telegram bot. Available commands:
+
+- `/start` or `/help` - Welcome message
+- `/login email@example.com` - Start TGTG login (sends PIN to email)
+- `/pin 12345` - Complete login with PIN
+- `/info` - Show currently available favorite bags
+- `/settings` - Configure notification preferences
+
+## Security
+
+- **No public ports**: Bot polls Telegram and TGTG APIs outbound only
+- **Dedicated system user**: Runs as `tgtg` user with nologin shell
+- **Systemd hardening**: NoNewPrivileges, PrivateTmp, ProtectSystem=strict
+- **Secrets**: Bot token stored in `config.ini` with mode `0600`
+
+## Data
+
+- **Persistent state**: `/var/lib/tgtg/` (login data, settings, item cache)
+- **Source code**: `/opt/tgtg/`
+
+## Troubleshooting
+
+### Service Won't Start
+
+```bash
+journalctl -u tgtg -n 50
+```
+
+Check for:
+
+- Missing Telegram bot token
+- Python/dependencies not installed
+- Network connectivity
+
+### Bot Not Responding
+
+```bash
+journalctl -u tgtg -f
+```
+
+Check for:
+
+- Invalid Telegram bot token
+- TGTG API rate limiting
+- Expired TGTG login session
+
+## Updates
+
+### Update via Ansible
+
+```bash
+auberge deploy tgtg
+```
+
+### Update via SSH
+
+```bash
+ssh user@your-vps
+sudo -u tgtg git -C /opt/tgtg pull
+sudo systemctl restart tgtg
+```
+
+## Removal
+
+```bash
+ssh user@your-vps
+sudo systemctl stop tgtg
+sudo systemctl disable tgtg
+sudo rm -f /etc/systemd/system/tgtg.service
+sudo systemctl daemon-reload
+sudo userdel tgtg
+sudo rm -rf /opt/tgtg /var/lib/tgtg
+```
+
+## References
+
+- [GitHub](https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot)
+- [Too Good To Go](https://www.toogoodtogo.com)
+- [Telegram BotFather](https://t.me/BotFather)

--- a/docs/applications/overview.md
+++ b/docs/applications/overview.md
@@ -36,6 +36,12 @@ Auberge deploys a curated stack of self-hosted FOSS applications. All services r
 | [WebDAV](apps/webdav.md)           | File sharing and synchronization        |
 | [YOURLS](apps/yourls.md)           | URL shortener                           |
 
+## Notifications
+
+| Application              | Description                               |
+| ------------------------ | ----------------------------------------- |
+| [TGTG Bot](apps/tgtg.md) | Too Good To Go availability notifications |
+
 ## AI
 
 | Application                    | Description                          |

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -71,6 +71,7 @@ fn tag_required_keys(tag: &str) -> &[&'static str] {
     match tag {
         "colporteur" => &["colporteur_subdomain"],
         "hermes" => &["hermes_openrouter_api_key", "hermes_telegram_bot_token"],
+        "tgtg" => &["tgtg_telegram_bot_token"],
         _ => &[],
     }
 }

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -294,6 +294,14 @@ mod tests {
     }
 
     #[test]
+    fn test_required_config_keys_apps_with_tgtg_tag() {
+        let tags = vec!["tgtg".to_string()];
+        let keys = required_config_keys("apps.yml", Some(&tags));
+        assert!(keys.contains(&"cloudflare_dns_api_token"));
+        assert!(keys.contains(&"tgtg_telegram_bot_token"));
+    }
+
+    #[test]
     fn test_required_config_keys_apps_with_unrelated_tag() {
         let tags = vec!["paperless".to_string()];
         let keys = required_config_keys("apps.yml", Some(&tags));

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -63,6 +63,8 @@ tailscale_api_key = ""
 tailscale_authkey = ""
 tailscale_login_server = ""
 
+tgtg_telegram_bot_token = ""
+
 webdav_password = ""
 webdav_subdomain = ""
 


### PR DESCRIPTION
## Summary

- Add `tgtg` ansible role deploying the [TooGoodToGo-TelegramBot](https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot) as a systemd service
- Dedicated `tgtg` system user with nologin shell and systemd hardening (NoNewPrivileges, ProtectSystem=strict)
- Polling-based bot (outbound only, no ports/Caddy/DNS needed)
- Register in CLI config validation (`tgtg_telegram_bot_token`)
- Add documentation page, sidebar, and overview entries

## Test plan

- [ ] `cargo test` passes (164 tests, verified locally)
- [ ] `auberge deploy tgtg --check` dry-run on target host
- [ ] `auberge deploy tgtg` full deploy, verify `systemctl status tgtg` is active
- [ ] Message bot on Telegram, confirm `/start` responds