### PR TITLE
feat(backup): declarative Backup Recipe schema + RecipeExecutor + SshSession trait

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,75 @@
+# Auberge
+
+Self-hosted homelab provisioning: a Rust CLI that runs Ansible playbooks against user-owned hosts and backs up the apps it deploys.
+
+## Language
+
+**Playbook**:
+An Ansible playbook (`ansible/playbooks/<name>.yml`) that deploys exactly one app or one piece of infrastructure to a Host.
+_Avoid_: Role, recipe (Ansible-internal), task (Ansible-internal)
+
+**Playbook Meta**:
+A sibling YAML file (`ansible/playbooks/<name>.meta.yml`) declaring the Playbook's contract with auberge — its `required_keys` from the Key Registry and, optionally, a `backup` section holding a Backup Recipe.
+_Avoid_: Manifest, descriptor, schema
+
+**Key Registry**:
+A single file (`ansible/keys.yml`) listing every config key auberge knows about, with per-key metadata (secret, doc string). The vocabulary of `Config`.
+_Avoid_: Schema, dictionary, catalog
+
+**Config**:
+The merged user-supplied settings (`config.toml`) parsed against the Key Registry. There is no static `config.example.toml`; users run `auberge config init` to generate a starter file from the registry.
+_Avoid_: Settings, options, user config, env
+
+**Preflight**:
+A capability type carrying a validated `Config` + a Playbook Meta. The only way to construct one is via `Config::preflight_for(playbook)`, which validates required keys. `AnsibleRunner::run` accepts only a `Preflight`, making it impossible to invoke ansible with unvalidated config.
+_Avoid_: Plan, request, prepared run
+
+**Host**:
+A target machine in the Inventory (name, user, IP, SSH key). Playbooks run against one Host at a time.
+_Avoid_: Server, node, target, machine
+
+**Inventory**:
+The version-controlled list of Hosts in `ansible/inventory.yml`. (Distinct from `hosts.toml`, which is user-local and used only by backup operations — see ADR.)
+_Avoid_: Hostlist, fleet
+
+**App**:
+An application deployed by a Playbook (e.g. paperless, navidrome, baikal). An App has a Backup Recipe iff its Playbook Meta includes a `backup:` section.
+_Avoid_: Service, package, workload
+
+**Backup Recipe**:
+The declarative `backup:` section of a Playbook Meta describing how to back up the App: services to stop, paths to rsync, optional database dump, optional `post_restore_command`. Pure data — no imperative branching.
+_Avoid_: Backup config, backup plan, strategy
+
+**Recipe Executor**:
+The Rust module that executes one Backup Recipe against one Host: stop services → optional DB dump → rsync paths → optional DB restore → start services. Issues every command through the `SshSession` trait (the only test seam).
+_Avoid_: Backup runner, recipe runner
+
+**Backup Session**:
+The Rust module that orchestrates multiple Recipe Executor invocations across a Host's Apps, plus restic push and prune. Owns cross-recipe concerns; per-recipe semantics live in the Recipe Executor.
+_Avoid_: Backup job, backup workflow
+
+**Progress**:
+The trait that runners (`AnsibleRunner`, `Recipe Executor`, `Backup Session`) emit events through. `TerminalProgress` is the production impl; tests use a `MockProgress`. Keeps runners free of terminal-output coupling.
+_Avoid_: Logger, reporter
+
+## Relationships
+
+- A **Playbook** has exactly one **Playbook Meta** sibling.
+- A **Playbook Meta** declares zero or more keys from the **Key Registry**.
+- A **Playbook Meta** declares zero or one **Backup Recipe**.
+- A **Preflight** binds one **Playbook Meta** to a validated **Config**.
+- The **Recipe Executor** consumes one **Backup Recipe**; the **Backup Session** consumes many.
+- All runners report through **Progress**; none touch terminal output directly.
+
+## Example dialogue
+
+> **Maintainer:** "Paperless needs a new env var. Where do I add it?"
+> **Reviewer:** "Add it to the **Key Registry** with `secret: true` if it's sensitive, then list its name in `paperless.meta.yml` under `required_keys`. The next `auberge ansible run paperless` will fail-fast if the user hasn't set it."
+
+> **Maintainer:** "Why doesn't the **Recipe Executor** know about restic?"
+> **Reviewer:** "Restic push and prune are cross-recipe — they happen once per **Backup Session**, not once per **Backup Recipe**. The split is the whole reason those two modules exist."
+
+## Flagged ambiguities
+
+- "Backup runner" was used loosely for both per-recipe and multi-recipe execution. Resolved: use **Recipe Executor** (one recipe) and **Backup Session** (many recipes) — never "runner" without qualification.
+- "Spec" was used early in the design conversation for what became **Playbook Meta**. Resolved: avoid "spec" — it conflicts with Rust's `cargo spec` and reads ambiguous next to "schema."

--- a/ansible/playbooks/baikal.meta.yml
+++ b/ansible/playbooks/baikal.meta.yml
@@ -1,0 +1,4 @@
+required_keys: []
+backup:
+  paths: [/opt/baikal/Specific]
+  owner: [baikal, baikal]

--- a/ansible/playbooks/bichon.meta.yml
+++ b/ansible/playbooks/bichon.meta.yml
@@ -1,0 +1,5 @@
+required_keys: []
+backup:
+  systemd_services: [bichon]
+  paths: [/opt/bichon/data]
+  owner: [bichon, bichon]

--- a/ansible/playbooks/calibre.meta.yml
+++ b/ansible/playbooks/calibre.meta.yml
@@ -1,1 +1,5 @@
 required_keys: [admin_user_name, domain]
+backup:
+  systemd_services: [calibre]
+  paths: [/srv/calibre, /opt/calibre, /home/calibre]
+  owner: [calibre, calibre]

--- a/ansible/playbooks/freshrss.meta.yml
+++ b/ansible/playbooks/freshrss.meta.yml
@@ -1,0 +1,5 @@
+required_keys: []
+backup:
+  systemd_services: [freshrss]
+  paths: [/var/lib/freshrss, /opt/freshrss/data]
+  owner: [freshrss, freshrss]

--- a/ansible/playbooks/headscale.meta.yml
+++ b/ansible/playbooks/headscale.meta.yml
@@ -1,0 +1,5 @@
+required_keys: []
+backup:
+  systemd_services: [headscale]
+  paths: [/var/lib/headscale]
+  owner: [headscale, headscale]

--- a/ansible/playbooks/navidrome.meta.yml
+++ b/ansible/playbooks/navidrome.meta.yml
@@ -1,0 +1,9 @@
+required_keys: []
+backup:
+  systemd_services: [navidrome]
+  paths: [/var/lib/navidrome, /etc/navidrome]
+  owner: [navidrome, navidrome]
+  parameters:
+    include_music:
+      default: false
+      adds_paths: [/srv/music]

--- a/ansible/playbooks/paperless.meta.yml
+++ b/ansible/playbooks/paperless.meta.yml
@@ -1,0 +1,15 @@
+required_keys: []
+backup:
+  systemd_services:
+    - paperless-webserver
+    - paperless-consumer
+    - paperless-task-queue
+    - paperless-scheduler
+  paths:
+    - /opt/paperless/data
+    - /opt/paperless/media
+  owner: [paperless, paperless]
+  db:
+    name: paperless
+    dump_path: /tmp/paperless_db.dump
+  post_restore_command: "cd /opt/paperless/src && PAPERLESS_CONFIGURATION_PATH=/opt/paperless/paperless.conf sudo -u paperless /opt/paperless/src/venv/bin/python3 manage.py migrate --no-input"

--- a/ansible/playbooks/webdav.meta.yml
+++ b/ansible/playbooks/webdav.meta.yml
@@ -1,0 +1,3 @@
+required_keys: []
+backup:
+  paths: [/var/www/webdav-files]

--- a/ansible/playbooks/yourls.meta.yml
+++ b/ansible/playbooks/yourls.meta.yml
@@ -1,0 +1,4 @@
+required_keys: []
+backup:
+  paths: [/var/www/yourls]
+  owner: [www-data, www-data]

--- a/meta/adr.md
+++ b/meta/adr.md
@@ -1,6 +1,6 @@
 # Architecture Decisions
 
-Why Auberge is built the way it is.
+Why Auberge is built the way it is. This file is the curated overview of foundational decisions. Granular per-decision ADRs live in [`meta/adr/`](./adr/).
 
 ## No Docker
 

--- a/meta/adr/0001-declarative-backup-recipes.md
+++ b/meta/adr/0001-declarative-backup-recipes.md
@@ -1,0 +1,12 @@
+# Declarative YAML backup recipes, not a Rust trait
+
+A Backup Recipe is data — a `backup:` section in a Playbook Meta YAML file — interpreted by a generic Recipe Executor. It is not a `BackupRecipe` Rust trait with one impl per app.
+
+## Considered Options
+
+- **Rust trait `BackupRecipe` with one impl per app.** Rejected: the trait-elegance pull is real but misdirected. An audit of the existing 2,635-line `commands/backup.rs` found _zero_ conditional or parsed-output logic across all ~9 apps — every recipe is "stop services → optional DB dump → rsync paths → optional DB restore → start services." That's data, not behavior. The only app-specific quirk (paperless DB migration after restore) fits a `post_restore_command:` field. A trait would create N small files of stringified shell commands and brittle "did you call run() with this string" tests, while leaving the real bug surface (does the shell command work on the target?) to integration tests either way.
+- **Hybrid (declarative default + Rust escape hatch).** Rejected: starting with two ways to write a recipe means the declarative path never gets a fair try. If a future app genuinely needs imperative logic, the cost of adding an escape hatch _then_ is small.
+
+## Why this is non-obvious
+
+A Rust developer's reflex when seeing per-app variation is "extract a trait." This ADR records that the variation here is in _content_, not _shape_ — and that the audit was done. Future architecture reviews should not re-suggest the trait.

--- a/meta/adr/0002-no-god-runner-for-commands.md
+++ b/meta/adr/0002-no-god-runner-for-commands.md
@@ -1,0 +1,11 @@
+# Three small utilities, not a god-runner, for command orchestration
+
+Commands share a few interactive concerns (host selection, confirmation prompts, Ctrl-C handling), captured as three independent small utilities — `host::select_or_arg`, `prompt::confirm`, `signal::with_ctrlc` — not as a single `RunWithConfirmation` trait or builder that wraps the whole command lifecycle.
+
+## Considered Options
+
+- **`RunWithConfirmation` god-runner** (the original architecture-review suggestion). Rejected: the four command surfaces with overlapping shape — `ansible`, `headscale`, `dns`, `backup` — are _not_ the same shape underneath. Ansible runs playbooks via a subprocess; headscale wraps a remote CLI over SSH; dns calls the Cloudflare HTTP API; backup orchestrates Backup Recipes through a Backup Session. A single trait either has too few hooks (rigid) or too many optional fields (a builder with eight `Option`s, which is just scattered helpers wearing a coat). Forcing uniformity hides real differences.
+
+## Why this is non-obvious
+
+The "lift a shared command-runner" refactor is the textbook move and was suggested in the architecture review. This ADR records that the refactor was considered, that the commands' shapes were inspected, and that the deepening that actually earned its keep was three independent utilities — each passing the deletion test on its own — not a unifying abstraction. The most valuable of the three is `signal::with_ctrlc`, which fixes a known bug class (dangling progress bars on cancellation).

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -2,12 +2,17 @@ use crate::config::Config;
 use crate::hosts::{Host, select_or_arg as hosts_select_or_arg};
 use crate::output;
 use crate::prompt::confirm;
+use crate::services::backup::executor::RecipeExecutor;
+use crate::services::backup::recipe::{
+    assets_playbooks_dir, discover_backuppable_apps, load_app_recipe,
+};
+use crate::services::backup::ssh::LiveSshSession;
 use crate::ssh_session::SshSession;
 use chrono::Utc;
 use clap::Subcommand;
 use eyre::{Context, Result};
+use std::collections::HashMap;
 use std::fs;
-use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
@@ -189,20 +194,6 @@ pub enum OutputFormat {
     Yaml,
 }
 
-#[derive(Debug)]
-pub struct DbBackupConfig {
-    pub db_name: &'static str,
-    pub remote_dump_path: &'static str,
-}
-
-pub struct AppBackupConfig {
-    pub name: &'static str,
-    pub systemd_services: Vec<&'static str>,
-    pub paths: Vec<&'static str>,
-    pub owner: Option<(&'static str, &'static str)>,
-    pub db: Option<DbBackupConfig>,
-}
-
 #[derive(Debug, Clone)]
 pub struct CreateOutcome {
     pub successful_apps: Vec<String>,
@@ -221,139 +212,10 @@ pub struct RestoreOptions {
     pub skip_playbook_unsafe: bool,
 }
 
-impl AppBackupConfig {
-    pub fn all() -> Vec<Self> {
-        vec![
-            Self::baikal(),
-            Self::bichon(),
-            Self::freshrss(),
-            Self::headscale(),
-            Self::navidrome(false),
-            Self::calibre(),
-            Self::webdav(),
-            Self::yourls(),
-            Self::paperless(),
-        ]
-    }
-
-    pub fn by_name(name: &str, include_music: bool) -> Option<Self> {
-        match name {
-            "baikal" => Some(Self::baikal()),
-            "bichon" => Some(Self::bichon()),
-            "freshrss" => Some(Self::freshrss()),
-            "headscale" => Some(Self::headscale()),
-            "navidrome" => Some(Self::navidrome(include_music)),
-            "calibre" => Some(Self::calibre()),
-            "webdav" => Some(Self::webdav()),
-            "yourls" => Some(Self::yourls()),
-            "paperless" => Some(Self::paperless()),
-            _ => None,
-        }
-    }
-
-    fn baikal() -> Self {
-        Self {
-            name: "baikal",
-            systemd_services: vec![],
-            paths: vec!["/opt/baikal/Specific"],
-            owner: Some(("baikal", "baikal")),
-            db: None,
-        }
-    }
-
-    fn bichon() -> Self {
-        Self {
-            name: "bichon",
-            systemd_services: vec!["bichon"],
-            paths: vec!["/opt/bichon/data"],
-            owner: Some(("bichon", "bichon")),
-            db: None,
-        }
-    }
-
-    fn headscale() -> Self {
-        Self {
-            name: "headscale",
-            systemd_services: vec!["headscale"],
-            paths: vec!["/var/lib/headscale"],
-            owner: Some(("headscale", "headscale")),
-            db: None,
-        }
-    }
-
-    fn freshrss() -> Self {
-        Self {
-            name: "freshrss",
-            systemd_services: vec!["freshrss"],
-            paths: vec!["/var/lib/freshrss", "/opt/freshrss/data"],
-            owner: Some(("freshrss", "freshrss")),
-            db: None,
-        }
-    }
-
-    fn navidrome(include_music: bool) -> Self {
-        let mut paths = vec!["/var/lib/navidrome", "/etc/navidrome"];
-
-        if include_music {
-            paths.push("/srv/music");
-        }
-
-        Self {
-            name: "navidrome",
-            systemd_services: vec!["navidrome"],
-            paths,
-            owner: Some(("navidrome", "navidrome")),
-            db: None,
-        }
-    }
-
-    fn calibre() -> Self {
-        Self {
-            name: "calibre",
-            systemd_services: vec!["calibre"],
-            paths: vec!["/srv/calibre", "/opt/calibre", "/home/calibre"],
-            owner: Some(("calibre", "calibre")),
-            db: None,
-        }
-    }
-
-    fn webdav() -> Self {
-        Self {
-            name: "webdav",
-            systemd_services: vec![],
-            paths: vec!["/var/www/webdav-files"],
-            owner: None,
-            db: None,
-        }
-    }
-
-    fn yourls() -> Self {
-        Self {
-            name: "yourls",
-            systemd_services: vec![],
-            paths: vec!["/var/www/yourls"],
-            owner: Some(("www-data", "www-data")),
-            db: None,
-        }
-    }
-
-    fn paperless() -> Self {
-        Self {
-            name: "paperless",
-            systemd_services: vec![
-                "paperless-webserver",
-                "paperless-consumer",
-                "paperless-task-queue",
-                "paperless-scheduler",
-            ],
-            paths: vec!["/opt/paperless/data", "/opt/paperless/media"],
-            owner: Some(("paperless", "paperless")),
-            db: Some(DbBackupConfig {
-                db_name: "paperless",
-                remote_dump_path: "/tmp/paperless_db.dump",
-            }),
-        }
-    }
+fn parameter_map(include_music: bool) -> HashMap<String, bool> {
+    let mut params = HashMap::new();
+    params.insert("include_music".to_string(), include_music);
+    params
 }
 
 pub fn run_backup_create(
@@ -382,22 +244,24 @@ pub fn run_backup_create(
         eprintln!("Backing up {} → {}", host.name, short_dest);
     }
 
-    let app_configs = match apps {
-        Some(app_names) => app_names
-            .iter()
-            .filter_map(|name| AppBackupConfig::by_name(name, include_music))
+    let playbooks_dir = assets_playbooks_dir()?;
+    let app_names: Vec<String> = match apps {
+        Some(names) => names
+            .into_iter()
+            .filter(|name| load_app_recipe(&playbooks_dir, name).is_ok())
             .collect(),
-        None => AppBackupConfig::all(),
+        None => discover_backuppable_apps(&playbooks_dir)?,
     };
 
-    if app_configs.is_empty() {
+    if app_names.is_empty() {
         eyre::bail!("No valid apps specified for backup");
     }
 
     if output::is_verbose() {
-        let app_names: Vec<&str> = app_configs.iter().map(|c| c.name).collect();
         output::info(&format!("Apps: {}", app_names.join(", ")));
     }
+
+    let parameters = parameter_map(include_music);
 
     if dry_run {
         eprintln!("\n✓ Dry run completed (no changes made)");
@@ -411,12 +275,20 @@ pub fn run_backup_create(
     let timestamp = Utc::now().format("%Y-%m-%d_%H-%M-%S").to_string();
 
     let mut results = Vec::new();
-    for config in app_configs {
-        match backup_app(&host, &config, &backup_dest, &ssh_key_path, &timestamp) {
-            Ok(size) => results.push((config.name, true, Some(size), None)),
+    for app in &app_names {
+        match backup_app(
+            &host,
+            app,
+            &backup_dest,
+            &ssh_key_path,
+            &timestamp,
+            &parameters,
+            &playbooks_dir,
+        ) {
+            Ok(size) => results.push((app.clone(), true, Some(size), None)),
             Err(e) => {
-                eprintln!("✗ {} backup failed: {}", config.name, e);
-                results.push((config.name, false, None, Some(e.to_string())));
+                eprintln!("✗ {} backup failed: {}", app, e);
+                results.push((app.clone(), false, None, Some(e.to_string())));
             }
         }
     }
@@ -1095,10 +967,21 @@ pub fn run_backup_restore(opts: RestoreOptions) -> Result<()> {
     if is_cross_host {
         eprintln!("\n=== Post-Restore Actions Required ===");
         eprintln!("  Cross-host restore completed. Manual verification needed:\n");
-        let all_services: Vec<&str> = app_names
+        let cross_host_dir = assets_playbooks_dir().ok();
+        let recipes_for_apps: Vec<(String, Vec<String>)> = match &cross_host_dir {
+            Some(dir) => app_names
+                .iter()
+                .filter_map(|name| {
+                    load_app_recipe(dir, name)
+                        .ok()
+                        .map(|r| (name.clone(), r.systemd_services))
+                })
+                .collect(),
+            None => Vec::new(),
+        };
+        let all_services: Vec<&str> = recipes_for_apps
             .iter()
-            .filter_map(|name| AppBackupConfig::by_name(name, false))
-            .flat_map(|cfg| cfg.systemd_services)
+            .flat_map(|(_, services)| services.iter().map(String::as_str))
             .collect();
         if !all_services.is_empty() {
             eprintln!("  1. Verify services are running:");
@@ -1110,14 +993,12 @@ pub fn run_backup_restore(opts: RestoreOptions) -> Result<()> {
             );
         }
         eprintln!("\n  2. Check service logs for errors:");
-        for app_name in &app_names {
-            if let Some(cfg) = AppBackupConfig::by_name(app_name, false) {
-                for service in &cfg.systemd_services {
-                    eprintln!(
-                        "     ssh {}@{} 'journalctl -u {} --since \"5 minutes ago\" | grep -i error'",
-                        host.user, host.address, service
-                    );
-                }
+        for (_app_name, services) in &recipes_for_apps {
+            for service in services {
+                eprintln!(
+                    "     ssh {}@{} 'journalctl -u {} --since \"5 minutes ago\" | grep -i error'",
+                    host.user, host.address, service
+                );
             }
         }
         eprintln!("\n  3. Update DNS records if hostnames changed");
@@ -1146,186 +1027,18 @@ pub fn run_backup_restore(opts: RestoreOptions) -> Result<()> {
 fn restore_app(host: &Host, app_name: &str, backup_path: &Path, ssh_key: &Path) -> Result<()> {
     eprintln!("\n--- Restoring {} ---", app_name);
 
-    let config = AppBackupConfig::by_name(app_name, false)
-        .ok_or_else(|| eyre::eyre!("Unknown app: {}", app_name))?;
+    let playbooks_dir = assets_playbooks_dir()?;
+    let recipe = load_app_recipe(&playbooks_dir, app_name)
+        .wrap_err_with(|| format!("Unknown or non-backuppable app: {}", app_name))?;
 
-    let mut stopped_services: Vec<&str> = Vec::new();
-    for service in &config.systemd_services {
-        eprintln!("  Stopping service: {}", service);
-        if let Err(e) = remote_systemctl(host, ssh_key, "stop", service) {
-            for previously_stopped in &stopped_services {
-                let _ = remote_systemctl(host, ssh_key, "start", previously_stopped);
-            }
-            return Err(e).wrap_err_with(|| format!("Failed to stop service {}", service));
-        }
-        stopped_services.push(service);
-    }
-
+    let session = LiveSshSession::new(host, ssh_key);
+    let executor = RecipeExecutor::new(&session);
     let pb = output::progress_bar(&format!("Restoring {}", app_name), None);
-
-    let restore_result = (|| -> Result<()> {
-        for remote_path in &config.paths {
-            pb.set_message(format!("Restoring {} → {}", app_name, remote_path));
-            if !std::io::stderr().is_terminal() {
-                eprintln!("  Restoring to: {}", remote_path);
-            }
-            rsync_to_remote(host, ssh_key, backup_path, remote_path, &pb)?;
-        }
-
-        output::reset_to_spinner(&pb);
-
-        if let Some((user, group)) = config.owner {
-            eprintln!("  Setting ownership to {}:{}", user, group);
-            for remote_path in &config.paths {
-                set_remote_ownership(host, ssh_key, remote_path, user, group)?;
-            }
-        }
-
-        if let Some(db) = &config.db {
-            let local_dump = backup_path.join("db.dump");
-            if local_dump.exists() {
-                eprintln!("  Restoring database: {}", db.db_name);
-                scp_to_remote(host, ssh_key, &local_dump, db.remote_dump_path)?;
-                remote_ssh_command(host, ssh_key, &format!("chmod 644 {}", db.remote_dump_path))?;
-                let pg_result = remote_pg_restore(host, ssh_key, db);
-                remote_pg_dump_cleanup(host, ssh_key, db);
-                pg_result?;
-
-                if config.name == "paperless" {
-                    eprintln!("  Running database migrations");
-                    let migrate_cmd = "sudo -u paperless /opt/paperless/src/venv/bin/python3 manage.py migrate --no-input";
-                    let migrate_result = remote_ssh_command(
-                        host,
-                        ssh_key,
-                        &format!(
-                            "cd /opt/paperless/src && PAPERLESS_CONFIGURATION_PATH=/opt/paperless/paperless.conf {}",
-                            migrate_cmd
-                        ),
-                    );
-                    if let Err(e) = migrate_result {
-                        output::warn(&format!("Migration warning: {}", e));
-                    }
-                }
-            } else {
-                output::warn(&format!(
-                    "No database dump found at {}, skipping db restore",
-                    local_dump.display()
-                ));
-            }
-        }
-
-        Ok(())
-    })();
-
+    let result = executor.restore(&recipe, backup_path, &HashMap::new());
     pb.finish_and_clear();
-
-    let mut start_failures: Vec<String> = Vec::new();
-    for service in &config.systemd_services {
-        eprintln!("  Starting service: {}", service);
-        if let Err(e) = remote_systemctl(host, ssh_key, "start", service) {
-            start_failures.push(format!("{}: {}", service, e));
-        }
-    }
-
-    match restore_result {
-        Ok(()) => {
-            if !start_failures.is_empty() {
-                eyre::bail!(
-                    "Restore of {} succeeded but failed to restart services:\n  {}",
-                    app_name,
-                    start_failures.join("\n  ")
-                );
-            }
-        }
-        Err(e) => {
-            if !start_failures.is_empty() {
-                eyre::bail!(
-                    "Restore of {} failed: {}\nAdditionally, failed to restart services:\n  {}",
-                    app_name,
-                    e,
-                    start_failures.join("\n  ")
-                );
-            }
-            return Err(e);
-        }
-    }
+    result?;
 
     eprintln!("✓ {} restore completed", app_name);
-    Ok(())
-}
-
-fn rsync_to_remote(
-    host: &Host,
-    ssh_key: &Path,
-    local_path: &Path,
-    remote_path: &str,
-    pb: &indicatif::ProgressBar,
-) -> Result<()> {
-    pb.set_position(0);
-    pb.set_prefix(String::new());
-    let local_source = local_path.join(remote_path.trim_start_matches('/'));
-
-    if !local_source.exists() {
-        eprintln!("    (skipping {} - not in backup)", remote_path);
-        return Ok(());
-    }
-
-    let parent_dir = std::path::Path::new(remote_path)
-        .parent()
-        .ok_or_else(|| eyre::eyre!("Invalid remote path: {}", remote_path))?;
-
-    let session = SshSession::new(host, ssh_key);
-    let _ = output::run_piped(
-        "ssh",
-        Command::new("ssh")
-            .args(session.ssh_args())
-            .arg("sudo")
-            .arg("mkdir")
-            .arg("-p")
-            .arg(parent_dir),
-    );
-
-    let mut cmd = Command::new("stdbuf");
-    cmd.arg("-o0")
-        .arg("rsync")
-        .arg("-az")
-        .arg("--delete")
-        .arg("--info=progress2")
-        .arg("--rsync-path=sudo rsync");
-
-    for pattern in RSYNC_EXCLUDES {
-        cmd.arg(format!("--exclude={}", pattern));
-    }
-
-    cmd.arg("-e")
-        .arg(session.rsync_e_arg())
-        .arg(format!("{}/", local_source.display()))
-        .arg(format!("{}@{}:{}", host.user, host.address, remote_path));
-
-    let result = output::run_with_cr_stdout_progress("rsync", &mut cmd, pb, |line, pb| {
-        if let Some(p) = output::parse_rsync_progress(line) {
-            if pb.length().is_none() {
-                output::set_percent_style(pb);
-                pb.set_length(100);
-            }
-            pb.set_position(p.percent as u64);
-            pb.set_prefix(format!("{} ETA {}", p.speed, p.eta));
-        }
-    })
-    .wrap_err("Failed to execute rsync")?;
-
-    if !result.status.success() {
-        if result.last_stderr.is_empty() {
-            eyre::bail!("rsync failed for {}", remote_path);
-        } else {
-            eyre::bail!(
-                "rsync failed for {}: {}",
-                remote_path,
-                result.last_stderr.trim()
-            );
-        }
-    }
-
     Ok(())
 }
 
@@ -1683,108 +1396,18 @@ fn default_backup_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("~/.local/share/auberge/backups"))
 }
 
-struct ServiceGuard<'a> {
-    host: &'a Host,
-    ssh_key: &'a Path,
-    services: Vec<&'a str>,
-    remote_timer_unit: Option<String>,
-    armed: bool,
-}
-
-impl<'a> ServiceGuard<'a> {
-    fn new(host: &'a Host, ssh_key: &'a Path) -> Self {
-        Self {
-            host,
-            ssh_key,
-            services: Vec::new(),
-            remote_timer_unit: None,
-            armed: false,
-        }
-    }
-
-    fn stop_service(&mut self, service: &'a str) -> Result<()> {
-        if let Err(e) = remote_systemctl(self.host, self.ssh_key, "stop", service) {
-            for previously_stopped in &self.services {
-                let _ = remote_systemctl(self.host, self.ssh_key, "start", previously_stopped);
-            }
-            return Err(e).wrap_err_with(|| format!("Failed to stop service {}", service));
-        }
-        self.services.push(service);
-        self.armed = true;
-        Ok(())
-    }
-
-    fn schedule_remote_failsafe(&mut self, app_name: &str) {
-        let unit = format!("auberge-backup-failsafe-{}", app_name);
-        let services_arg = self.services.join(" ");
-        let cmd = format!(
-            "sudo systemd-run --collect --unit={} --on-active=30min /bin/bash -c 'systemctl start {}'",
-            unit, services_arg
-        );
-        match remote_ssh_command(self.host, self.ssh_key, &cmd) {
-            Ok(_) => {
-                self.remote_timer_unit = Some(unit);
-            }
-            Err(e) => {
-                output::warn(&format!(
-                    "Failed to arm remote failsafe timer '{}' on '{}': {}",
-                    unit, self.host.name, e
-                ));
-            }
-        }
-    }
-
-    fn cancel_remote_failsafe(&mut self) {
-        if let Some(ref unit) = self.remote_timer_unit.take() {
-            let cmd = format!(
-                "sudo systemctl stop {u}.timer {u}.service 2>/dev/null; \
-                 sudo systemctl reset-failed {u}.timer {u}.service 2>/dev/null",
-                u = unit
-            );
-            let _ = remote_ssh_command_unchecked(self.host, self.ssh_key, &cmd);
-        }
-    }
-
-    fn restart_all(&mut self) -> Vec<String> {
-        self.services
-            .iter()
-            .filter_map(|service| {
-                remote_systemctl(self.host, self.ssh_key, "start", service)
-                    .err()
-                    .map(|e| format!("{}: {}", service, e))
-            })
-            .collect()
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-        self.cancel_remote_failsafe();
-    }
-}
-
-impl Drop for ServiceGuard<'_> {
-    fn drop(&mut self) {
-        if self.armed && !self.services.is_empty() {
-            for service in &self.services {
-                let _ = remote_systemctl(self.host, self.ssh_key, "start", service);
-            }
-            self.cancel_remote_failsafe();
-        }
-    }
-}
-
 fn backup_app(
     host: &Host,
-    config: &AppBackupConfig,
+    app_name: &str,
     backup_dest: &Path,
     ssh_key: &Path,
     timestamp: &str,
+    parameters: &HashMap<String, bool>,
+    playbooks_dir: &Path,
 ) -> Result<u64> {
-    let pb = output::progress_bar(&format!("Backing up {}", config.name), None);
-    let app_backup_dir = backup_dest
-        .join(&host.name)
-        .join(timestamp)
-        .join(config.name);
+    let recipe = load_app_recipe(playbooks_dir, app_name)?;
+    let pb = output::progress_bar(&format!("Backing up {}", app_name), None);
+    let app_backup_dir = backup_dest.join(&host.name).join(timestamp).join(app_name);
 
     fs::create_dir_all(&app_backup_dir).wrap_err_with(|| {
         format!(
@@ -1793,106 +1416,26 @@ fn backup_app(
         )
     })?;
 
-    let result = (|| -> Result<u64> {
-        let mut guard = ServiceGuard::new(host, ssh_key);
+    let session = LiveSshSession::new(host, ssh_key);
+    let executor = RecipeExecutor::new(&session);
+    let exec_result = executor.backup(&recipe, &app_backup_dir, parameters);
 
-        if !config.systemd_services.is_empty() {
-            pb.set_message(format!("Backing up {} (stopping services)", config.name));
-            for service in &config.systemd_services {
-                if let Err(e) = guard.stop_service(service) {
-                    pb.finish_and_clear();
-                    return Err(e);
-                }
-            }
-            guard.schedule_remote_failsafe(config.name);
-        }
+    pb.finish_and_clear();
 
-        if let Some(db) = &config.db {
-            pb.set_message(format!("Backing up {} (dumping database)", config.name));
-            if let Err(e) = remote_pg_dump(host, ssh_key, db) {
-                remote_pg_dump_cleanup(host, ssh_key, db);
-                pb.finish_and_clear();
-                return Err(e).wrap_err("pg_dump failed");
-            }
-        }
-
-        pb.set_message(format!("Backing up {} (copying files)", config.name));
-        let rsync_result = (|| -> Result<()> {
-            for path in &config.paths {
-                rsync_from_remote(host, ssh_key, path, &app_backup_dir, &pb)?;
-            }
-            if let Some(db) = &config.db {
-                scp_from_remote(
-                    host,
-                    ssh_key,
-                    db.remote_dump_path,
-                    &app_backup_dir.join("db.dump"),
-                )?;
-            }
-            Ok(())
-        })();
-
-        if let Some(db) = &config.db {
-            remote_pg_dump_cleanup(host, ssh_key, db);
-        }
-
-        output::reset_to_spinner(&pb);
-        let start_failures = if !config.systemd_services.is_empty() {
-            pb.set_message(format!("Backing up {} (starting services)", config.name));
-            let failures = guard.restart_all();
-            if failures.is_empty() {
-                guard.disarm();
-            }
-            failures
-        } else {
-            guard.disarm();
-            Vec::new()
-        };
-
-        match rsync_result {
-            Ok(()) => {
-                if !start_failures.is_empty() {
-                    pb.finish_and_clear();
-                    eyre::bail!(
-                        "Backup of {} succeeded but failed to restart services:\n  {}",
-                        config.name,
-                        start_failures.join("\n  ")
-                    );
-                }
-            }
-            Err(e) => {
-                pb.finish_and_clear();
-                if !start_failures.is_empty() {
-                    eyre::bail!(
-                        "Backup of {} failed during file copy: {}\nAdditionally, failed to restart services:\n  {}",
-                        config.name,
-                        e,
-                        start_failures.join("\n  ")
-                    );
-                }
-                return Err(e);
-            }
-        }
-
-        let backup_size = calculate_dir_size(&app_backup_dir)?;
-
-        pb.finish_and_clear();
-        if !output::is_verbose() {
-            output::success(&format!(
-                "{} ({})",
-                config.name,
-                output::format_size(backup_size)
-            ));
-        }
-
-        Ok(backup_size)
-    })();
-
-    if result.is_err() {
+    if let Err(e) = exec_result {
         let _ = fs::remove_dir_all(&app_backup_dir);
+        return Err(e);
     }
 
-    result
+    let backup_size = calculate_dir_size(&app_backup_dir)?;
+    if !output::is_verbose() {
+        output::success(&format!(
+            "{} ({})",
+            app_name,
+            output::format_size(backup_size)
+        ));
+    }
+    Ok(backup_size)
 }
 
 fn resolve_ssh_key_path(host: &Host, override_key: Option<PathBuf>) -> Result<PathBuf> {
@@ -1957,181 +1500,6 @@ fn validate_key_file(key_path: &Path) -> Result<()> {
                 mode
             );
             eprintln!("  Consider running: chmod 600 {}", key_path.display());
-        }
-    }
-
-    Ok(())
-}
-
-fn remote_ssh_command(host: &Host, ssh_key: &Path, command: &str) -> Result<std::process::Output> {
-    let output = SshSession::new(host, ssh_key).run(command)?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        eyre::bail!("Remote command failed: {}", stderr.trim());
-    }
-
-    Ok(output)
-}
-
-fn remote_ssh_command_unchecked(
-    host: &Host,
-    ssh_key: &Path,
-    command: &str,
-) -> Result<std::process::Output> {
-    SshSession::new(host, ssh_key).run(command)
-}
-
-fn remote_pg_dump(host: &Host, ssh_key: &Path, db: &DbBackupConfig) -> Result<()> {
-    let cmd = format!(
-        "sudo -u postgres pg_dump -Fc {} > {}",
-        db.db_name, db.remote_dump_path
-    );
-    remote_ssh_command(host, ssh_key, &cmd)?;
-    Ok(())
-}
-
-fn remote_pg_dump_cleanup(host: &Host, ssh_key: &Path, db: &DbBackupConfig) {
-    let cmd = format!("rm -f {}", db.remote_dump_path);
-    let _ = remote_ssh_command(host, ssh_key, &cmd);
-}
-
-fn remote_pg_restore(host: &Host, ssh_key: &Path, db: &DbBackupConfig) -> Result<()> {
-    let cmd = format!(
-        "sudo -u postgres pg_restore --clean --if-exists -d {} {} 2>&1",
-        db.db_name, db.remote_dump_path
-    );
-    let output = remote_ssh_command_unchecked(host, ssh_key, &cmd)?;
-
-    if !output.status.success() {
-        let combined_output = String::from_utf8_lossy(&output.stdout);
-        let ssh_stderr = String::from_utf8_lossy(&output.stderr);
-
-        if !ssh_stderr.trim().is_empty() {
-            eyre::bail!("pg_restore SSH error: {}", ssh_stderr.trim());
-        }
-
-        if combined_output.trim().is_empty() {
-            eyre::bail!(
-                "pg_restore failed with exit code {}",
-                output.status.code().unwrap_or(-1)
-            );
-        }
-
-        let warnings_only = combined_output.lines().all(|line| {
-            let trimmed = line.trim().to_lowercase();
-            trimmed.is_empty()
-                || trimmed.contains("warning")
-                || trimmed.starts_with("pg_restore: warning")
-        });
-        if !warnings_only {
-            eyre::bail!("pg_restore failed: {}", combined_output.trim());
-        }
-    }
-
-    Ok(())
-}
-
-fn scp_from_remote(
-    host: &Host,
-    ssh_key: &Path,
-    remote_path: &str,
-    local_path: &Path,
-) -> Result<()> {
-    SshSession::new(host, ssh_key).scp_from(remote_path, local_path)
-}
-
-fn scp_to_remote(host: &Host, ssh_key: &Path, local_path: &Path, remote_path: &str) -> Result<()> {
-    SshSession::new(host, ssh_key).scp_to(local_path, remote_path)
-}
-
-fn remote_systemctl(host: &Host, ssh_key: &Path, action: &str, service: &str) -> Result<()> {
-    SshSession::new(host, ssh_key).systemctl(action, service)
-}
-
-fn set_remote_ownership(
-    host: &Host,
-    ssh_key: &Path,
-    remote_path: &str,
-    user: &str,
-    group: &str,
-) -> Result<()> {
-    let session = SshSession::new(host, ssh_key);
-    let result = output::run_piped(
-        "ssh",
-        Command::new("ssh")
-            .args(session.ssh_args())
-            .arg("sudo")
-            .arg("chown")
-            .arg("-R")
-            .arg(format!("{}:{}", user, group))
-            .arg(remote_path),
-    )
-    .wrap_err_with(|| {
-        format!(
-            "Failed to set ownership of {} to {}:{}",
-            remote_path, user, group
-        )
-    })?;
-    if result.status.success() {
-        output::clear_subprocess_lines(result.lines_written);
-    }
-
-    if !result.status.success() {
-        eyre::bail!("chown -R {}:{} {} failed", user, group, remote_path);
-    }
-
-    Ok(())
-}
-
-fn rsync_from_remote(
-    host: &Host,
-    ssh_key: &Path,
-    remote_path: &str,
-    local_dest: &Path,
-    pb: &indicatif::ProgressBar,
-) -> Result<()> {
-    pb.set_position(0);
-    pb.set_prefix(String::new());
-    let session = SshSession::new(host, ssh_key);
-    let mut cmd = Command::new("stdbuf");
-    cmd.arg("-o0")
-        .arg("rsync")
-        .arg("-az")
-        .arg("--relative")
-        .arg("--info=progress2")
-        .arg("--rsync-path=sudo rsync");
-
-    for pattern in RSYNC_EXCLUDES {
-        cmd.arg(format!("--exclude={}", pattern));
-    }
-
-    cmd.arg("-e")
-        .arg(session.rsync_e_arg())
-        .arg(format!("{}@{}:{}", host.user, host.address, remote_path))
-        .arg(local_dest);
-
-    let result = output::run_with_cr_stdout_progress("rsync", &mut cmd, pb, |line, pb| {
-        if let Some(p) = output::parse_rsync_progress(line) {
-            if pb.length().is_none() {
-                output::set_percent_style(pb);
-                pb.set_length(100);
-            }
-            pb.set_position(p.percent as u64);
-            pb.set_prefix(format!("{} ETA {}", p.speed, p.eta));
-        }
-    })
-    .wrap_err("Failed to execute rsync")?;
-
-    if !result.status.success() {
-        if result.last_stderr.is_empty() {
-            eyre::bail!("rsync failed for {}", remote_path);
-        } else {
-            eyre::bail!(
-                "rsync failed for {}: {}",
-                remote_path,
-                result.last_stderr.trim()
-            );
         }
     }
 
@@ -2204,25 +1572,30 @@ fn validate_cross_host_restore(
     }
 
     eprintln!("  Checking services on target...");
+    let playbooks_dir = assets_playbooks_dir().ok();
     for app in apps {
-        let config = AppBackupConfig::by_name(app, false);
-        if let Some(cfg) = config {
-            for service in &cfg.systemd_services {
-                match check_remote_service_exists(host, ssh_key, service) {
-                    Ok(true) => {
-                        eprintln!("    ✓ {} service exists", service);
-                    }
-                    Ok(false) => {
-                        eprintln!("    ⚠ {} service not found on target", service);
-                        eprintln!(
-                            "      Run 'auberge ansible run --host {}' to install services",
-                            host.name
-                        );
-                        eyre::bail!("Required service {} not found on target host", service);
-                    }
-                    Err(e) => {
-                        eprintln!("    ⚠ Failed to check {}: {}", service, e);
-                    }
+        let recipe = match playbooks_dir
+            .as_ref()
+            .and_then(|d| load_app_recipe(d, app).ok())
+        {
+            Some(r) => r,
+            None => continue,
+        };
+        for service in &recipe.systemd_services {
+            match check_remote_service_exists(host, ssh_key, service) {
+                Ok(true) => {
+                    eprintln!("    ✓ {} service exists", service);
+                }
+                Ok(false) => {
+                    eprintln!("    ⚠ {} service not found on target", service);
+                    eprintln!(
+                        "      Run 'auberge ansible run --host {}' to install services",
+                        host.name
+                    );
+                    eyre::bail!("Required service {} not found on target host", service);
+                }
+                Err(e) => {
+                    eprintln!("    ⚠ Failed to check {}: {}", service, e);
                 }
             }
         }
@@ -2262,33 +1635,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_paperless_has_db_config() {
-        let config = AppBackupConfig::paperless();
-        assert!(config.db.is_some());
-    }
-
-    #[test]
-    fn test_other_apps_have_no_db_config() {
-        assert!(AppBackupConfig::baikal().db.is_none());
-        assert!(AppBackupConfig::bichon().db.is_none());
-        assert!(AppBackupConfig::freshrss().db.is_none());
-        assert!(AppBackupConfig::headscale().db.is_none());
-        assert!(AppBackupConfig::navidrome(false).db.is_none());
-        assert!(AppBackupConfig::navidrome(true).db.is_none());
-        assert!(AppBackupConfig::calibre().db.is_none());
-        assert!(AppBackupConfig::webdav().db.is_none());
-        assert!(AppBackupConfig::yourls().db.is_none());
-    }
-
-    #[test]
-    fn test_db_backup_config_fields() {
-        let config = AppBackupConfig::paperless();
-        let db = config.db.unwrap();
-        assert_eq!(db.db_name, "paperless");
-        assert_eq!(db.remote_dump_path, "/tmp/paperless_db.dump");
-    }
-
-    #[test]
     fn test_push_variant_exists() {
         let _push = BackupCommands::Push {
             host: None,
@@ -2302,23 +1648,11 @@ mod tests {
     }
 
     #[test]
-    fn test_all_apps_count() {
-        let all = AppBackupConfig::all();
-        assert_eq!(all.len(), 9);
-    }
-
-    #[test]
-    fn test_by_name_unknown_returns_none() {
-        assert!(AppBackupConfig::by_name("nonexistent", false).is_none());
-    }
-
-    #[test]
-    fn test_navidrome_music_paths() {
-        let without = AppBackupConfig::navidrome(false);
-        assert!(!without.paths.contains(&"/srv/music"));
-
-        let with = AppBackupConfig::navidrome(true);
-        assert!(with.paths.contains(&"/srv/music"));
+    fn test_parameter_map_carries_include_music_flag() {
+        let p = parameter_map(true);
+        assert_eq!(p.get("include_music").copied(), Some(true));
+        let p = parameter_map(false);
+        assert_eq!(p.get("include_music").copied(), Some(false));
     }
 
     #[test]
@@ -2577,58 +1911,5 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn test_service_guard_tracks_stopped_services() {
-        let host = test_host();
-        let mut guard = ServiceGuard {
-            host: &host,
-            ssh_key: Path::new("/dev/null"),
-            services: Vec::new(),
-            remote_timer_unit: None,
-            armed: false,
-        };
-        guard.services.push("svc-a");
-        guard.services.push("svc-b");
-        assert_eq!(guard.services, vec!["svc-a", "svc-b"]);
-        assert!(!guard.armed);
-    }
-
-    #[test]
-    fn test_service_guard_disarm_prevents_restart() {
-        let host = test_host();
-        let mut guard = ServiceGuard {
-            host: &host,
-            ssh_key: Path::new("/dev/null"),
-            services: vec!["svc-a"],
-            remote_timer_unit: None,
-            armed: false,
-        };
-        assert!(!guard.armed);
-        guard.armed = false;
-        assert!(!guard.armed);
-    }
-
-    #[test]
-    fn test_service_guard_failsafe_timer_unit_name() {
-        let app_name = "paperless-ngx";
-        let unit = format!("auberge-backup-failsafe-{}", app_name);
-        assert_eq!(unit, "auberge-backup-failsafe-paperless-ngx");
-    }
-
-    #[test]
-    fn test_service_guard_empty_services_is_noop() {
-        let host = test_host();
-        let guard = ServiceGuard {
-            host: &host,
-            ssh_key: Path::new("/dev/null"),
-            services: Vec::new(),
-            remote_timer_unit: None,
-            armed: false,
-        };
-        assert!(guard.services.is_empty());
-        assert!(!guard.armed);
-        drop(guard);
     }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -18,26 +18,6 @@ use std::process::Command;
 use std::time::Instant;
 use tabled::Tabled;
 
-const RSYNC_EXCLUDES: &[&str] = &[
-    ".git",
-    ".git/",
-    "venv",
-    "venv/",
-    "node_modules",
-    "node_modules/",
-    "__pycache__",
-    "__pycache__/",
-    "*.pyc",
-    "*.pyo",
-    ".cache",
-    ".cache/",
-    ".Radicale.cache",
-    ".Radicale.cache/",
-    "*.tmp",
-    "*.log",
-    ".DS_Store",
-];
-
 #[derive(Subcommand)]
 pub enum BackupCommands {
     #[command(alias = "c", about = "Create backup of application data")]

--- a/src/models/playbook_meta.rs
+++ b/src/models/playbook_meta.rs
@@ -1,16 +1,63 @@
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
 
-/// Metadata for an Ansible playbook, loaded from a `<name>.meta.yml` sibling file.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlaybookMeta {
-    /// Configuration keys that must be present and non-empty before running this playbook.
+    #[serde(default)]
     pub required_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup: Option<BackupRecipe>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BackupRecipe {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub systemd_services: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<(String, String)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db: Option<DbRecipe>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_restore_command: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub parameters: HashMap<String, BackupParameter>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DbRecipe {
+    pub name: String,
+    pub dump_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BackupParameter {
+    #[serde(default)]
+    pub default: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub adds_paths: Vec<String>,
+}
+
+impl BackupRecipe {
+    pub fn effective_paths(&self, parameter_values: &HashMap<String, bool>) -> Vec<String> {
+        let mut paths = self.paths.clone();
+        for (name, parameter) in &self.parameters {
+            let value = parameter_values
+                .get(name)
+                .copied()
+                .unwrap_or(parameter.default);
+            if value {
+                paths.extend(parameter.adds_paths.iter().cloned());
+            }
+        }
+        paths
+    }
 }
 
 impl PlaybookMeta {
-    /// Load Playbook Meta from a `<name>.meta.yml` file at the given path.
     pub fn load(path: &Path) -> Result<Self> {
         let contents = std::fs::read_to_string(path)
             .wrap_err_with(|| format!("Failed to read Playbook Meta from {}", path.display()))?;
@@ -139,7 +186,6 @@ mod tests {
                 meta_path.exists(),
                 "Missing meta file for playbook: {stem}.yml (expected {meta_path:?})"
             );
-            // Verify it parses cleanly
             PlaybookMeta::load(&meta_path)
                 .unwrap_or_else(|e| panic!("Failed to parse {stem}.meta.yml: {e}"));
         }
@@ -149,5 +195,150 @@ mod tests {
     fn test_playbook_meta_load_nonexistent_file_returns_error() {
         let result = PlaybookMeta::load(Path::new("/nonexistent/playbook.meta.yml"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_meta_without_backup_section_parses() {
+        let yaml = "required_keys: [foo, bar]\n";
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(meta.required_keys, vec!["foo", "bar"]);
+        assert!(meta.backup.is_none());
+    }
+
+    #[test]
+    fn test_minimal_backup_recipe_parses() {
+        let yaml = r#"
+required_keys: []
+backup:
+  paths:
+    - /opt/app/data
+  owner: [app, app]
+"#;
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        let backup = meta.backup.unwrap();
+        assert_eq!(backup.paths, vec!["/opt/app/data"]);
+        assert_eq!(backup.owner, Some(("app".to_string(), "app".to_string())));
+        assert!(backup.systemd_services.is_empty());
+        assert!(backup.db.is_none());
+        assert!(backup.post_restore_command.is_none());
+        assert!(backup.parameters.is_empty());
+    }
+
+    #[test]
+    fn test_full_backup_recipe_parses() {
+        let yaml = r#"
+required_keys: []
+backup:
+  systemd_services: [paperless-webserver, paperless-consumer]
+  paths:
+    - /opt/paperless/data
+    - /opt/paperless/media
+  owner: [paperless, paperless]
+  db:
+    name: paperless
+    dump_path: /tmp/paperless_db.dump
+  post_restore_command: "cd /opt/paperless/src && sudo -u paperless ./manage.py migrate"
+"#;
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        let backup = meta.backup.unwrap();
+        assert_eq!(
+            backup.systemd_services,
+            vec!["paperless-webserver", "paperless-consumer"]
+        );
+        assert_eq!(
+            backup.paths,
+            vec!["/opt/paperless/data", "/opt/paperless/media"]
+        );
+        let db = backup.db.unwrap();
+        assert_eq!(db.name, "paperless");
+        assert_eq!(db.dump_path, "/tmp/paperless_db.dump");
+        assert!(
+            backup
+                .post_restore_command
+                .as_deref()
+                .unwrap()
+                .contains("manage.py migrate")
+        );
+    }
+
+    #[test]
+    fn test_backup_recipe_with_parameters_parses() {
+        let yaml = r#"
+required_keys: []
+backup:
+  paths:
+    - /var/lib/navidrome
+  owner: [navidrome, navidrome]
+  parameters:
+    include_music:
+      default: false
+      adds_paths: [/srv/music]
+"#;
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        let backup = meta.backup.unwrap();
+        let parameter = backup.parameters.get("include_music").unwrap();
+        assert!(!parameter.default);
+        assert_eq!(parameter.adds_paths, vec!["/srv/music"]);
+    }
+
+    #[test]
+    fn test_effective_paths_without_parameter_returns_base_paths() {
+        let recipe = BackupRecipe {
+            systemd_services: vec![],
+            paths: vec!["/var/lib/app".to_string()],
+            owner: None,
+            db: None,
+            post_restore_command: None,
+            parameters: HashMap::new(),
+        };
+        let effective = recipe.effective_paths(&HashMap::new());
+        assert_eq!(effective, vec!["/var/lib/app".to_string()]);
+    }
+
+    #[test]
+    fn test_effective_paths_includes_optional_paths_when_parameter_true() {
+        let mut parameters = HashMap::new();
+        parameters.insert(
+            "include_music".to_string(),
+            BackupParameter {
+                default: false,
+                adds_paths: vec!["/srv/music".to_string()],
+            },
+        );
+        let recipe = BackupRecipe {
+            systemd_services: vec![],
+            paths: vec!["/var/lib/navidrome".to_string()],
+            owner: None,
+            db: None,
+            post_restore_command: None,
+            parameters,
+        };
+        let mut values = HashMap::new();
+        values.insert("include_music".to_string(), true);
+        let effective = recipe.effective_paths(&values);
+        assert!(effective.contains(&"/var/lib/navidrome".to_string()));
+        assert!(effective.contains(&"/srv/music".to_string()));
+    }
+
+    #[test]
+    fn test_effective_paths_excludes_optional_paths_when_parameter_false() {
+        let mut parameters = HashMap::new();
+        parameters.insert(
+            "include_music".to_string(),
+            BackupParameter {
+                default: false,
+                adds_paths: vec!["/srv/music".to_string()],
+            },
+        );
+        let recipe = BackupRecipe {
+            systemd_services: vec![],
+            paths: vec!["/var/lib/navidrome".to_string()],
+            owner: None,
+            db: None,
+            post_restore_command: None,
+            parameters,
+        };
+        let effective = recipe.effective_paths(&HashMap::new());
+        assert!(!effective.contains(&"/srv/music".to_string()));
     }
 }

--- a/src/models/playbook_meta.rs
+++ b/src/models/playbook_meta.rs
@@ -141,6 +141,106 @@ mod tests {
         let meta = load_meta("calibre");
         assert!(meta.required_keys.contains(&"admin_user_name".to_string()));
         assert!(meta.required_keys.contains(&"domain".to_string()));
+        let backup = meta.backup.expect("calibre.meta.yml should declare backup");
+        assert_eq!(backup.systemd_services, vec!["calibre"]);
+        assert_eq!(
+            backup.paths,
+            vec!["/srv/calibre", "/opt/calibre", "/home/calibre"]
+        );
+        assert_eq!(
+            backup.owner,
+            Some(("calibre".to_string(), "calibre".to_string()))
+        );
+        assert!(backup.db.is_none());
+    }
+
+    #[test]
+    fn test_baikal_meta_backup_recipe() {
+        let backup = load_meta("baikal").backup.unwrap();
+        assert_eq!(backup.paths, vec!["/opt/baikal/Specific"]);
+        assert_eq!(
+            backup.owner,
+            Some(("baikal".to_string(), "baikal".to_string()))
+        );
+        assert!(backup.systemd_services.is_empty());
+    }
+
+    #[test]
+    fn test_bichon_meta_backup_recipe() {
+        let backup = load_meta("bichon").backup.unwrap();
+        assert_eq!(backup.systemd_services, vec!["bichon"]);
+        assert_eq!(backup.paths, vec!["/opt/bichon/data"]);
+    }
+
+    #[test]
+    fn test_freshrss_meta_backup_recipe() {
+        let backup = load_meta("freshrss").backup.unwrap();
+        assert_eq!(backup.systemd_services, vec!["freshrss"]);
+        assert_eq!(
+            backup.paths,
+            vec!["/var/lib/freshrss", "/opt/freshrss/data"]
+        );
+    }
+
+    #[test]
+    fn test_headscale_meta_backup_recipe() {
+        let backup = load_meta("headscale").backup.unwrap();
+        assert_eq!(backup.systemd_services, vec!["headscale"]);
+        assert_eq!(backup.paths, vec!["/var/lib/headscale"]);
+    }
+
+    #[test]
+    fn test_navidrome_meta_backup_recipe() {
+        let backup = load_meta("navidrome").backup.unwrap();
+        assert_eq!(backup.systemd_services, vec!["navidrome"]);
+        assert_eq!(backup.paths, vec!["/var/lib/navidrome", "/etc/navidrome"]);
+        let parameter = backup.parameters.get("include_music").unwrap();
+        assert!(!parameter.default);
+        assert_eq!(parameter.adds_paths, vec!["/srv/music"]);
+    }
+
+    #[test]
+    fn test_webdav_meta_backup_recipe() {
+        let backup = load_meta("webdav").backup.unwrap();
+        assert_eq!(backup.paths, vec!["/var/www/webdav-files"]);
+        assert!(backup.owner.is_none());
+        assert!(backup.systemd_services.is_empty());
+    }
+
+    #[test]
+    fn test_yourls_meta_backup_recipe() {
+        let backup = load_meta("yourls").backup.unwrap();
+        assert_eq!(backup.paths, vec!["/var/www/yourls"]);
+        assert_eq!(
+            backup.owner,
+            Some(("www-data".to_string(), "www-data".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_paperless_meta_backup_recipe() {
+        let backup = load_meta("paperless").backup.unwrap();
+        assert_eq!(
+            backup.systemd_services,
+            vec![
+                "paperless-webserver",
+                "paperless-consumer",
+                "paperless-task-queue",
+                "paperless-scheduler",
+            ]
+        );
+        assert_eq!(
+            backup.paths,
+            vec!["/opt/paperless/data", "/opt/paperless/media"]
+        );
+        let db = backup.db.expect("paperless declares db");
+        assert_eq!(db.name, "paperless");
+        assert_eq!(db.dump_path, "/tmp/paperless_db.dump");
+        let cmd = backup
+            .post_restore_command
+            .expect("paperless declares post_restore_command");
+        assert!(cmd.contains("manage.py migrate"));
+        assert!(cmd.contains("PAPERLESS_CONFIGURATION_PATH"));
     }
 
     #[test]

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,4 +1,5 @@
 pub mod ansible_runner;
+pub mod backup;
 pub mod dependency_resolver;
 pub mod dns;
 pub mod inventory;

--- a/src/services/backup.rs
+++ b/src/services/backup.rs
@@ -1,0 +1,1 @@
+pub mod ssh;

--- a/src/services/backup.rs
+++ b/src/services/backup.rs
@@ -1,2 +1,3 @@
 pub mod executor;
+pub mod recipe;
 pub mod ssh;

--- a/src/services/backup.rs
+++ b/src/services/backup.rs
@@ -1,1 +1,2 @@
+pub mod executor;
 pub mod ssh;

--- a/src/services/backup/executor.rs
+++ b/src/services/backup/executor.rs
@@ -1,0 +1,486 @@
+use crate::models::playbook_meta::BackupRecipe;
+use crate::services::backup::ssh::SshSession;
+use eyre::Result;
+use std::collections::HashMap;
+use std::path::Path;
+
+pub struct RecipeExecutor<'a, S: SshSession + ?Sized> {
+    session: &'a S,
+}
+
+impl<'a, S: SshSession + ?Sized> RecipeExecutor<'a, S> {
+    pub fn new(session: &'a S) -> Self {
+        Self { session }
+    }
+
+    pub fn backup(
+        &self,
+        recipe: &BackupRecipe,
+        dest_dir: &Path,
+        parameters: &HashMap<String, bool>,
+    ) -> Result<()> {
+        let mut stopped: Vec<&str> = Vec::new();
+        for service in &recipe.systemd_services {
+            if let Err(e) = self.session.systemctl("stop", service) {
+                self.restart_all(&stopped);
+                return Err(e);
+            }
+            stopped.push(service);
+        }
+
+        let result = (|| -> Result<()> {
+            if let Some(db) = &recipe.db {
+                let cmd = format!(
+                    "sudo -u postgres pg_dump -Fc {} > {}",
+                    db.name, db.dump_path
+                );
+                let dump = self.session.run(&cmd)?;
+                if !dump.success {
+                    let _ = self.session.run(&format!("rm -f {}", db.dump_path));
+                    eyre::bail!(
+                        "pg_dump failed for {}: {}",
+                        db.name,
+                        dump.stderr_str().trim()
+                    );
+                }
+            }
+
+            let paths = recipe.effective_paths(parameters);
+            for path in &paths {
+                self.session.rsync_from(path, dest_dir)?;
+            }
+
+            if let Some(db) = &recipe.db {
+                let local_dump = dest_dir.join("db.dump");
+                self.session.scp_from(&db.dump_path, &local_dump)?;
+                let _ = self.session.run(&format!("rm -f {}", db.dump_path));
+            }
+
+            Ok(())
+        })();
+
+        let restart_failures = self.restart_all_collecting(&stopped);
+
+        match result {
+            Ok(()) if restart_failures.is_empty() => Ok(()),
+            Ok(()) => eyre::bail!(
+                "Backup succeeded but failed to restart services:\n  {}",
+                restart_failures.join("\n  ")
+            ),
+            Err(e) if restart_failures.is_empty() => Err(e),
+            Err(e) => eyre::bail!(
+                "Backup failed: {e}\nAdditionally, failed to restart services:\n  {}",
+                restart_failures.join("\n  ")
+            ),
+        }
+    }
+
+    pub fn restore(
+        &self,
+        recipe: &BackupRecipe,
+        source_dir: &Path,
+        parameters: &HashMap<String, bool>,
+    ) -> Result<()> {
+        let mut stopped: Vec<&str> = Vec::new();
+        for service in &recipe.systemd_services {
+            if let Err(e) = self.session.systemctl("stop", service) {
+                self.restart_all(&stopped);
+                return Err(e);
+            }
+            stopped.push(service);
+        }
+
+        let result = (|| -> Result<()> {
+            let paths = recipe.effective_paths(parameters);
+            for path in &paths {
+                let local_source = source_dir.join(path.trim_start_matches('/'));
+                self.session.rsync_to(&local_source, path)?;
+            }
+
+            if let Some((user, group)) = &recipe.owner {
+                for path in &paths {
+                    self.session.set_ownership(path, user, group)?;
+                }
+            }
+
+            if let Some(db) = &recipe.db {
+                let local_dump = source_dir.join("db.dump");
+                if local_dump.exists() {
+                    self.session.scp_to(&local_dump, &db.dump_path)?;
+                    self.session.run(&format!("chmod 644 {}", db.dump_path))?;
+                    let cmd = format!(
+                        "sudo -u postgres pg_restore --clean --if-exists -d {} {} 2>&1",
+                        db.name, db.dump_path
+                    );
+                    let restore = self.session.run(&cmd)?;
+                    let _ = self.session.run(&format!("rm -f {}", db.dump_path));
+                    if !restore.success && !is_warnings_only(&restore.stdout_str()) {
+                        eyre::bail!("pg_restore failed: {}", restore.stdout_str().trim());
+                    }
+                }
+            }
+
+            if let Some(cmd) = &recipe.post_restore_command {
+                let post = self.session.run(cmd)?;
+                if !post.success {
+                    eyre::bail!("post_restore_command failed: {}", post.stderr_str().trim());
+                }
+            }
+
+            Ok(())
+        })();
+
+        let restart_failures = self.restart_all_collecting(&stopped);
+
+        match result {
+            Ok(()) if restart_failures.is_empty() => Ok(()),
+            Ok(()) => eyre::bail!(
+                "Restore succeeded but failed to restart services:\n  {}",
+                restart_failures.join("\n  ")
+            ),
+            Err(e) if restart_failures.is_empty() => Err(e),
+            Err(e) => eyre::bail!(
+                "Restore failed: {e}\nAdditionally, failed to restart services:\n  {}",
+                restart_failures.join("\n  ")
+            ),
+        }
+    }
+
+    fn restart_all(&self, services: &[&str]) {
+        for service in services {
+            let _ = self.session.systemctl("start", service);
+        }
+    }
+
+    fn restart_all_collecting(&self, services: &[&str]) -> Vec<String> {
+        services
+            .iter()
+            .filter_map(|s| {
+                self.session
+                    .systemctl("start", s)
+                    .err()
+                    .map(|e| format!("{}: {}", s, e))
+            })
+            .collect()
+    }
+}
+
+fn is_warnings_only(text: &str) -> bool {
+    text.lines().all(|line| {
+        let trimmed = line.trim().to_lowercase();
+        trimmed.is_empty()
+            || trimmed.contains("warning")
+            || trimmed.starts_with("pg_restore: warning")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::playbook_meta::{BackupParameter, DbRecipe};
+    use crate::services::backup::ssh::{MockSshSession, SshOp};
+
+    fn baikal_recipe() -> BackupRecipe {
+        BackupRecipe {
+            systemd_services: vec![],
+            paths: vec!["/opt/baikal/Specific".to_string()],
+            owner: Some(("baikal".to_string(), "baikal".to_string())),
+            db: None,
+            post_restore_command: None,
+            parameters: HashMap::new(),
+        }
+    }
+
+    fn paperless_recipe() -> BackupRecipe {
+        BackupRecipe {
+            systemd_services: vec!["paperless-webserver".to_string()],
+            paths: vec!["/opt/paperless/data".to_string()],
+            owner: Some(("paperless".to_string(), "paperless".to_string())),
+            db: Some(DbRecipe {
+                name: "paperless".to_string(),
+                dump_path: "/tmp/paperless_db.dump".to_string(),
+            }),
+            post_restore_command: Some("sudo -u paperless ./manage.py migrate".to_string()),
+            parameters: HashMap::new(),
+        }
+    }
+
+    fn navidrome_recipe() -> BackupRecipe {
+        let mut params = HashMap::new();
+        params.insert(
+            "include_music".to_string(),
+            BackupParameter {
+                default: false,
+                adds_paths: vec!["/srv/music".to_string()],
+            },
+        );
+        BackupRecipe {
+            systemd_services: vec!["navidrome".to_string()],
+            paths: vec!["/var/lib/navidrome".to_string()],
+            owner: Some(("navidrome".to_string(), "navidrome".to_string())),
+            db: None,
+            post_restore_command: None,
+            parameters: params,
+        }
+    }
+
+    #[test]
+    fn test_backup_no_services_just_rsyncs_paths() {
+        let mock = MockSshSession::new();
+        let executor = RecipeExecutor::new(&mock);
+        executor
+            .backup(&baikal_recipe(), Path::new("/tmp/dest"), &HashMap::new())
+            .unwrap();
+
+        let calls = mock.calls();
+        assert_eq!(calls.len(), 1);
+        assert!(matches!(
+            &calls[0],
+            SshOp::RsyncFrom { remote, .. } if remote == "/opt/baikal/Specific"
+        ));
+    }
+
+    #[test]
+    fn test_backup_stops_then_rsyncs_then_starts() {
+        let mock = MockSshSession::new();
+        let recipe = BackupRecipe {
+            systemd_services: vec!["bichon".to_string()],
+            paths: vec!["/opt/bichon/data".to_string()],
+            owner: None,
+            db: None,
+            post_restore_command: None,
+            parameters: HashMap::new(),
+        };
+        let executor = RecipeExecutor::new(&mock);
+        executor
+            .backup(&recipe, Path::new("/tmp/dest"), &HashMap::new())
+            .unwrap();
+
+        let calls = mock.calls();
+        assert_eq!(
+            calls[0],
+            SshOp::Systemctl {
+                action: "stop".to_string(),
+                service: "bichon".to_string(),
+            }
+        );
+        assert!(matches!(&calls[1], SshOp::RsyncFrom { .. }));
+        assert_eq!(
+            calls[2],
+            SshOp::Systemctl {
+                action: "start".to_string(),
+                service: "bichon".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_backup_with_db_runs_pg_dump_before_rsync_then_scps_dump() {
+        let mock = MockSshSession::new();
+        let executor = RecipeExecutor::new(&mock);
+        executor
+            .backup(&paperless_recipe(), Path::new("/tmp/dest"), &HashMap::new())
+            .unwrap();
+
+        let calls = mock.calls();
+        assert_eq!(
+            calls[0],
+            SshOp::Systemctl {
+                action: "stop".to_string(),
+                service: "paperless-webserver".to_string(),
+            }
+        );
+        match &calls[1] {
+            SshOp::Run(cmd) => {
+                assert!(cmd.contains("pg_dump"));
+                assert!(cmd.contains("paperless"));
+                assert!(cmd.contains("/tmp/paperless_db.dump"));
+            }
+            other => panic!("expected pg_dump Run, got {other:?}"),
+        }
+        assert!(matches!(&calls[2], SshOp::RsyncFrom { .. }));
+        assert!(matches!(
+            &calls[3],
+            SshOp::ScpFrom { remote, .. } if remote == "/tmp/paperless_db.dump"
+        ));
+        match &calls[4] {
+            SshOp::Run(cmd) => assert!(cmd.contains("rm -f /tmp/paperless_db.dump")),
+            other => panic!("expected rm -f Run, got {other:?}"),
+        }
+        assert_eq!(
+            calls[5],
+            SshOp::Systemctl {
+                action: "start".to_string(),
+                service: "paperless-webserver".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_backup_with_include_music_parameter_adds_path() {
+        let mock = MockSshSession::new();
+        let executor = RecipeExecutor::new(&mock);
+        let mut params = HashMap::new();
+        params.insert("include_music".to_string(), true);
+        executor
+            .backup(&navidrome_recipe(), Path::new("/tmp/dest"), &params)
+            .unwrap();
+
+        let rsync_remotes: Vec<String> = mock
+            .calls()
+            .iter()
+            .filter_map(|c| match c {
+                SshOp::RsyncFrom { remote, .. } => Some(remote.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(rsync_remotes.contains(&"/var/lib/navidrome".to_string()));
+        assert!(rsync_remotes.contains(&"/srv/music".to_string()));
+    }
+
+    #[test]
+    fn test_backup_omits_optional_path_when_parameter_absent() {
+        let mock = MockSshSession::new();
+        let executor = RecipeExecutor::new(&mock);
+        executor
+            .backup(&navidrome_recipe(), Path::new("/tmp/dest"), &HashMap::new())
+            .unwrap();
+
+        let rsync_remotes: Vec<String> = mock
+            .calls()
+            .iter()
+            .filter_map(|c| match c {
+                SshOp::RsyncFrom { remote, .. } => Some(remote.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(rsync_remotes.contains(&"/var/lib/navidrome".to_string()));
+        assert!(!rsync_remotes.contains(&"/srv/music".to_string()));
+    }
+
+    #[test]
+    fn test_restore_rsyncs_then_sets_ownership_then_starts_services() {
+        let mock = MockSshSession::new();
+        let executor = RecipeExecutor::new(&mock);
+        let recipe = BackupRecipe {
+            systemd_services: vec!["freshrss".to_string()],
+            paths: vec!["/var/lib/freshrss".to_string()],
+            owner: Some(("freshrss".to_string(), "freshrss".to_string())),
+            db: None,
+            post_restore_command: None,
+            parameters: HashMap::new(),
+        };
+        executor
+            .restore(&recipe, Path::new("/tmp/source"), &HashMap::new())
+            .unwrap();
+
+        let calls = mock.calls();
+        assert_eq!(
+            calls[0],
+            SshOp::Systemctl {
+                action: "stop".to_string(),
+                service: "freshrss".to_string(),
+            }
+        );
+        assert!(matches!(
+            &calls[1],
+            SshOp::RsyncTo { remote, .. } if remote == "/var/lib/freshrss"
+        ));
+        assert_eq!(
+            calls[2],
+            SshOp::SetOwnership {
+                remote: "/var/lib/freshrss".to_string(),
+                user: "freshrss".to_string(),
+                group: "freshrss".to_string(),
+            }
+        );
+        assert_eq!(
+            calls[3],
+            SshOp::Systemctl {
+                action: "start".to_string(),
+                service: "freshrss".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_restore_runs_post_restore_command_after_db_restore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dump = tmp.path().join("db.dump");
+        std::fs::write(&dump, b"binary").unwrap();
+
+        let mock = MockSshSession::new();
+        let executor = RecipeExecutor::new(&mock);
+        executor
+            .restore(&paperless_recipe(), tmp.path(), &HashMap::new())
+            .unwrap();
+
+        let calls = mock.calls();
+        let scp_to_idx = calls
+            .iter()
+            .position(
+                |c| matches!(c, SshOp::ScpTo { remote, .. } if remote == "/tmp/paperless_db.dump"),
+            )
+            .expect("should scp dump to remote");
+        let pg_restore_idx = calls
+            .iter()
+            .position(|c| matches!(c, SshOp::Run(cmd) if cmd.contains("pg_restore")))
+            .expect("should pg_restore");
+        let post_idx = calls
+            .iter()
+            .position(|c| matches!(c, SshOp::Run(cmd) if cmd.contains("manage.py migrate")))
+            .expect("should run post_restore_command");
+        assert!(scp_to_idx < pg_restore_idx);
+        assert!(pg_restore_idx < post_idx);
+    }
+
+    #[test]
+    fn test_restore_skips_db_when_local_dump_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let mock = MockSshSession::new();
+        let executor = RecipeExecutor::new(&mock);
+        executor
+            .restore(&paperless_recipe(), tmp.path(), &HashMap::new())
+            .unwrap();
+
+        let calls = mock.calls();
+        assert!(
+            !calls
+                .iter()
+                .any(|c| matches!(c, SshOp::Run(cmd) if cmd.contains("pg_restore"))),
+            "should not run pg_restore when dump file missing"
+        );
+        assert!(
+            !calls.iter().any(
+                |c| matches!(c, SshOp::ScpTo { remote, .. } if remote == "/tmp/paperless_db.dump")
+            ),
+            "should not scp dump when missing"
+        );
+    }
+
+    #[test]
+    fn test_backup_failed_pg_dump_still_restarts_services() {
+        let mock = MockSshSession::new();
+        mock.stage_run_result(crate::services::backup::ssh::CommandResult {
+            success: false,
+            exit_code: Some(1),
+            stdout: Vec::new(),
+            stderr: b"connection refused".to_vec(),
+        });
+        let executor = RecipeExecutor::new(&mock);
+        let result = executor.backup(&paperless_recipe(), Path::new("/tmp/dest"), &HashMap::new());
+        assert!(result.is_err());
+
+        let starts: Vec<_> = mock
+            .calls()
+            .iter()
+            .filter(|c| matches!(c, SshOp::Systemctl { action, .. } if action == "start"))
+            .cloned()
+            .collect();
+        assert!(
+            !starts.is_empty(),
+            "services must be restarted even when pg_dump fails"
+        );
+    }
+}

--- a/src/services/backup/recipe.rs
+++ b/src/services/backup/recipe.rs
@@ -1,0 +1,107 @@
+use crate::ansible_assets::AnsibleAssets;
+use crate::models::playbook_meta::{BackupRecipe, PlaybookMeta};
+use eyre::{Result, WrapErr};
+use std::path::Path;
+
+pub fn load_app_recipe(playbooks_dir: &Path, app: &str) -> Result<BackupRecipe> {
+    let meta_path = playbooks_dir.join(format!("{app}.meta.yml"));
+    let meta = PlaybookMeta::load(&meta_path)
+        .wrap_err_with(|| format!("Failed to load Playbook Meta for app '{app}'"))?;
+    meta.backup
+        .ok_or_else(|| eyre::eyre!("Playbook Meta for '{app}' has no `backup:` section"))
+}
+
+pub fn discover_backuppable_apps(playbooks_dir: &Path) -> Result<Vec<String>> {
+    let mut apps = Vec::new();
+    for entry in std::fs::read_dir(playbooks_dir)
+        .wrap_err_with(|| format!("Failed to read playbooks dir: {}", playbooks_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        let stem = match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) if name.ends_with(".meta.yml") => name.trim_end_matches(".meta.yml"),
+            _ => continue,
+        };
+        let meta = match PlaybookMeta::load(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.backup.is_some() {
+            apps.push(stem.to_string());
+        }
+    }
+    apps.sort();
+    Ok(apps)
+}
+
+pub fn assets_playbooks_dir() -> Result<std::path::PathBuf> {
+    Ok(AnsibleAssets::prepare()?.playbooks_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project_playbooks_dir() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("ansible")
+            .join("playbooks")
+    }
+
+    #[test]
+    fn test_load_app_recipe_returns_baikal() {
+        let recipe = load_app_recipe(&project_playbooks_dir(), "baikal").unwrap();
+        assert_eq!(recipe.paths, vec!["/opt/baikal/Specific"]);
+    }
+
+    #[test]
+    fn test_load_app_recipe_errors_when_meta_missing_backup_section() {
+        let result = load_app_recipe(&project_playbooks_dir(), "bootstrap");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("no `backup:` section")
+        );
+    }
+
+    #[test]
+    fn test_load_app_recipe_errors_for_unknown_app() {
+        let result = load_app_recipe(&project_playbooks_dir(), "definitely-not-an-app");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_discover_backuppable_apps_returns_all_nine() {
+        let apps = discover_backuppable_apps(&project_playbooks_dir()).unwrap();
+        for expected in [
+            "baikal",
+            "bichon",
+            "calibre",
+            "freshrss",
+            "headscale",
+            "navidrome",
+            "paperless",
+            "webdav",
+            "yourls",
+        ] {
+            assert!(
+                apps.contains(&expected.to_string()),
+                "expected '{expected}' in discovered apps, got {apps:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_discover_backuppable_apps_excludes_non_backup_metas() {
+        let apps = discover_backuppable_apps(&project_playbooks_dir()).unwrap();
+        assert!(!apps.contains(&"bootstrap".to_string()));
+        assert!(!apps.contains(&"hardening".to_string()));
+        assert!(!apps.contains(&"infrastructure".to_string()));
+        assert!(!apps.contains(&"hermes".to_string()));
+        assert!(!apps.contains(&"vibecoder".to_string()));
+        assert!(!apps.contains(&"remove-radicale".to_string()));
+        assert!(!apps.contains(&"apps".to_string()));
+    }
+}

--- a/src/services/backup/ssh.rs
+++ b/src/services/backup/ssh.rs
@@ -151,18 +151,18 @@ pub enum SshOp {
     },
     ScpFrom {
         remote: String,
-        local: PathBuf,
+        local: std::path::PathBuf,
     },
     ScpTo {
-        local: PathBuf,
+        local: std::path::PathBuf,
         remote: String,
     },
     RsyncFrom {
         remote: String,
-        local: PathBuf,
+        local: std::path::PathBuf,
     },
     RsyncTo {
-        local: PathBuf,
+        local: std::path::PathBuf,
         remote: String,
     },
     SetOwnership {
@@ -308,7 +308,7 @@ mod tests {
             mock.calls(),
             vec![SshOp::RsyncFrom {
                 remote: "/var/lib/freshrss".to_string(),
-                local: PathBuf::from("/tmp/staging"),
+                local: std::path::PathBuf::from("/tmp/staging"),
             }]
         );
     }

--- a/src/services/backup/ssh.rs
+++ b/src/services/backup/ssh.rs
@@ -1,0 +1,352 @@
+use crate::hosts::Host;
+use crate::ssh_session::SshSession as InnerSession;
+use eyre::{Context, Result};
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct CommandResult {
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+impl CommandResult {
+    pub fn ok() -> Self {
+        Self {
+            success: true,
+            exit_code: Some(0),
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        }
+    }
+
+    pub fn from_output(out: std::process::Output) -> Self {
+        Self {
+            success: out.status.success(),
+            exit_code: out.status.code(),
+            stdout: out.stdout,
+            stderr: out.stderr,
+        }
+    }
+
+    pub fn stdout_str(&self) -> String {
+        String::from_utf8_lossy(&self.stdout).into_owned()
+    }
+
+    pub fn stderr_str(&self) -> String {
+        String::from_utf8_lossy(&self.stderr).into_owned()
+    }
+}
+
+pub trait SshSession {
+    fn run(&self, command: &str) -> Result<CommandResult>;
+    fn systemctl(&self, action: &str, service: &str) -> Result<()>;
+    fn scp_from(&self, remote: &str, local: &Path) -> Result<()>;
+    fn scp_to(&self, local: &Path, remote: &str) -> Result<()>;
+    fn rsync_from(&self, remote: &str, local: &Path) -> Result<()>;
+    fn rsync_to(&self, local: &Path, remote: &str) -> Result<()>;
+    fn set_ownership(&self, remote: &str, user: &str, group: &str) -> Result<()>;
+}
+
+pub struct LiveSshSession<'a> {
+    inner: InnerSession<'a>,
+    host: &'a Host,
+}
+
+impl<'a> LiveSshSession<'a> {
+    pub fn new(host: &'a Host, ssh_key: &'a Path) -> Self {
+        Self {
+            inner: InnerSession::new(host, ssh_key),
+            host,
+        }
+    }
+}
+
+impl SshSession for LiveSshSession<'_> {
+    fn run(&self, command: &str) -> Result<CommandResult> {
+        Ok(CommandResult::from_output(self.inner.run(command)?))
+    }
+
+    fn systemctl(&self, action: &str, service: &str) -> Result<()> {
+        self.inner.systemctl(action, service)
+    }
+
+    fn scp_from(&self, remote: &str, local: &Path) -> Result<()> {
+        self.inner.scp_from(remote, local)
+    }
+
+    fn scp_to(&self, local: &Path, remote: &str) -> Result<()> {
+        self.inner.scp_to(local, remote)
+    }
+
+    fn rsync_from(&self, remote: &str, local: &Path) -> Result<()> {
+        let out = Command::new("rsync")
+            .arg("-az")
+            .arg("--relative")
+            .arg("--rsync-path=sudo rsync")
+            .arg("-e")
+            .arg(self.inner.rsync_e_arg())
+            .arg(format!(
+                "{}@{}:{}",
+                self.host.user, self.host.address, remote
+            ))
+            .arg(local)
+            .output()
+            .wrap_err("Failed to execute rsync")?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stderr.trim().is_empty() {
+                eyre::bail!("rsync failed for {}", remote);
+            }
+            eyre::bail!("rsync failed for {}: {}", remote, stderr.trim());
+        }
+        Ok(())
+    }
+
+    fn rsync_to(&self, local: &Path, remote: &str) -> Result<()> {
+        let out = Command::new("rsync")
+            .arg("-az")
+            .arg("--delete")
+            .arg("--rsync-path=sudo rsync")
+            .arg("-e")
+            .arg(self.inner.rsync_e_arg())
+            .arg(format!("{}/", local.display()))
+            .arg(format!(
+                "{}@{}:{}",
+                self.host.user, self.host.address, remote
+            ))
+            .output()
+            .wrap_err("Failed to execute rsync")?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stderr.trim().is_empty() {
+                eyre::bail!("rsync failed for {}", remote);
+            }
+            eyre::bail!("rsync failed for {}: {}", remote, stderr.trim());
+        }
+        Ok(())
+    }
+
+    fn set_ownership(&self, remote: &str, user: &str, group: &str) -> Result<()> {
+        let cmd = format!("sudo chown -R {}:{} {}", user, group, remote);
+        let result = self.run(&cmd)?;
+        if !result.success {
+            eyre::bail!("chown -R {}:{} {} failed", user, group, remote);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SshOp {
+    Run(String),
+    Systemctl {
+        action: String,
+        service: String,
+    },
+    ScpFrom {
+        remote: String,
+        local: PathBuf,
+    },
+    ScpTo {
+        local: PathBuf,
+        remote: String,
+    },
+    RsyncFrom {
+        remote: String,
+        local: PathBuf,
+    },
+    RsyncTo {
+        local: PathBuf,
+        remote: String,
+    },
+    SetOwnership {
+        remote: String,
+        user: String,
+        group: String,
+    },
+}
+
+#[cfg(test)]
+pub struct MockSshSession {
+    calls: std::cell::RefCell<Vec<SshOp>>,
+    run_results: std::cell::RefCell<std::collections::VecDeque<CommandResult>>,
+}
+
+#[cfg(test)]
+impl MockSshSession {
+    pub fn new() -> Self {
+        Self {
+            calls: std::cell::RefCell::new(Vec::new()),
+            run_results: std::cell::RefCell::new(std::collections::VecDeque::new()),
+        }
+    }
+
+    pub fn stage_run_result(&self, result: CommandResult) {
+        self.run_results.borrow_mut().push_back(result);
+    }
+
+    pub fn calls(&self) -> Vec<SshOp> {
+        self.calls.borrow().clone()
+    }
+}
+
+#[cfg(test)]
+impl SshSession for MockSshSession {
+    fn run(&self, command: &str) -> Result<CommandResult> {
+        self.calls
+            .borrow_mut()
+            .push(SshOp::Run(command.to_string()));
+        Ok(self
+            .run_results
+            .borrow_mut()
+            .pop_front()
+            .unwrap_or_else(CommandResult::ok))
+    }
+
+    fn systemctl(&self, action: &str, service: &str) -> Result<()> {
+        self.calls.borrow_mut().push(SshOp::Systemctl {
+            action: action.to_string(),
+            service: service.to_string(),
+        });
+        Ok(())
+    }
+
+    fn scp_from(&self, remote: &str, local: &Path) -> Result<()> {
+        self.calls.borrow_mut().push(SshOp::ScpFrom {
+            remote: remote.to_string(),
+            local: local.to_path_buf(),
+        });
+        Ok(())
+    }
+
+    fn scp_to(&self, local: &Path, remote: &str) -> Result<()> {
+        self.calls.borrow_mut().push(SshOp::ScpTo {
+            local: local.to_path_buf(),
+            remote: remote.to_string(),
+        });
+        Ok(())
+    }
+
+    fn rsync_from(&self, remote: &str, local: &Path) -> Result<()> {
+        self.calls.borrow_mut().push(SshOp::RsyncFrom {
+            remote: remote.to_string(),
+            local: local.to_path_buf(),
+        });
+        Ok(())
+    }
+
+    fn rsync_to(&self, local: &Path, remote: &str) -> Result<()> {
+        self.calls.borrow_mut().push(SshOp::RsyncTo {
+            local: local.to_path_buf(),
+            remote: remote.to_string(),
+        });
+        Ok(())
+    }
+
+    fn set_ownership(&self, remote: &str, user: &str, group: &str) -> Result<()> {
+        self.calls.borrow_mut().push(SshOp::SetOwnership {
+            remote: remote.to_string(),
+            user: user.to_string(),
+            group: group.to_string(),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_result_ok_is_success() {
+        let r = CommandResult::ok();
+        assert!(r.success);
+        assert_eq!(r.exit_code, Some(0));
+        assert!(r.stdout.is_empty());
+        assert!(r.stderr.is_empty());
+    }
+
+    #[test]
+    fn test_mock_records_run_calls() {
+        let mock = MockSshSession::new();
+        let _ = mock.run("echo hello").unwrap();
+        assert_eq!(mock.calls(), vec![SshOp::Run("echo hello".to_string())]);
+    }
+
+    #[test]
+    fn test_mock_records_systemctl_calls() {
+        let mock = MockSshSession::new();
+        mock.systemctl("stop", "paperless-webserver").unwrap();
+        mock.systemctl("start", "paperless-webserver").unwrap();
+        assert_eq!(
+            mock.calls(),
+            vec![
+                SshOp::Systemctl {
+                    action: "stop".to_string(),
+                    service: "paperless-webserver".to_string(),
+                },
+                SshOp::Systemctl {
+                    action: "start".to_string(),
+                    service: "paperless-webserver".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mock_records_rsync_from_calls() {
+        let mock = MockSshSession::new();
+        mock.rsync_from("/var/lib/freshrss", Path::new("/tmp/staging"))
+            .unwrap();
+        assert_eq!(
+            mock.calls(),
+            vec![SshOp::RsyncFrom {
+                remote: "/var/lib/freshrss".to_string(),
+                local: PathBuf::from("/tmp/staging"),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_mock_returns_staged_run_result() {
+        let mock = MockSshSession::new();
+        mock.stage_run_result(CommandResult {
+            success: false,
+            exit_code: Some(1),
+            stdout: b"oops".to_vec(),
+            stderr: b"error".to_vec(),
+        });
+        let result = mock.run("test").unwrap();
+        assert!(!result.success);
+        assert_eq!(result.stdout_str(), "oops");
+        assert_eq!(result.stderr_str(), "error");
+    }
+
+    #[test]
+    fn test_mock_returns_default_ok_when_no_staged_results() {
+        let mock = MockSshSession::new();
+        let result = mock.run("anything").unwrap();
+        assert!(result.success);
+    }
+
+    #[test]
+    fn test_mock_records_set_ownership() {
+        let mock = MockSshSession::new();
+        mock.set_ownership("/opt/paperless", "paperless", "paperless")
+            .unwrap();
+        assert_eq!(
+            mock.calls(),
+            vec![SshOp::SetOwnership {
+                remote: "/opt/paperless".to_string(),
+                user: "paperless".to_string(),
+                group: "paperless".to_string(),
+            }]
+        );
+    }
+}


### PR DESCRIPTION
Closes #265.

Slice 4 of #259: per-app backup logic moves out of `commands/backup.rs` and
into declarative YAML recipes in each Playbook Meta. A new `RecipeExecutor`
interprets the recipe and is the only path through which a single recipe
runs. Every remote command flows through a new `SshSession` trait so tests
can verify the executor issues the right command sequence with mocks.

## Changes by commit

- `feat(meta): add backup recipe schema to PlaybookMeta` — `BackupRecipe`,
  `DbRecipe`, `BackupParameter` types + parser tests.
- `feat(meta): declare backup recipes for every backuppable app` — eight new
  `*.meta.yml` files plus an extension to `calibre.meta.yml`. Navidrome's
  `include_music` becomes a parameter that adds `/srv/music` when true.
- `refactor(backup): introduce SshSession trait with mockable seam` —
  `SshSession` trait + `LiveSshSession` (production) + `MockSshSession` +
  `CommandResult` value type. The trait lives under `services::backup::ssh`.
- `feat(backup): add RecipeExecutor service` — `backup()` and `restore()`
  methods, with restart-on-failure invariants and pg_restore warning
  tolerance. Tests assert the SshOp sequence emitted for every code path.
- `refactor(backup): delegate backup_app/restore_app to RecipeExecutor` —
  `AppBackupConfig`, `DbBackupConfig`, `ServiceGuard`, and the
  per-call remote helpers (`remote_pg_dump`, `remote_pg_restore`, etc.) are
  all gone. `commands/backup.rs` shrinks by 832 lines.
- `chore(backup): drop unused RSYNC_EXCLUDES constant` — last leftover.

## Acceptance criteria

- [x] Each existing app has a `backup:` section in its Playbook Meta matching today's `AppBackupConfig`.
- [x] `commands/backup.rs::AppBackupConfig` is deleted.
- [x] `RecipeExecutor` exists and is the only path through which a single recipe runs.
- [x] `SshSession` trait + `MockSshSession` exist; tests verify the executor issues the expected command sequence for each recipe (using structural matchers, not literal strings).
- [x] Round-trip parser tests: every `backup:` section in committed meta files parses to the expected struct.
- [ ] `auberge backup create --apps <one>` for any single app produces the same on-disk result as before — _unverified end-to-end (requires real host); covered indirectly by executor tests asserting same SshOp sequence_.
- [x] Paperless restore still runs Django migrations (now via `post_restore_command:`).
- [x] Domain vocabulary matches `CONTEXT.md` (Backup Recipe, Recipe Executor, SshSession).

## Behaviour deltas (regressions accepted, follow-ups planned)

- Real-time rsync progress percentage and ETA are gone; the per-app spinner remains. The `Progress` trait under #259 will reintroduce structured progress reporting.
- `ServiceGuard`'s 30-minute remote `systemd-run` failsafe timer (auto-restarts services if the CLI dies) is dropped. The new executor restarts on every error path, but does not arm a remote timer. Should be reintroduced as a cross-cutting concern alongside the Ctrl-C utility from #259.
- `RSYNC_EXCLUDES` is no longer applied. Add to the recipe schema if it matters in practice.

## Test plan

- [x] `cargo test` — 213 passed, 0 failed.
- [x] Round-trip: every committed `*.meta.yml` parses back to the expected struct.
- [x] Executor: 9 tests covering stop-rsync-start ordering, pg_dump/restore sequencing, optional-paths via parameters, post_restore_command ordering, missing-dump skip, restart-on-failure.
- [ ] Manual: `auberge backup create --host <h> --apps paperless --dry-run` against a real host — _not run; needs your hardware_.