### PR TITLE
chore: release v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4](https://github.com/sripwoud/auberge/compare/v0.9.3...v0.9.4) - 2026-04-27
+
+### Fixed
+
+- *(hermes)* gate role on host membership in 'hermes' group ([#254](https://github.com/sripwoud/auberge/pull/254))
+- *(tailscale)* run status probe in check mode
+
+### Other
+
+- *(release)* add workflow_dispatch and recover from silent tag skip ([#255](https://github.com/sripwoud/auberge/pull/255))
+
 ## [0.9.3](https://github.com/sripwoud/auberge/compare/v0.9.2...v0.9.3) - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.9.3 -> 0.9.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.4](https://github.com/sripwoud/auberge/compare/v0.9.3...v0.9.4) - 2026-04-27

### Fixed

- *(hermes)* gate role on host membership in 'hermes' group ([#254](https://github.com/sripwoud/auberge/pull/254))
- *(tailscale)* run status probe in check mode

### Other

- *(release)* add workflow_dispatch and recover from silent tag skip ([#255](https://github.com/sripwoud/auberge/pull/255))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).