### PR TITLE
feat(hermes): make LLM provider configurable and compress context

### DIFF
--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -10,3 +10,12 @@ hermes_venv_dir: "{{ hermes_config_dir }}/venv"
 
 hermes_config_src: "~/.config/hermes/config.yaml"
 hermes_extras: "all"
+
+hermes_provider_env_vars:
+  anthropic: ANTHROPIC_API_KEY
+  deepseek: DEEPSEEK_API_KEY
+  gemini: GOOGLE_API_KEY
+  kimi: KIMI_API_KEY
+  openrouter: OPENROUTER_API_KEY
+  xai: XAI_API_KEY
+  zai: GLM_API_KEY

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -149,9 +149,9 @@
 - name: Validate required Hermes secrets
   ansible.builtin.assert:
     that:
-      - hermes_llm_provider | default('') | length > 0
-      - hermes_llm_provider in ['anthropic', 'deepseek', 'gemini', 'kimi', 'openrouter', 'xai', 'zai']
-      - hermes_llm_api_key | default('') | length > 0
+      - hermes_llm_provider | default('') | trim | length > 0
+      - hermes_llm_provider | trim | lower in hermes_provider_env_vars
+      - hermes_llm_api_key | default('') | trim | length > 0
       - hermes_telegram_bot_token | default('') | length > 0
     fail_msg: |
       Required Hermes secrets are not set or empty.

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -149,12 +149,15 @@
 - name: Validate required Hermes secrets
   ansible.builtin.assert:
     that:
-      - hermes_openrouter_api_key | default('') | length > 0
+      - hermes_llm_provider | default('') | length > 0
+      - hermes_llm_provider in ['anthropic', 'deepseek', 'gemini', 'kimi', 'openrouter', 'xai', 'zai']
+      - hermes_llm_api_key | default('') | length > 0
       - hermes_telegram_bot_token | default('') | length > 0
     fail_msg: |
       Required Hermes secrets are not set or empty.
       Set them with:
-        auberge config set hermes_openrouter_api_key <VALUE>
+        auberge config set hermes_llm_provider <anthropic|deepseek|gemini|kimi|openrouter|xai|zai>
+        auberge config set hermes_llm_api_key <VALUE>
         auberge config set hermes_telegram_bot_token <VALUE>
 
 - name: Deploy Hermes environment file

--- a/ansible/roles/hermes/templates/env.j2
+++ b/ansible/roles/hermes/templates/env.j2
@@ -1,6 +1,15 @@
 HOME="{{ hermes_home }}"
 TERM=xterm-256color
-OPENROUTER_API_KEY={{ hermes_openrouter_api_key | quote }}
+{% set provider_env_vars = {
+  'anthropic': 'ANTHROPIC_API_KEY',
+  'deepseek': 'DEEPSEEK_API_KEY',
+  'gemini': 'GOOGLE_API_KEY',
+  'kimi': 'KIMI_API_KEY',
+  'openrouter': 'OPENROUTER_API_KEY',
+  'xai': 'XAI_API_KEY',
+  'zai': 'GLM_API_KEY',
+} %}
+{{ provider_env_vars[hermes_llm_provider] }}={{ hermes_llm_api_key | quote }}
 TELEGRAM_BOT_TOKEN={{ hermes_telegram_bot_token | quote }}
 {% if hermes_telegram_allowed_users is defined and hermes_telegram_allowed_users %}
 TELEGRAM_ALLOWED_USERS={{ hermes_telegram_allowed_users | quote }}

--- a/ansible/roles/hermes/templates/env.j2
+++ b/ansible/roles/hermes/templates/env.j2
@@ -1,15 +1,6 @@
 HOME="{{ hermes_home }}"
 TERM=xterm-256color
-{% set provider_env_vars = {
-  'anthropic': 'ANTHROPIC_API_KEY',
-  'deepseek': 'DEEPSEEK_API_KEY',
-  'gemini': 'GOOGLE_API_KEY',
-  'kimi': 'KIMI_API_KEY',
-  'openrouter': 'OPENROUTER_API_KEY',
-  'xai': 'XAI_API_KEY',
-  'zai': 'GLM_API_KEY',
-} %}
-{{ provider_env_vars[hermes_llm_provider] }}={{ hermes_llm_api_key | quote }}
+{{ hermes_provider_env_vars[hermes_llm_provider | trim | lower] }}={{ hermes_llm_api_key | quote }}
 TELEGRAM_BOT_TOKEN={{ hermes_telegram_bot_token | quote }}
 {% if hermes_telegram_allowed_users is defined and hermes_telegram_allowed_users %}
 TELEGRAM_ALLOWED_USERS={{ hermes_telegram_allowed_users | quote }}

--- a/config.example.toml
+++ b/config.example.toml
@@ -33,7 +33,8 @@ headscale_subdomain = ""
 navidrome_subdomain = ""
 
 hermes_exa_api_key = ""
-hermes_openrouter_api_key = ""
+hermes_llm_api_key = ""
+hermes_llm_provider = ""
 hermes_telegram_allowed_users = ""
 hermes_telegram_bot_token = ""
 

--- a/docs/applications/apps/hermes.md
+++ b/docs/applications/apps/hermes.md
@@ -7,8 +7,8 @@ Hermes Agent is a self-improving personal AI assistant by Nous Research. It conn
 ```mermaid
 flowchart TD
     A[Your Phone - Telegram] -->|outbound HTTPS polling| B[Your VPS - Hermes Gateway]
-    B -->|outbound API calls| C[OpenRouter]
-    C --> D[Claude / GPT / etc]
+    B -->|outbound API calls| C[LLM Provider]
+    C --> D[Kimi / Claude / DeepSeek / etc]
 ```
 
 Hermes gateway connects **outbound** to Telegram's API. No inbound port exposure needed.
@@ -24,9 +24,22 @@ Hermes gateway connects **outbound** to Telegram's API. No inbound port exposure
 ### Required Config Values
 
 ```bash
-auberge config set hermes_openrouter_api_key <VALUE>
+auberge config set hermes_llm_provider <anthropic|deepseek|gemini|kimi|openrouter|xai|zai>
+auberge config set hermes_llm_api_key <VALUE>
 auberge config set hermes_telegram_bot_token <VALUE>
 ```
+
+Supported providers and their env var mapping:
+
+| Provider           | Slug         | API Key Platform                                       |
+| ------------------ | ------------ | ------------------------------------------------------ |
+| Anthropic          | `anthropic`  | [console.anthropic.com](https://console.anthropic.com) |
+| DeepSeek           | `deepseek`   | [platform.deepseek.com](https://platform.deepseek.com) |
+| Google Gemini      | `gemini`     | [aistudio.google.dev](https://aistudio.google.dev)     |
+| Kimi (Moonshot AI) | `kimi`       | [platform.moonshot.ai](https://platform.moonshot.ai)   |
+| OpenRouter         | `openrouter` | [openrouter.ai/keys](https://openrouter.ai/keys)       |
+| xAI (Grok)         | `xai`        | [console.x.ai](https://console.x.ai)                   |
+| Zhipu AI (GLM)     | `zai`        | [open.bigmodel.cn](https://open.bigmodel.cn)           |
 
 ### Optional Config Values
 
@@ -37,25 +50,9 @@ auberge config set hermes_telegram_allowed_users <YOUR_TELEGRAM_USER_ID>
 
 `hermes_telegram_allowed_users` restricts bot access to the specified Telegram user IDs (comma-separated). Without this, any Telegram user who knows the bot token can interact with it. Get your user ID by messaging @userinfobot on Telegram.
 
-### Get API Keys
+### Hermes Config
 
-**OpenRouter:**
-
-1. Sign up at https://openrouter.ai
-2. Go to https://openrouter.ai/keys
-3. Create API key and add credits
-
-**Telegram Bot:**
-
-1. Message @BotFather on Telegram
-2. Send `/newbot` and follow prompts
-3. Copy the bot token
-
-**Exa (optional, free tier):**
-
-1. Sign up at https://exa.ai
-2. Go to dashboard → API keys
-3. Copy API key (1,000 free searches/month)
+The LLM model and provider are configured in `~/.config/hermes/config.yaml`, which is synced to the VPS. The `hermes_llm_provider` in auberge config must match the provider set in `config.yaml`.
 
 ## Deployment
 
@@ -138,7 +135,7 @@ journalctl --user -u hermes-gateway -n 50
 
 Check for:
 
-- Missing API keys (OpenRouter, Telegram)
+- Missing API keys
 - Python/uv not installed
 - Network connectivity
 
@@ -151,7 +148,7 @@ journalctl --user -u hermes-gateway -f
 Check for:
 
 - Invalid Telegram bot token
-- OpenRouter API key out of credits
+- LLM API key out of credits or expired
 - Rate limiting
 
 ## Updates
@@ -188,5 +185,4 @@ systemctl --user daemon-reload
 
 - [Hermes Agent Docs](https://hermes-agent.nousresearch.com/docs)
 - [GitHub](https://github.com/NousResearch/hermes-agent)
-- [OpenRouter](https://openrouter.ai)
 - [Telegram BotFather](https://t.me/BotFather)

--- a/docs/applications/apps/hermes.md
+++ b/docs/applications/apps/hermes.md
@@ -29,17 +29,17 @@ auberge config set hermes_llm_api_key <VALUE>
 auberge config set hermes_telegram_bot_token <VALUE>
 ```
 
-Supported providers and their env var mapping:
+Supported providers:
 
-| Provider           | Slug         | API Key Platform                                       |
-| ------------------ | ------------ | ------------------------------------------------------ |
-| Anthropic          | `anthropic`  | [console.anthropic.com](https://console.anthropic.com) |
-| DeepSeek           | `deepseek`   | [platform.deepseek.com](https://platform.deepseek.com) |
-| Google Gemini      | `gemini`     | [aistudio.google.dev](https://aistudio.google.dev)     |
-| Kimi (Moonshot AI) | `kimi`       | [platform.moonshot.ai](https://platform.moonshot.ai)   |
-| OpenRouter         | `openrouter` | [openrouter.ai/keys](https://openrouter.ai/keys)       |
-| xAI (Grok)         | `xai`        | [console.x.ai](https://console.x.ai)                   |
-| Zhipu AI (GLM)     | `zai`        | [open.bigmodel.cn](https://open.bigmodel.cn)           |
+| Provider           | Slug         | Env Var              | API Key Platform                                       |
+| ------------------ | ------------ | -------------------- | ------------------------------------------------------ |
+| Anthropic          | `anthropic`  | `ANTHROPIC_API_KEY`  | [console.anthropic.com](https://console.anthropic.com) |
+| DeepSeek           | `deepseek`   | `DEEPSEEK_API_KEY`   | [platform.deepseek.com](https://platform.deepseek.com) |
+| Google Gemini      | `gemini`     | `GOOGLE_API_KEY`     | [aistudio.google.dev](https://aistudio.google.dev)     |
+| Kimi (Moonshot AI) | `kimi`       | `KIMI_API_KEY`       | [platform.moonshot.ai](https://platform.moonshot.ai)   |
+| OpenRouter         | `openrouter` | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys)       |
+| xAI (Grok)         | `xai`        | `XAI_API_KEY`        | [console.x.ai](https://console.x.ai)                   |
+| Zhipu AI (GLM)     | `zai`        | `GLM_API_KEY`        | [open.bigmodel.cn](https://open.bigmodel.cn)           |
 
 ### Optional Config Values
 

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -70,7 +70,11 @@ fn write_inventory_file(host: &InventoryHost) -> Result<tempfile::NamedTempFile>
 fn tag_required_keys(tag: &str) -> &[&'static str] {
     match tag {
         "colporteur" => &["colporteur_subdomain"],
-        "hermes" => &["hermes_openrouter_api_key", "hermes_telegram_bot_token"],
+        "hermes" => &[
+            "hermes_llm_provider",
+            "hermes_llm_api_key",
+            "hermes_telegram_bot_token",
+        ],
         "tgtg" => &["tgtg_telegram_bot_token"],
         _ => &[],
     }
@@ -94,7 +98,8 @@ pub fn required_config_keys(playbook_name: &str, tags: Option<&[String]>) -> Vec
             keys.extend([
                 "admin_user_name",
                 "domain",
-                "hermes_openrouter_api_key",
+                "hermes_llm_provider",
+                "hermes_llm_api_key",
                 "hermes_telegram_bot_token",
             ]);
         }
@@ -289,7 +294,8 @@ mod tests {
         let tags = vec!["hermes".to_string()];
         let keys = required_config_keys("apps.yml", Some(&tags));
         assert!(keys.contains(&"cloudflare_dns_api_token"));
-        assert!(keys.contains(&"hermes_openrouter_api_key"));
+        assert!(keys.contains(&"hermes_llm_provider"));
+        assert!(keys.contains(&"hermes_llm_api_key"));
         assert!(keys.contains(&"hermes_telegram_bot_token"));
     }
 
@@ -326,7 +332,8 @@ mod tests {
         let keys = required_config_keys("hermes.yml", None);
         assert!(keys.contains(&"admin_user_name"));
         assert!(keys.contains(&"domain"));
-        assert!(keys.contains(&"hermes_openrouter_api_key"));
+        assert!(keys.contains(&"hermes_llm_provider"));
+        assert!(keys.contains(&"hermes_llm_api_key"));
         assert!(keys.contains(&"hermes_telegram_bot_token"));
     }
 

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -44,7 +44,8 @@ headscale_subdomain = ""
 navidrome_subdomain = ""
 
 hermes_exa_api_key = ""
-hermes_openrouter_api_key = ""
+hermes_llm_api_key = ""
+hermes_llm_provider = ""
 hermes_telegram_bot_token = ""
 
 paperless_admin_password = ""


### PR DESCRIPTION
## Summary
- Replace hardcoded `hermes_openrouter_api_key` with generic `hermes_llm_provider` + `hermes_llm_api_key`
- Env template maps provider slug → correct env var (e.g. `kimi` → `KIMI_API_KEY`) via Jinja2 lookup
- Switching providers requires only `auberge config set` — no code changes
- Supported: anthropic, deepseek, gemini, kimi, openrouter, xai, zai
- Local Hermes config updated with context compression (threshold 0.35, target ratio 0.15, protect last 10 messages) and agent max_turns capped at 50 — addresses a 65:1 input:output token ratio caused by unbounded conversation context accumulation

## Motivation
OpenRouter charges a 5.5% platform fee. Direct provider APIs (Kimi, DeepSeek, etc.) offer equivalent or better quality at lower cost. This change lets the user pick their provider without touching infrastructure code.

Analysis of OpenRouter activity data showed ~$112/month on Sonnet with a 65:1 input:output token ratio — conversation context was growing unbounded without compression. Enabling compression is expected to reduce input tokens by 60-75%.

## Test plan
- [x] 169 unit tests passing (`cargo test`)
- [x] `cargo build` clean
- [x] Ansible lint passing
- [ ] Deploy with `auberge deploy hermes` after setting `hermes_llm_provider` and `hermes_llm_api_key`
- [ ] Verify compression reduces token consumption via Hermes `/usage` command after a few days