### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/sripwoud/auberge/compare/v0.9.1...v0.9.2) - 2026-04-22
+
+### Added
+
+- *(tgtg)* add Too Good To Go telegram bot deployment ([#245](https://github.com/sripwoud/auberge/pull/245))
+
+### Fixed
+
+- silence warnings for non-required config keys in flatten_for_ansible
+- skip unresolvable config keys in flatten_for_ansible ([#246](https://github.com/sripwoud/auberge/pull/246))
+
 ## [0.9.1](https://github.com/sripwoud/auberge/compare/v0.9.0...v0.9.1) - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.9.1 -> 0.9.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.2](https://github.com/sripwoud/auberge/compare/v0.9.1...v0.9.2) - 2026-04-22

### Added

- *(tgtg)* add Too Good To Go telegram bot deployment ([#245](https://github.com/sripwoud/auberge/pull/245))

### Fixed

- silence warnings for non-required config keys in flatten_for_ansible
- skip unresolvable config keys in flatten_for_ansible ([#246](https://github.com/sripwoud/auberge/pull/246))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).