### PR TITLE
fix(hermes): gate role on host membership in 'hermes' group

### DIFF
--- a/ansible/playbooks/apps.yml
+++ b/ansible/playbooks/apps.yml
@@ -17,6 +17,7 @@
       tags: [apps, storage, media, books, grimmory]
     - role: hermes
       tags: [apps, ai, hermes]
+      when: "'hermes' in group_names"
     - role: cockpit
       tags: [apps, monitoring, cockpit]
       vars:


### PR DESCRIPTION
## Summary

Re-introduces the `when: "'hermes' in group_names"` clause on the hermes role in `apps.yml`. The change was originally merged via PR #251 but its merge commit (`f1a6cad`) is no longer reachable from `master` — likely lost during a force-push or history rewrite around the v0.9.3 release.

Without this gate, the hermes role runs on every host in the `vps` group, forcing ~880MB of agent + venv + skills onto unrelated deployments.

To enable hermes on a host, add `hermes` to its tags in `hosts.toml` (mapped to ansible groups in `src/services/inventory.rs:64`).

## Test plan
- [ ] `cargo test` passes
- [ ] `AUBERGE_DEV=1 cargo run --release -- deploy --tags hermes --host <hermes-tagged-host> --check` runs the hermes role
- [ ] Same dry-run against a non-hermes-tagged host shows the role skipped