### PR TITLE
refactor(backup): add BackupSession multi-recipe orchestrator (#269)

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -6,7 +6,9 @@ use crate::services::backup::executor::RecipeExecutor;
 use crate::services::backup::recipe::{
     assets_playbooks_dir, discover_backuppable_apps, load_app_recipe,
 };
-use crate::services::backup::restic::{ResticMessage, parse_restic_message};
+use crate::services::backup::session::{
+    BackupSession, CreateOutcome, SessionOpts, restic_prune, restic_push,
+};
 use crate::services::backup::ssh::LiveSshSession;
 use crate::ssh_session::SshSession;
 use chrono::Utc;
@@ -175,13 +177,6 @@ pub enum OutputFormat {
     Yaml,
 }
 
-#[derive(Debug, Clone)]
-pub struct CreateOutcome {
-    pub successful_apps: Vec<String>,
-    pub failed_apps: Vec<(String, String)>,
-    pub timestamp: String,
-}
-
 pub struct RestoreOptions {
     pub backup_id: String,
     pub host_arg: Option<String>,
@@ -191,12 +186,6 @@ pub struct RestoreOptions {
     pub dry_run: bool,
     pub yes: bool,
     pub skip_playbook_unsafe: bool,
-}
-
-fn parameter_map(include_music: bool) -> HashMap<String, bool> {
-    let mut params = HashMap::new();
-    params.insert("include_music".to_string(), include_music);
-    params
 }
 
 pub fn run_backup_create(
@@ -242,42 +231,50 @@ pub fn run_backup_create(
         output::info(&format!("Apps: {}", app_names.join(", ")));
     }
 
-    let parameters = parameter_map(include_music);
-
     if dry_run {
         eprintln!("\n✓ Dry run completed (no changes made)");
         return Ok(CreateOutcome {
-            successful_apps: Vec::new(),
-            failed_apps: Vec::new(),
+            results: Vec::new(),
             timestamp: String::new(),
         });
     }
+
+    let mut parameters = HashMap::new();
+    parameters.insert("include_music".to_string(), include_music);
+
+    let recipes: Vec<(String, _)> = app_names
+        .iter()
+        .map(|name| Ok::<_, eyre::Report>((name.clone(), load_app_recipe(&playbooks_dir, name)?)))
+        .collect::<Result<_>>()?;
+
     let start_time = Instant::now();
     let timestamp = Utc::now().format("%Y-%m-%d_%H-%M-%S").to_string();
 
-    let mut results = Vec::new();
-    for app in &app_names {
-        match backup_app(
-            &host,
-            app,
-            &backup_dest,
-            &ssh_key_path,
-            &timestamp,
-            &parameters,
-            &playbooks_dir,
-        ) {
-            Ok(size) => results.push((app.clone(), true, Some(size), None)),
-            Err(e) => {
-                eprintln!("✗ {} backup failed: {}", app, e);
-                results.push((app.clone(), false, None, Some(e.to_string())));
-            }
-        }
-    }
+    let opts = SessionOpts {
+        host_name: host.name.clone(),
+        dest: backup_dest.clone(),
+        timestamp: timestamp.clone(),
+        parameters,
+    };
+    let ssh = LiveSshSession::new(&host, &ssh_key_path);
+    let session = BackupSession::new(&ssh, recipes, opts);
+    let outcome = session.create()?;
 
+    render_create_outcome(&outcome, &backup_dest, &host.name, start_time);
+
+    Ok(outcome)
+}
+
+fn render_create_outcome(
+    outcome: &CreateOutcome,
+    backup_dest: &Path,
+    host_name: &str,
+    start_time: Instant,
+) {
     let elapsed = start_time.elapsed().as_secs();
-    let total_size: u64 = results.iter().filter_map(|(_, _, size, _)| *size).sum();
-    let successful = results.iter().filter(|(_, ok, _, _)| *ok).count();
-    let failed = results.iter().filter(|(_, ok, _, _)| !*ok).count();
+    let successful = outcome.successful_apps().len();
+    let failed = outcome.failed_apps().len();
+    let total_size = outcome.total_size();
 
     eprintln!();
 
@@ -292,16 +289,16 @@ pub fn run_backup_create(
             size: String,
         }
 
-        let table_data: Vec<BackupResult> = results
+        let table_data: Vec<BackupResult> = outcome
+            .results
             .iter()
-            .map(|(app, ok, size, err)| BackupResult {
-                app: app.to_string(),
-                status: if *ok {
-                    "✓".to_string()
-                } else {
-                    format!("✗ {}", err.as_ref().unwrap())
+            .map(|r| BackupResult {
+                app: r.app.clone(),
+                status: match &r.error {
+                    None => "✓".to_string(),
+                    Some(err) => format!("✗ {}", err),
                 },
-                size: size.map(output::format_size).unwrap_or_default(),
+                size: r.size_bytes.map(output::format_size).unwrap_or_default(),
             })
             .collect();
 
@@ -328,26 +325,10 @@ pub fn run_backup_create(
     if output::is_verbose() {
         output::info(&format!(
             "Location: {}/{}/",
-            backup_dest.join(&host.name).display(),
-            timestamp
+            backup_dest.join(host_name).display(),
+            outcome.timestamp
         ));
     }
-
-    let outcome = CreateOutcome {
-        successful_apps: results
-            .iter()
-            .filter(|(_, ok, _, _)| *ok)
-            .map(|(name, _, _, _)| name.to_string())
-            .collect(),
-        failed_apps: results
-            .into_iter()
-            .filter(|(_, ok, _, _)| !*ok)
-            .map(|(name, _, _, err)| (name.to_string(), err.unwrap_or_default()))
-            .collect(),
-        timestamp,
-    };
-
-    Ok(outcome)
 }
 
 pub fn run_backup_sync(
@@ -379,24 +360,20 @@ pub fn run_backup_sync(
         .join(&host_name)
         .join(&outcome.timestamp);
 
-    if outcome.successful_apps.is_empty() {
+    let successful = outcome.successful_apps();
+    let failed = outcome.failed_apps();
+
+    if successful.is_empty() {
         let _ = fs::remove_dir_all(&staging_dir);
-        eyre::bail!(
-            "All {} app(s) failed; nothing to push",
-            outcome.failed_apps.len()
-        );
+        eyre::bail!("All {} app(s) failed; nothing to push", failed.len());
     }
 
-    if !outcome.failed_apps.is_empty() {
-        let names: Vec<&str> = outcome
-            .failed_apps
-            .iter()
-            .map(|(name, _)| name.as_str())
-            .collect();
+    if !failed.is_empty() {
+        let names: Vec<&str> = failed.iter().map(|(name, _)| name.as_str()).collect();
         output::warn(&format!(
             "Continuing push/prune with {} succeeded, {} failed: {}",
-            outcome.successful_apps.len(),
-            outcome.failed_apps.len(),
+            successful.len(),
+            failed.len(),
             names.join(", ")
         ));
     }
@@ -409,11 +386,11 @@ pub fn run_backup_sync(
 
     cleanup_staging_dir(&staging_dir)?;
 
-    if !outcome.failed_apps.is_empty() {
+    if !failed.is_empty() {
         eyre::bail!(
             "Sync completed with {} app failure(s); push/prune ran on {} successful app(s)",
-            outcome.failed_apps.len(),
-            outcome.successful_apps.len()
+            failed.len(),
+            successful.len()
         );
     }
 
@@ -821,10 +798,11 @@ pub fn run_backup_restore(opts: RestoreOptions) -> Result<()> {
             false,
         )
         .and_then(|outcome| {
-            if outcome.failed_apps.is_empty() {
+            let failed = outcome.failed_apps();
+            if failed.is_empty() {
                 Ok(())
             } else {
-                eyre::bail!("{} backup(s) failed", outcome.failed_apps.len());
+                eyre::bail!("{} backup(s) failed", failed.len());
             }
         });
 
@@ -1144,157 +1122,12 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
     let backup_dir =
         resolve_backup_dir(&backup_root, host_filter.as_deref(), backup_id.as_deref())?;
 
-    output::info(&format!("Pushing {} to restic", backup_dir.display()));
-
-    use crate::services::progress::{Progress, TerminalProgress};
-    let mut progress = TerminalProgress::new("Checking restic repository");
-    let snapshots_check = Command::new("restic")
-        .arg("snapshots")
-        .arg("--json")
-        .env("RESTIC_REPOSITORY", &restic_repo)
-        .env("RESTIC_PASSWORD", &restic_password)
-        .env_remove("RESTIC_PASSWORD_COMMAND")
-        .output();
-
-    let needs_init = match snapshots_check {
-        Ok(out) => {
-            let stderr_text = String::from_utf8_lossy(&out.stderr);
-            let lines = output::subprocess_output("restic", &stderr_text);
-            if out.status.success() {
-                output::clear_subprocess_lines(lines);
-                false
-            } else if stderr_text.contains("Is there a repository at the following location")
-                || stderr_text.contains("unable to open config file")
-            {
-                output::clear_subprocess_lines(lines);
-                true
-            } else {
-                eyre::bail!("restic snapshots failed: {}", stderr_text.trim());
-            }
-        }
-        Err(_) => eyre::bail!("restic not found. Install restic: https://restic.net"),
-    };
-
-    if needs_init {
-        progress.task_started("Initializing restic repository");
-        let init_output = Command::new("restic")
-            .arg("init")
-            .env("RESTIC_REPOSITORY", &restic_repo)
-            .env("RESTIC_PASSWORD", &restic_password)
-            .env_remove("RESTIC_PASSWORD_COMMAND")
-            .output()
-            .wrap_err("Failed to initialize restic repository")?;
-        let stderr_text = String::from_utf8_lossy(&init_output.stderr);
-        let lines = output::subprocess_output("restic", &stderr_text);
-        if init_output.status.success() {
-            output::clear_subprocess_lines(lines);
-        }
-
-        if !init_output.status.success() {
-            eyre::bail!(
-                "Failed to initialize restic repository: {}",
-                stderr_text.trim()
-            );
-        }
-    }
-
-    progress.task_started(&format!("Pushing {}", backup_dir.display()));
-    let mut snapshot_id: Option<String> = None;
-
-    let result = output::stream_command_stdout(
-        "restic",
-        Command::new("restic")
-            .arg("backup")
-            .arg("--json")
-            .arg(&backup_dir)
-            .env("RESTIC_REPOSITORY", &restic_repo)
-            .env("RESTIC_PASSWORD", &restic_password)
-            .env_remove("RESTIC_PASSWORD_COMMAND"),
-        |line| match parse_restic_message(line) {
-            Some(ResticMessage::Status(s)) => {
-                if let (Some(total), Some(done)) = (s.total_bytes, s.bytes_done) {
-                    progress.set_total(Some(total));
-                    progress.bytes_transferred(done);
-                } else {
-                    progress.set_total(Some(100));
-                    progress.bytes_transferred((s.percent_done * 100.0) as u64);
-                }
-            }
-            Some(ResticMessage::Summary(s)) => {
-                snapshot_id = Some(s.snapshot_id);
-            }
-            None => {}
-        },
-    )
-    .wrap_err("Failed to run restic backup")?;
-
-    progress.task_done();
-
-    if !result.status.success() {
-        if result.last_stderr.is_empty() {
-            eyre::bail!("restic backup failed");
-        } else {
-            eyre::bail!("restic backup failed: {}", result.last_stderr.trim());
-        }
-    }
-
-    match snapshot_id {
-        Some(id) => output::success(&format!("Push complete: snapshot {}", id)),
-        None => output::success("Push complete"),
-    };
-
-    Ok(())
+    restic_push(&restic_repo, &restic_password, &backup_dir)
 }
 
 pub fn run_backup_prune(dry_run: bool) -> Result<()> {
     let (restic_repo, restic_password) = load_restic_config()?;
-
-    use crate::services::progress::{Progress, TerminalProgress};
-    let mut progress = TerminalProgress::new("Pruning restic snapshots");
-
-    let mut cmd = Command::new("restic");
-    cmd.arg("forget")
-        .arg("--keep-daily")
-        .arg("7")
-        .arg("--keep-weekly")
-        .arg("4")
-        .arg("--keep-monthly")
-        .arg("12")
-        .arg("--prune")
-        .env("RESTIC_REPOSITORY", &restic_repo)
-        .env("RESTIC_PASSWORD", &restic_password)
-        .env_remove("RESTIC_PASSWORD_COMMAND");
-
-    if dry_run {
-        cmd.arg("--dry-run");
-    }
-
-    let prune_output = cmd.output().wrap_err("Failed to run restic forget")?;
-
-    progress.task_done();
-
-    let stderr_text = String::from_utf8_lossy(&prune_output.stderr);
-    let lines = output::subprocess_output("restic", &stderr_text);
-    if prune_output.status.success() {
-        output::clear_subprocess_lines(lines);
-    }
-
-    if !prune_output.status.success() {
-        eyre::bail!("restic prune failed: {}", stderr_text.trim());
-    }
-
-    let stdout = String::from_utf8_lossy(&prune_output.stdout);
-    if !stdout.is_empty() {
-        eprintln!("{}", stdout.trim());
-    }
-
-    if dry_run {
-        output::info("Dry run completed (no changes made)");
-    } else {
-        output::success("Prune complete");
-    }
-
-    Ok(())
+    restic_prune(&restic_repo, &restic_password, dry_run)
 }
 
 fn resolve_backup_dir(
@@ -1372,47 +1205,6 @@ fn default_backup_dir() -> PathBuf {
     dirs::data_local_dir()
         .map(|d| d.join("auberge").join("backups"))
         .unwrap_or_else(|| PathBuf::from("~/.local/share/auberge/backups"))
-}
-
-fn backup_app(
-    host: &Host,
-    app_name: &str,
-    backup_dest: &Path,
-    ssh_key: &Path,
-    timestamp: &str,
-    parameters: &HashMap<String, bool>,
-    playbooks_dir: &Path,
-) -> Result<u64> {
-    let recipe = load_app_recipe(playbooks_dir, app_name)?;
-    let mut progress =
-        crate::services::progress::TerminalProgress::new(&format!("Backing up {}", app_name));
-    let app_backup_dir = backup_dest.join(&host.name).join(timestamp).join(app_name);
-
-    fs::create_dir_all(&app_backup_dir).wrap_err_with(|| {
-        format!(
-            "Failed to create backup directory: {}",
-            app_backup_dir.display()
-        )
-    })?;
-
-    let session = LiveSshSession::new(host, ssh_key);
-    let executor = RecipeExecutor::new(&session);
-    let exec_result = executor.backup(&recipe, &app_backup_dir, parameters, &mut progress);
-
-    if let Err(e) = exec_result {
-        let _ = fs::remove_dir_all(&app_backup_dir);
-        return Err(e);
-    }
-
-    let backup_size = calculate_dir_size(&app_backup_dir)?;
-    if !output::is_verbose() {
-        output::success(&format!(
-            "{} ({})",
-            app_name,
-            output::format_size(backup_size)
-        ));
-    }
-    Ok(backup_size)
 }
 
 fn resolve_ssh_key_path(host: &Host, override_key: Option<PathBuf>) -> Result<PathBuf> {
@@ -1622,27 +1414,6 @@ mod tests {
     #[test]
     fn test_prune_variant_exists() {
         let _prune = BackupCommands::Prune { dry_run: true };
-    }
-
-    #[test]
-    fn test_parameter_map_carries_include_music_flag() {
-        let p = parameter_map(true);
-        assert_eq!(p.get("include_music").copied(), Some(true));
-        let p = parameter_map(false);
-        assert_eq!(p.get("include_music").copied(), Some(false));
-    }
-
-    #[test]
-    fn create_outcome_records_partial_success() {
-        let outcome = CreateOutcome {
-            successful_apps: vec!["paperless".to_string(), "freshrss".to_string()],
-            failed_apps: vec![("bichon".to_string(), "Unit not loaded".to_string())],
-            timestamp: "2026-04-28_03-00-00".to_string(),
-        };
-        assert_eq!(outcome.successful_apps.len(), 2);
-        assert_eq!(outcome.failed_apps.len(), 1);
-        assert_eq!(outcome.failed_apps[0].0, "bichon");
-        assert_eq!(outcome.timestamp, "2026-04-28_03-00-00");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,10 +168,11 @@ async fn main() -> Result<()> {
             } => signal::with_ctrlc(|| {
                 run_backup_create(host, apps, dest, ssh_key, include_music, dry_run).and_then(
                     |outcome| {
-                        if outcome.failed_apps.is_empty() {
+                        let failed = outcome.failed_apps();
+                        if failed.is_empty() {
                             Ok(())
                         } else {
-                            eyre::bail!("{} backup(s) failed", outcome.failed_apps.len());
+                            eyre::bail!("{} backup(s) failed", failed.len());
                         }
                     },
                 )

--- a/src/services/backup.rs
+++ b/src/services/backup.rs
@@ -1,4 +1,5 @@
 pub mod executor;
 pub mod recipe;
 pub mod restic;
+pub mod session;
 pub mod ssh;

--- a/src/services/backup/session.rs
+++ b/src/services/backup/session.rs
@@ -1,0 +1,558 @@
+use crate::output;
+use crate::playbook_meta::BackupRecipe;
+use crate::services::backup::executor::RecipeExecutor;
+use crate::services::backup::restic::{ResticMessage, parse_restic_message};
+use crate::services::backup::ssh::SshSession;
+use crate::services::progress::{Progress, TerminalProgress};
+use eyre::{Context, Result};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct SessionOpts {
+    pub host_name: String,
+    pub dest: PathBuf,
+    pub timestamp: String,
+    pub parameters: HashMap<String, bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecipeOutcome {
+    pub app: String,
+    pub size_bytes: Option<u64>,
+    pub error: Option<String>,
+}
+
+impl RecipeOutcome {
+    pub fn is_success(&self) -> bool {
+        self.error.is_none()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateOutcome {
+    pub results: Vec<RecipeOutcome>,
+    pub timestamp: String,
+}
+
+impl CreateOutcome {
+    pub fn successful_apps(&self) -> Vec<String> {
+        self.results
+            .iter()
+            .filter(|r| r.is_success())
+            .map(|r| r.app.clone())
+            .collect()
+    }
+
+    pub fn failed_apps(&self) -> Vec<(String, String)> {
+        self.results
+            .iter()
+            .filter(|r| !r.is_success())
+            .map(|r| (r.app.clone(), r.error.clone().unwrap_or_default()))
+            .collect()
+    }
+
+    pub fn total_size(&self) -> u64 {
+        self.results.iter().filter_map(|r| r.size_bytes).sum()
+    }
+}
+
+pub struct BackupSession<'a, S: SshSession + ?Sized> {
+    ssh: &'a S,
+    recipes: Vec<(String, BackupRecipe)>,
+    opts: SessionOpts,
+}
+
+impl<'a, S: SshSession + ?Sized> BackupSession<'a, S> {
+    pub fn new(ssh: &'a S, recipes: Vec<(String, BackupRecipe)>, opts: SessionOpts) -> Self {
+        Self { ssh, recipes, opts }
+    }
+
+    pub fn create(&self) -> Result<CreateOutcome> {
+        let executor = RecipeExecutor::new(self.ssh);
+        let mut results = Vec::with_capacity(self.recipes.len());
+
+        for (app_name, recipe) in &self.recipes {
+            let app_dir = self
+                .opts
+                .dest
+                .join(&self.opts.host_name)
+                .join(&self.opts.timestamp)
+                .join(app_name);
+
+            if let Err(e) = fs::create_dir_all(&app_dir) {
+                eprintln!("✗ {} backup failed: {}", app_name, e);
+                results.push(RecipeOutcome {
+                    app: app_name.clone(),
+                    size_bytes: None,
+                    error: Some(e.to_string()),
+                });
+                continue;
+            }
+
+            let mut progress = make_recipe_progress(app_name);
+            let exec_result =
+                executor.backup(recipe, &app_dir, &self.opts.parameters, &mut *progress);
+
+            match exec_result {
+                Ok(()) => {
+                    let size = calculate_dir_size(&app_dir).unwrap_or(0);
+                    if !output::is_verbose() {
+                        output::success(&format!("{} ({})", app_name, output::format_size(size)));
+                    }
+                    results.push(RecipeOutcome {
+                        app: app_name.clone(),
+                        size_bytes: Some(size),
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    let _ = fs::remove_dir_all(&app_dir);
+                    eprintln!("✗ {} backup failed: {}", app_name, e);
+                    results.push(RecipeOutcome {
+                        app: app_name.clone(),
+                        size_bytes: None,
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        }
+
+        Ok(CreateOutcome {
+            results,
+            timestamp: self.opts.timestamp.clone(),
+        })
+    }
+}
+
+#[cfg(not(test))]
+fn make_recipe_progress(app: &str) -> Box<dyn Progress> {
+    Box::new(TerminalProgress::new(&format!("Backing up {}", app)))
+}
+
+#[cfg(test)]
+fn make_recipe_progress(app: &str) -> Box<dyn Progress> {
+    Box::new(TerminalProgress::hidden(&format!("Backing up {}", app)))
+}
+
+pub fn restic_push(restic_repo: &str, restic_password: &str, backup_dir: &Path) -> Result<()> {
+    output::info(&format!("Pushing {} to restic", backup_dir.display()));
+
+    let mut progress = TerminalProgress::new("Checking restic repository");
+    let snapshots_check = Command::new("restic")
+        .arg("snapshots")
+        .arg("--json")
+        .env("RESTIC_REPOSITORY", restic_repo)
+        .env("RESTIC_PASSWORD", restic_password)
+        .env_remove("RESTIC_PASSWORD_COMMAND")
+        .output();
+
+    let needs_init = match snapshots_check {
+        Ok(out) => {
+            let stderr_text = String::from_utf8_lossy(&out.stderr);
+            let lines = output::subprocess_output("restic", &stderr_text);
+            if out.status.success() {
+                output::clear_subprocess_lines(lines);
+                false
+            } else if stderr_text.contains("Is there a repository at the following location")
+                || stderr_text.contains("unable to open config file")
+            {
+                output::clear_subprocess_lines(lines);
+                true
+            } else {
+                eyre::bail!("restic snapshots failed: {}", stderr_text.trim());
+            }
+        }
+        Err(_) => eyre::bail!("restic not found. Install restic: https://restic.net"),
+    };
+
+    if needs_init {
+        progress.task_started("Initializing restic repository");
+        let init_output = Command::new("restic")
+            .arg("init")
+            .env("RESTIC_REPOSITORY", restic_repo)
+            .env("RESTIC_PASSWORD", restic_password)
+            .env_remove("RESTIC_PASSWORD_COMMAND")
+            .output()
+            .wrap_err("Failed to initialize restic repository")?;
+        let stderr_text = String::from_utf8_lossy(&init_output.stderr);
+        let lines = output::subprocess_output("restic", &stderr_text);
+        if init_output.status.success() {
+            output::clear_subprocess_lines(lines);
+        }
+
+        if !init_output.status.success() {
+            eyre::bail!(
+                "Failed to initialize restic repository: {}",
+                stderr_text.trim()
+            );
+        }
+    }
+
+    progress.task_started(&format!("Pushing {}", backup_dir.display()));
+    let mut snapshot_id: Option<String> = None;
+
+    let result = output::stream_command_stdout(
+        "restic",
+        Command::new("restic")
+            .arg("backup")
+            .arg("--json")
+            .arg(backup_dir)
+            .env("RESTIC_REPOSITORY", restic_repo)
+            .env("RESTIC_PASSWORD", restic_password)
+            .env_remove("RESTIC_PASSWORD_COMMAND"),
+        |line| match parse_restic_message(line) {
+            Some(ResticMessage::Status(s)) => {
+                if let (Some(total), Some(done)) = (s.total_bytes, s.bytes_done) {
+                    progress.set_total(Some(total));
+                    progress.bytes_transferred(done);
+                } else {
+                    progress.set_total(Some(100));
+                    progress.bytes_transferred((s.percent_done * 100.0) as u64);
+                }
+            }
+            Some(ResticMessage::Summary(s)) => {
+                snapshot_id = Some(s.snapshot_id);
+            }
+            None => {}
+        },
+    )
+    .wrap_err("Failed to run restic backup")?;
+
+    progress.task_done();
+
+    if !result.status.success() {
+        if result.last_stderr.is_empty() {
+            eyre::bail!("restic backup failed");
+        } else {
+            eyre::bail!("restic backup failed: {}", result.last_stderr.trim());
+        }
+    }
+
+    match snapshot_id {
+        Some(id) => output::success(&format!("Push complete: snapshot {}", id)),
+        None => output::success("Push complete"),
+    };
+
+    Ok(())
+}
+
+pub fn restic_prune(restic_repo: &str, restic_password: &str, dry_run: bool) -> Result<()> {
+    let mut progress = TerminalProgress::new("Pruning restic snapshots");
+
+    let mut cmd = Command::new("restic");
+    cmd.arg("forget")
+        .arg("--keep-daily")
+        .arg("7")
+        .arg("--keep-weekly")
+        .arg("4")
+        .arg("--keep-monthly")
+        .arg("12")
+        .arg("--prune")
+        .env("RESTIC_REPOSITORY", restic_repo)
+        .env("RESTIC_PASSWORD", restic_password)
+        .env_remove("RESTIC_PASSWORD_COMMAND");
+
+    if dry_run {
+        cmd.arg("--dry-run");
+    }
+
+    let prune_output = cmd.output().wrap_err("Failed to run restic forget")?;
+
+    progress.task_done();
+
+    let stderr_text = String::from_utf8_lossy(&prune_output.stderr);
+    let lines = output::subprocess_output("restic", &stderr_text);
+    if prune_output.status.success() {
+        output::clear_subprocess_lines(lines);
+    }
+
+    if !prune_output.status.success() {
+        eyre::bail!("restic prune failed: {}", stderr_text.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&prune_output.stdout);
+    if !stdout.is_empty() {
+        eprintln!("{}", stdout.trim());
+    }
+
+    if dry_run {
+        output::info("Dry run completed (no changes made)");
+    } else {
+        output::success("Prune complete");
+    }
+
+    Ok(())
+}
+
+fn calculate_dir_size(path: &Path) -> Result<u64> {
+    let mut total = 0u64;
+
+    if path.is_file() {
+        return Ok(path.metadata()?.len());
+    }
+
+    if path.is_dir() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let metadata = entry.metadata()?;
+
+            if metadata.is_file() {
+                total += metadata.len();
+            } else if metadata.is_dir() {
+                total += calculate_dir_size(&entry.path())?;
+            }
+        }
+    }
+
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::playbook_meta::DbRecipe;
+    use crate::services::backup::ssh::{MockSshSession, SshOp};
+
+    fn baikal_recipe() -> BackupRecipe {
+        BackupRecipe {
+            systemd_services: vec![],
+            paths: vec!["/opt/baikal/Specific".to_string()],
+            owner: Some(("baikal".to_string(), "baikal".to_string())),
+            db: None,
+            post_restore_command: None,
+            parameters: HashMap::new(),
+        }
+    }
+
+    fn bichon_recipe() -> BackupRecipe {
+        BackupRecipe {
+            systemd_services: vec!["bichon".to_string()],
+            paths: vec!["/opt/bichon/data".to_string()],
+            owner: None,
+            db: None,
+            post_restore_command: None,
+            parameters: HashMap::new(),
+        }
+    }
+
+    fn paperless_recipe() -> BackupRecipe {
+        BackupRecipe {
+            systemd_services: vec!["paperless-webserver".to_string()],
+            paths: vec!["/opt/paperless/data".to_string()],
+            owner: Some(("paperless".to_string(), "paperless".to_string())),
+            db: Some(DbRecipe {
+                name: "paperless".to_string(),
+                dump_path: "/tmp/paperless_db.dump".to_string(),
+            }),
+            post_restore_command: None,
+            parameters: HashMap::new(),
+        }
+    }
+
+    fn opts(dest: &Path) -> SessionOpts {
+        SessionOpts {
+            host_name: "myserver".to_string(),
+            dest: dest.to_path_buf(),
+            timestamp: "2026-04-28_03-00-00".to_string(),
+            parameters: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn create_runs_recipes_in_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mock = MockSshSession::new();
+        let recipes = vec![
+            ("baikal".to_string(), baikal_recipe()),
+            ("bichon".to_string(), bichon_recipe()),
+        ];
+        let session = BackupSession::new(&mock, recipes, opts(tmp.path()));
+
+        let outcome = session.create().unwrap();
+
+        assert_eq!(outcome.results.len(), 2);
+        assert_eq!(outcome.results[0].app, "baikal");
+        assert_eq!(outcome.results[1].app, "bichon");
+        assert!(outcome.results.iter().all(RecipeOutcome::is_success));
+
+        let calls = mock.calls();
+        let baikal_rsync = calls.iter().position(
+            |c| matches!(c, SshOp::RsyncFrom { remote, .. } if remote == "/opt/baikal/Specific"),
+        );
+        let bichon_stop = calls.iter().position(|c| {
+            matches!(
+                c,
+                SshOp::Systemctl { action, service }
+                if action == "stop" && service == "bichon"
+            )
+        });
+        assert!(baikal_rsync.is_some());
+        assert!(bichon_stop.is_some());
+        assert!(baikal_rsync.unwrap() < bichon_stop.unwrap());
+    }
+
+    #[test]
+    fn create_creates_per_app_dest_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mock = MockSshSession::new();
+        let recipes = vec![
+            ("baikal".to_string(), baikal_recipe()),
+            ("bichon".to_string(), bichon_recipe()),
+        ];
+        let session = BackupSession::new(&mock, recipes, opts(tmp.path()));
+
+        session.create().unwrap();
+
+        let baikal_dir = tmp
+            .path()
+            .join("myserver")
+            .join("2026-04-28_03-00-00")
+            .join("baikal");
+        let bichon_dir = tmp
+            .path()
+            .join("myserver")
+            .join("2026-04-28_03-00-00")
+            .join("bichon");
+        assert!(baikal_dir.is_dir());
+        assert!(bichon_dir.is_dir());
+    }
+
+    #[test]
+    fn create_does_not_abort_on_recipe_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mock = MockSshSession::new();
+        // Stage a failure for paperless's pg_dump (the first run() call).
+        mock.stage_run_result(crate::services::backup::ssh::CommandResult {
+            success: false,
+            exit_code: Some(1),
+            stdout: Vec::new(),
+            stderr: b"connection refused".to_vec(),
+        });
+
+        let recipes = vec![
+            ("paperless".to_string(), paperless_recipe()),
+            ("baikal".to_string(), baikal_recipe()),
+        ];
+        let session = BackupSession::new(&mock, recipes, opts(tmp.path()));
+
+        let outcome = session.create().unwrap();
+
+        assert_eq!(outcome.results.len(), 2);
+        let paperless = outcome
+            .results
+            .iter()
+            .find(|r| r.app == "paperless")
+            .unwrap();
+        let baikal = outcome.results.iter().find(|r| r.app == "baikal").unwrap();
+        assert!(!paperless.is_success());
+        assert!(baikal.is_success());
+
+        // Ensure the failed recipe's dest dir was cleaned up.
+        let paperless_dir = tmp
+            .path()
+            .join("myserver")
+            .join("2026-04-28_03-00-00")
+            .join("paperless");
+        assert!(!paperless_dir.exists());
+    }
+
+    #[test]
+    fn create_outcome_helpers_partition_results() {
+        let outcome = CreateOutcome {
+            timestamp: "2026-04-28_03-00-00".to_string(),
+            results: vec![
+                RecipeOutcome {
+                    app: "baikal".to_string(),
+                    size_bytes: Some(1024),
+                    error: None,
+                },
+                RecipeOutcome {
+                    app: "bichon".to_string(),
+                    size_bytes: None,
+                    error: Some("oops".to_string()),
+                },
+                RecipeOutcome {
+                    app: "freshrss".to_string(),
+                    size_bytes: Some(2048),
+                    error: None,
+                },
+            ],
+        };
+
+        assert_eq!(
+            outcome.successful_apps(),
+            vec!["baikal".to_string(), "freshrss".to_string()]
+        );
+        assert_eq!(
+            outcome.failed_apps(),
+            vec![("bichon".to_string(), "oops".to_string())]
+        );
+        assert_eq!(outcome.total_size(), 3072);
+    }
+
+    #[test]
+    fn create_handles_empty_recipe_list() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mock = MockSshSession::new();
+        let session = BackupSession::new(&mock, vec![], opts(tmp.path()));
+
+        let outcome = session.create().unwrap();
+
+        assert!(outcome.results.is_empty());
+        assert_eq!(outcome.timestamp, "2026-04-28_03-00-00");
+        assert!(mock.calls().is_empty());
+    }
+
+    #[test]
+    fn create_passes_parameters_to_executor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mock = MockSshSession::new();
+
+        let mut params = HashMap::new();
+        params.insert(
+            "include_music".to_string(),
+            crate::playbook_meta::BackupParameter {
+                default: false,
+                adds_paths: vec!["/srv/music".to_string()],
+            },
+        );
+        let navidrome = BackupRecipe {
+            systemd_services: vec!["navidrome".to_string()],
+            paths: vec!["/var/lib/navidrome".to_string()],
+            owner: None,
+            db: None,
+            post_restore_command: None,
+            parameters: params,
+        };
+
+        let mut session_params = HashMap::new();
+        session_params.insert("include_music".to_string(), true);
+
+        let opts_with_param = SessionOpts {
+            host_name: "myserver".to_string(),
+            dest: tmp.path().to_path_buf(),
+            timestamp: "2026-04-28_03-00-00".to_string(),
+            parameters: session_params,
+        };
+
+        let session = BackupSession::new(
+            &mock,
+            vec![("navidrome".to_string(), navidrome)],
+            opts_with_param,
+        );
+        session.create().unwrap();
+
+        let rsync_remotes: Vec<String> = mock
+            .calls()
+            .iter()
+            .filter_map(|c| match c {
+                SshOp::RsyncFrom { remote, .. } => Some(remote.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(rsync_remotes.contains(&"/srv/music".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #269 (Slice 7 of #259). Introduces `BackupSession` — the top-level multi-recipe orchestrator that loops `RecipeExecutor` invocations and runs restic push/prune as session-level steps. Migrates `commands/backup.rs` to delegate to it.

- New `src/services/backup/session.rs` carrying `BackupSession`, `SessionOpts`, `CreateOutcome`, `RecipeOutcome`, and free `restic_push` / `restic_prune` helpers.
- `commands/backup.rs` shrinks **−228 lines net**: the `backup_app` inline loop, the local `CreateOutcome`, the `parameter_map` helper, and the inline restic subprocess plumbing all move into the session module.
- Partial-failure semantics preserved — one recipe failing does not abort the session; failed recipes have their dest dirs cleaned up.
- Domain vocabulary now matches `CONTEXT.md` (Backup Session, Recipe Executor).

## Acceptance criteria (#269)

- [x] `BackupSession` exists in `src/services/backup/session.rs` and is the entry point for all multi-recipe backup operations.
- [x] `auberge backup create`, `backup sync`, `backup push`, `backup prune` all delegate to `BackupSession` (or its session-level helpers for push/prune).
- [x] Partial-failure semantics preserved: one recipe failing does not abort the session.
- [x] Tests using `MockSshSession` verify recipe ordering, dest dir lifecycle, partial-failure isolation, and parameter forwarding.
- [x] No functional regression — all 250 tests pass.
- [x] Commands in `src/commands/backup.rs` shrink substantially (−228 lines).
- [x] Domain vocabulary matches `CONTEXT.md`.

## Test plan

- [x] `cargo test` — 250 passed.
- [x] `cargo clippy --no-deps` — no new warnings introduced.
- [ ] Manual smoke: `auberge backup create --apps baikal -H <host> -n` (dry run path).
- [ ] Manual smoke: `auberge backup sync --apps baikal -H <host>` end-to-end against a real host.