### PR TITLE
ci(release): add workflow_dispatch and recover from silent tag skip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   release-plz-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
     outputs:
       releases_created: ${{ steps.outputs.outputs.releases_created }}
       tag: ${{ steps.outputs.outputs.tag }}
@@ -50,16 +53,26 @@ jobs:
           version=$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)
           tag="v${version}"
           if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "Tag ${tag} already exists on remote; nothing to recover."
+            echo "Tag ${tag} already exists on remote; enabling downstream binary upload."
+            {
+              echo "tag_present=true"
+              echo "tag=${tag}"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "::warning::release-plz skipped tagging ${tag} (likely already published on crates.io). Creating tag now."
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${tag}" -m "${tag}"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${tag}"
+          head_sha=$(git rev-parse HEAD)
+          tag_sha=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/git/tags" \
+            -f tag="${tag}" \
+            -f message="${tag}" \
+            -f object="${head_sha}" \
+            -f type=commit \
+            --jq '.sha')
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${tag}" \
+            -f sha="${tag_sha}" >/dev/null
           {
-            echo "created=true"
+            echo "tag_present=true"
             echo "tag=${tag}"
           } >> "$GITHUB_OUTPUT"
 
@@ -68,7 +81,7 @@ jobs:
         env:
           RELEASES_CREATED: ${{ steps.release.outputs.releases_created }}
           RELEASES_JSON: ${{ steps.release.outputs.releases }}
-          RECOVERY_CREATED: ${{ steps.recovery.outputs.created }}
+          RECOVERY_TAG_PRESENT: ${{ steps.recovery.outputs.tag_present }}
           RECOVERY_TAG: ${{ steps.recovery.outputs.tag }}
         run: |
           set -euo pipefail
@@ -76,7 +89,7 @@ jobs:
             tag=$(echo "$RELEASES_JSON" | jq -r '.[0].tag')
             echo "releases_created=true" >> "$GITHUB_OUTPUT"
             echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          elif [[ "$RECOVERY_CREATED" == "true" ]]; then
+          elif [[ "$RECOVERY_TAG_PRESENT" == "true" ]]; then
             echo "releases_created=true" >> "$GITHUB_OUTPUT"
             echo "tag=${RECOVERY_TAG}" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
       contents: write
       pull-requests: read
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      tag: ${{ steps.get-tag.outputs.tag }}
+      releases_created: ${{ steps.outputs.outputs.releases_created }}
+      tag: ${{ steps.outputs.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,10 +35,53 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Get release tag
-        id: get-tag
-        if: steps.release.outputs.releases_created == 'true'
-        run: echo "tag=${{ fromJSON(steps.release.outputs.releases)[0].tag }}" >> "$GITHUB_OUTPUT"
+      - name: Recover skipped release tag
+        id: recovery
+        if: steps.release.outputs.releases_created != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          head_subject=$(git log -1 --pretty=%s)
+          if [[ ! "$head_subject" =~ ^chore:\ release\ v ]]; then
+            echo "HEAD ($head_subject) is not a release commit; nothing to recover."
+            exit 0
+          fi
+          version=$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)
+          tag="v${version}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag ${tag} already exists on remote; nothing to recover."
+            exit 0
+          fi
+          echo "::warning::release-plz skipped tagging ${tag} (likely already published on crates.io). Creating tag now."
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "${tag}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${tag}"
+          {
+            echo "created=true"
+            echo "tag=${tag}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve job outputs
+        id: outputs
+        env:
+          RELEASES_CREATED: ${{ steps.release.outputs.releases_created }}
+          RELEASES_JSON: ${{ steps.release.outputs.releases }}
+          RECOVERY_CREATED: ${{ steps.recovery.outputs.created }}
+          RECOVERY_TAG: ${{ steps.recovery.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASES_CREATED" == "true" ]]; then
+            tag=$(echo "$RELEASES_JSON" | jq -r '.[0].tag')
+            echo "releases_created=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          elif [[ "$RECOVERY_CREATED" == "true" ]]; then
+            echo "releases_created=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${RECOVERY_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "releases_created=false" >> "$GITHUB_OUTPUT"
+          fi
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
## Summary

Two improvements to `release.yml` aimed at preventing/recovering from a release-plz failure mode hit during the v0.9.3 release.

## Background

When release-plz's `release` step finds the crate version already on crates.io, it logs `INFO auberge X.Y.Z: already published` and exits successfully — but **silently skips creating the git tag**. Two downstream failures follow:

1. The next release PR's changelog regresses to *every commit since project inception* because release-plz can't find the previous version's tag as a boundary. (See PR #253 — 351 added lines re-listing already-released PRs.)
2. The `upload-binaries` job is gated on `releases_created` and never runs, so no GitHub release or binaries are produced. (v0.9.3 has no GH release.)

## Changes

- **`workflow_dispatch` trigger** — re-running the release workflow no longer requires an empty commit or close/reopen tricks.
- **Recovery step (`Recover skipped release tag`)** — runs only when release-plz reported no release AND `HEAD` is a `chore: release vX.Y.Z` commit. Reads the version from `Cargo.toml`, verifies the tag is missing on the remote, then creates and pushes it. Emits a workflow `::warning::` so the recovery is visible in the Actions UI.
- **Unified outputs step (`Resolve job outputs`)** — collapses release-plz's path and the recovery path into a single source of truth for `releases_created` / `tag`, so `upload-binaries` runs transparently in either case.

## Test plan

- [x] `actionlint .github/workflows/release.yml` — passes
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid
- [ ] Manually trigger via `workflow_dispatch` after merge to confirm the trigger works
- [ ] On next release: confirm the recovery step is a no-op when release-plz tags successfully (checks remote tag, exits early)

## Follow-up (not in this PR)

The missing `v0.9.3` tag still needs to be pushed manually to fix PR #253's changelog. After merging this PR, that fix is a one-liner:

```bash
git tag -a v0.9.3 d38cb8d -m v0.9.3 && git push origin v0.9.3
```

Then close PR #253 — release-plz will regenerate it cleanly on the next run (or via `workflow_dispatch` from this PR).