### PR TITLE
fix: skip unresolvable config keys in flatten_for_ansible

### DIFF
--- a/src/commands/ansible.rs
+++ b/src/commands/ansible.rs
@@ -91,20 +91,7 @@ fn validate_config_for_playbook(
 ) -> Result<crate::user_config::UserConfig> {
     let config = crate::user_config::UserConfig::load()?;
     let required_keys = required_config_keys(playbook_name, tags);
-    let missing = config.validate_required(&required_keys);
-    if !missing.is_empty() {
-        output::error("Missing required config values:");
-        for key in &missing {
-            output::error(&format!(
-                "  '{}' is required. Run: auberge config set {} <VALUE>",
-                key, key
-            ));
-        }
-        eyre::bail!(
-            "{} required config value(s) missing in config.toml",
-            missing.len()
-        );
-    }
+    config.validate_required_resolved(&required_keys)?;
     Ok(config)
 }
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -106,20 +106,7 @@ fn validate_config_for_deploy(apps: &[String]) -> Result<UserConfig> {
         }
     }
 
-    let missing = config.validate_required(&all_keys);
-    if !missing.is_empty() {
-        output::error("Missing required config values:");
-        for key in &missing {
-            output::error(&format!(
-                "  '{}' is required. Run: auberge config set {} <VALUE>",
-                key, key
-            ));
-        }
-        eyre::bail!(
-            "{} required config value(s) missing in config.toml",
-            missing.len()
-        );
-    }
+    config.validate_required_resolved(&all_keys)?;
     Ok(config)
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -30,7 +30,6 @@ fn should_use_colors() -> bool {
     std::io::stderr().is_terminal()
 }
 
-const RED: &str = "\x1b[31m";
 const YELLOW: &str = "\x1b[33m";
 const GREEN: &str = "\x1b[32m";
 const CYAN: &str = "\x1b[36m";
@@ -42,14 +41,6 @@ pub fn success(msg: &str) {
         eprintln!("{}✓{} {}", GREEN, RESET, msg);
     } else {
         eprintln!("✓ {}", msg);
-    }
-}
-
-pub fn error(msg: &str) {
-    if should_use_colors() {
-        eprintln!("{}✗{} {}", RED, RESET, msg);
-    } else {
-        eprintln!("✗ {}", msg);
     }
 }
 

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -20,9 +20,7 @@ pub struct InventoryHost {
 
 fn write_extra_vars_file() -> Result<tempfile::NamedTempFile> {
     let config = UserConfig::load()?;
-    let flat = config
-        .flatten_for_ansible()
-        .wrap_err("Failed to resolve config values")?;
+    let flat = config.flatten_for_ansible();
     let yaml = serde_yaml::to_string(&flat).wrap_err("Failed to serialize config to YAML")?;
     let mut tmpfile = tempfile::NamedTempFile::new().wrap_err("Failed to create temp file")?;
     tmpfile

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -172,7 +172,7 @@ impl UserConfig {
             .collect()
     }
 
-    pub fn flatten_for_ansible(&self) -> Result<BTreeMap<String, String>> {
+    pub fn flatten_for_ansible(&self) -> BTreeMap<String, String> {
         flatten_toml(&self.table)
     }
 
@@ -232,21 +232,29 @@ fn resolve_value(v: &str) -> Result<String> {
     Ok(v.to_string())
 }
 
-fn flatten_toml(table: &toml::Table) -> Result<BTreeMap<String, String>> {
+fn flatten_toml(table: &toml::Table) -> BTreeMap<String, String> {
     let mut result = BTreeMap::new();
     for (key, value) in table {
         match value {
-            toml::Value::Table(inner) => result.extend(flatten_toml(inner)?),
+            toml::Value::Table(inner) => result.extend(flatten_toml(inner)),
             other => {
                 if let Some(s) = value_to_string(other) {
-                    let resolved = resolve_value(&s)
-                        .wrap_err_with(|| format!("Failed to resolve config key '{key}'"))?;
-                    result.insert(key.clone(), resolved);
+                    match resolve_value(&s) {
+                        Ok(resolved) => {
+                            result.insert(key.clone(), resolved);
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "Warning: skipping config key '{}' (resolution failed: {})",
+                                key, e
+                            );
+                        }
+                    }
                 }
             }
         }
     }
-    Ok(result)
+    result
 }
 
 #[cfg(test)]
@@ -279,7 +287,7 @@ mod tests {
             admin_user_name = "alice"
         "#;
         let table: toml::Table = toml::from_str(toml_str).unwrap();
-        let flat = flatten_toml(&table).unwrap();
+        let flat = flatten_toml(&table);
         assert_eq!(flat.get("domain").unwrap(), "example.com");
         assert_eq!(flat.get("ssh_port").unwrap(), "22022");
         assert_eq!(flat.get("admin_user_name").unwrap(), "alice");
@@ -468,7 +476,7 @@ mod tests {
             path: PathBuf::from("/tmp/fake"),
             table,
         };
-        let flat = config.flatten_for_ansible().unwrap();
+        let flat = config.flatten_for_ansible();
         assert_eq!(flat.get("domain").unwrap(), "example.com");
         assert_eq!(flat.get("ssh_port").unwrap(), "22022");
         assert_eq!(flat.get("baikal_admin_password").unwrap(), "secret");
@@ -583,7 +591,7 @@ mod tests {
             path: PathBuf::from("/tmp/fake"),
             table,
         };
-        let flat = config.flatten_for_ansible().unwrap();
+        let flat = config.flatten_for_ansible();
         assert_eq!(flat.get("domain").unwrap(), "example.com");
         assert_eq!(flat.get("baikal_admin_password").unwrap(), "cmdpassword");
     }
@@ -599,7 +607,24 @@ mod tests {
             path: PathBuf::from("/tmp/fake"),
             table,
         };
-        let flat = config.flatten_for_ansible().unwrap();
+        let flat = config.flatten_for_ansible();
         assert_eq!(flat.get("baikal_admin_password").unwrap(), "!literal");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_flatten_for_ansible_skips_failed_shell_commands() {
+        let toml_str = r#"
+            domain = "example.com"
+            broken_key = "!false"
+        "#;
+        let table: toml::Table = toml::from_str(toml_str).unwrap();
+        let config = UserConfig {
+            path: PathBuf::from("/tmp/fake"),
+            table,
+        };
+        let flat = config.flatten_for_ansible();
+        assert_eq!(flat.get("domain").unwrap(), "example.com");
+        assert!(flat.get("broken_key").is_none());
     }
 }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -172,6 +172,17 @@ impl UserConfig {
             .collect()
     }
 
+    pub fn validate_required_resolved(&self, keys: &[&str]) -> Result<()> {
+        let missing = self.validate_required(keys);
+        if !missing.is_empty() {
+            eyre::bail!("Missing required config values: {}", missing.join(", "));
+        }
+        for &key in keys {
+            self.get_resolved(key)?;
+        }
+        Ok(())
+    }
+
     pub fn flatten_for_ansible(&self) -> BTreeMap<String, String> {
         flatten_toml(&self.table)
     }
@@ -462,6 +473,58 @@ mod tests {
         };
         let missing = config.validate_required(&["domain", "admin_user_name"]);
         assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn test_validate_required_resolved_passes_when_all_set() {
+        let toml_str = r#"
+            domain = "example.com"
+            admin_user_name = "alice"
+        "#;
+        let table: toml::Table = toml::from_str(toml_str).unwrap();
+        let config = UserConfig {
+            path: PathBuf::from("/tmp/fake"),
+            table,
+        };
+        assert!(
+            config
+                .validate_required_resolved(&["domain", "admin_user_name"])
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_required_resolved_fails_on_missing_key() {
+        let toml_str = r#"
+            domain = "example.com"
+        "#;
+        let table: toml::Table = toml::from_str(toml_str).unwrap();
+        let config = UserConfig {
+            path: PathBuf::from("/tmp/fake"),
+            table,
+        };
+        let err = config
+            .validate_required_resolved(&["domain", "admin_user_name"])
+            .unwrap_err();
+        assert!(err.to_string().contains("admin_user_name"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_required_resolved_fails_on_broken_shell_command() {
+        let toml_str = r#"
+            domain = "example.com"
+            bot_token = "!false"
+        "#;
+        let table: toml::Table = toml::from_str(toml_str).unwrap();
+        let config = UserConfig {
+            path: PathBuf::from("/tmp/fake"),
+            table,
+        };
+        let err = config
+            .validate_required_resolved(&["domain", "bot_token"])
+            .unwrap_err();
+        assert!(err.to_string().contains("bot_token"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `flatten_toml()` eagerly resolved **all** config values (including `!`-prefixed shell commands) even when running playbooks that don't need them — a failing hermes token shell command would block unrelated deploys like hardening
- Added `validate_required_resolved()` that checks both presence **and** shell-command resolution for required keys upfront, scoped to the apps being deployed
- `flatten_for_ansible` now skips non-required keys that fail resolution (with a warning) instead of aborting
- Removed dead `output::error` + `RED` const (no callers left after the validation refactor)

## Test plan
- [x] All 168 tests pass including 3 new tests for `validate_required_resolved`
- [x] New `test_flatten_for_ansible_skips_failed_shell_commands` covers the tolerant path
- [x] Clippy clean (no new warnings)
- [ ] Manual: deploy non-hermes app with a broken hermes shell command in config.toml — should succeed with warning
- [ ] Manual: deploy hermes with a broken hermes shell command — should fail early with clear error