### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/sripwoud/auberge/compare/v0.9.2...v0.9.3) - 2026-04-23
+
+### Added
+
+- *(hermes)* make LLM provider configurable and compress context ([#248](https://github.com/sripwoud/auberge/pull/248))
+
+### Other
+
+- update README
+
 ## [0.9.2](https://github.com/sripwoud/auberge/compare/v0.9.1...v0.9.2) - 2026-04-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.9.2 -> 0.9.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.3](https://github.com/sripwoud/auberge/compare/v0.9.2...v0.9.3) - 2026-04-23

### Added

- *(hermes)* make LLM provider configurable and compress context ([#248](https://github.com/sripwoud/auberge/pull/248))

### Other

- update README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).