### PR TITLE
refactor(hermes): gate role on host membership in 'hermes' group

### DIFF
--- a/ansible/playbooks/apps.yml
+++ b/ansible/playbooks/apps.yml
@@ -17,6 +17,7 @@
       tags: [apps, storage, media, books, grimmory]
     - role: hermes
       tags: [apps, ai, hermes]
+      when: "'hermes' in group_names"
     - role: cockpit
       tags: [apps, monitoring, cockpit]
       vars:


### PR DESCRIPTION
## Summary

- Add `when: "'hermes' in group_names"` to the `hermes` role in `apps.yml` so it only runs on hosts explicitly tagged with `hermes`.
- Previously every host in the `vps` group got hermes installed (~880MB of agent + venv + skills + sqlite state) regardless of intent. This made it impossible to use a host for other workloads without also paying the hermes cost.

## Why

Discovered today that the `apps.yml` playbook had silently deployed hermes to two hosts (`auberge` and `openclaw`) — both running gateways concurrently against the same Telegram channels. After consolidating onto `openclaw`, this gate prevents future deploys from re-installing hermes on hosts that no longer want it.

## How to opt in

Per-host: add `"hermes"` to the host's `tags` in `~/.config/auberge/hosts.toml`. The auberge inventory generator (`src/services/inventory.rs:64`) maps `tags` to ansible group membership.

```toml
[[hosts]]
name = "openclaw"
tags = ["hermes"]
```

## Test plan

- [ ] `cd ansible && ansible-playbook -i inventory.yml playbooks/apps.yml --tags hermes --check` against an openclaw-tagged host → role runs (idempotent, no-op since already deployed)
- [ ] Same command against an untagged host (e.g. auberge) → role is **skipped** (visible in ansible output as `skipping: [auberge]`)
- [ ] Existing tag-based filtering (`--tags hermes`) still works for openclaw