### PR TITLE
fix(release): close race window between Release publish and binary upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,3 +157,17 @@ jobs:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    name: Publish draft release
+    needs: [release-plz-release, upload-binaries]
+    if: needs.release-plz-release.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Flip draft to published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false --latest --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.outputs.outputs.releases_created }}
       tag: ${{ steps.outputs.outputs.tag }}
+      draft_release_created: ${{ steps.outputs.outputs.draft_release_created }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -89,11 +90,14 @@ jobs:
             tag=$(echo "$RELEASES_JSON" | jq -r '.[0].tag')
             echo "releases_created=true" >> "$GITHUB_OUTPUT"
             echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+            echo "draft_release_created=true" >> "$GITHUB_OUTPUT"
           elif [[ "$RECOVERY_TAG_PRESENT" == "true" ]]; then
             echo "releases_created=true" >> "$GITHUB_OUTPUT"
             echo "tag=${RECOVERY_TAG}" >> "$GITHUB_OUTPUT"
+            echo "draft_release_created=false" >> "$GITHUB_OUTPUT"
           else
             echo "releases_created=false" >> "$GITHUB_OUTPUT"
+            echo "draft_release_created=false" >> "$GITHUB_OUTPUT"
           fi
 
   release-plz-pr:
@@ -161,7 +165,7 @@ jobs:
   publish-release:
     name: Publish draft release
     needs: [release-plz-release, upload-binaries]
-    if: needs.release-plz-release.outputs.releases_created == 'true'
+    if: needs.release-plz-release.outputs.draft_release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,3 +4,8 @@
 # Does NOT apply to "release-plz release" (publish). Publishing is triggered by merging the release PR
 # (release_always / commit associated with a release-plz-* PR), so no loop.
 release_commits = "^(feat|fix|build)(!|\\(|:)"
+
+# Create the GitHub Release as a draft so consumers don't see assets:[] during the
+# 5-15min window before upload-binaries finishes. The publish-release job in
+# .github/workflows/release.yml flips draft=false once all matrix legs succeed.
+git_release_draft = true


### PR DESCRIPTION
## Summary

- Set `git_release_draft = true` in `release-plz.toml` so the GitHub Release is created as a draft, hiding it from consumers until binaries are uploaded.
- Add `publish-release` job that flips `draft=false` once the `upload-binaries` matrix succeeds, gated on `release-plz-release.outputs.releases_created == 'true'` so the recovery path (no Release created) is a clean no-op.
- Use `gh release edit --draft=false --latest` to deterministically retain "latest" status across the draft→published transition.

## Why

`release-plz-release` publishes the Release before the downstream `upload-binaries` matrix attaches assets. That left a 5–15min window where the Release was publicly visible with `assets: []` — `mise install github:sripwoud/auberge@<version>` failed with `No matching asset found`, and mise then cached the empty response for 24h.

A failure in any matrix leg leaves the Release as a draft (default `success()` semantics on `needs:`) — better a stuck draft than a public broken release.

## Test plan

- [ ] Merge release-plz PR → confirm Release is created as draft (no assets visible to public)
- [ ] Confirm `upload-binaries` matrix succeeds and uploads to the draft
- [ ] Confirm `publish-release` flips `draft=false` and Release is marked as latest
- [ ] Confirm `mise install github:sripwoud/auberge@<new-version>` succeeds on first try
- [ ] Confirm `gh release download <tag>` works during and after the run

Closes #279