### PR TITLE
feat(dns): auto-fill tailnet-only DNS overrides from host tailscale_ip cache

### DIFF
--- a/ansible/playbooks/bichon.meta.yml
+++ b/ansible/playbooks/bichon.meta.yml
@@ -1,4 +1,5 @@
 required_keys: []
+tailnet_only: true
 backup:
   systemd_services: [bichon]
   paths: [/opt/bichon/data]

--- a/ansible/playbooks/paperless.meta.yml
+++ b/ansible/playbooks/paperless.meta.yml
@@ -1,4 +1,5 @@
 required_keys: []
+tailnet_only: true
 backup:
   systemd_services:
     - paperless-webserver

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -48,6 +48,7 @@
     - [show](cli-reference/host/show.md)
     - [edit](cli-reference/host/edit.md)
     - [remove](cli-reference/host/remove.md)
+    - [detect-tailscale-ip](cli-reference/host/detect-tailscale-ip.md)
   - Ansible
     - [run](cli-reference/ansible/run.md)
     - [bootstrap](cli-reference/ansible/bootstrap.md)

--- a/docs/applications/apps/bichon.md
+++ b/docs/applications/apps/bichon.md
@@ -21,7 +21,7 @@ Required variables in `config.toml`:
 
 Optional:
 
-- `bichon_tailscale_ip` - Override auto-detected Tailscale IP (e.g. `100.x.y.z`); signals `dns set-all` to use this IP instead of the public IP
+- `bichon_tailscale_ip` - Override the host's cached Tailscale IP for this app specifically (e.g. `100.x.y.z`). Usually unnecessary: bichon's playbook meta declares `tailnet_only: true`, so `dns set-all --host <name>` already auto-fills the IP from `host.tailscale_ip` (set once via [`auberge host detect-tailscale-ip`](../../cli-reference/host/detect-tailscale-ip.md)). Use this key only when bichon needs a _different_ Tailscale IP than the rest of the host's tailnet-only apps.
 
 > **Warning**: Once the encryption password is set, it **cannot be changed**. Changing it later will make all encrypted data unreadable. To start over, you must reinitialize Bichon and delete all emails and metadata. See [upstream docs](https://github.com/rustmailer/bichon/wiki/Setting-the-Bichon-Encryption-Password). The Ansible role enforces this: the password file is written once on first deploy, and subsequent runs will fail if the configured password differs from the deployed one.
 

--- a/docs/cli-reference/dns/set-all.md
+++ b/docs/cli-reference/dns/set-all.md
@@ -131,6 +131,20 @@ auberge dns set-all --host myserver
 # Uses 192.168.1.10 automatically
 ```
 
+## Tailnet-only apps
+
+Apps whose playbook meta declares `tailnet_only: true` (currently `bichon` and `paperless`) need to point at the host's Tailscale CGNAT IP, not its public IP — Caddy binds those vhosts only to the Tailnet interface.
+
+The IP is resolved per-subdomain in this order:
+
+1. `<app>_tailscale_ip` in `config.toml` (explicit per-app override)
+2. `host.tailscale_ip` from `hosts.toml` (cached via [`auberge host detect-tailscale-ip`](../host/detect-tailscale-ip.md), used only when `--host` is passed)
+3. The host's public IP (default for public apps)
+
+If a tailnet-only app has no resolvable Tailscale IP, `dns set-all` bails — silently pointing such DNS at the public IP would make the service unreachable.
+
+See [Tailnet-only Subdomains](../../dns/batch-operations.md#tailnet-only-subdomains) for the full pattern.
+
 ## Use Cases
 
 **Initial setup** after deploying apps:

--- a/docs/cli-reference/host/detect-tailscale-ip.md
+++ b/docs/cli-reference/host/detect-tailscale-ip.md
@@ -1,0 +1,55 @@
+# auberge host detect-tailscale-ip
+
+Detect and cache the host's Tailscale IPv4 address.
+
+## Usage
+
+```bash
+auberge host detect-tailscale-ip [NAME]
+# Alias: auberge h dti
+```
+
+If `NAME` is omitted, you'll be prompted to select a host.
+
+## What it does
+
+1. SSHs into the host using its existing SSH key.
+2. Runs `tailscale ip -4` on the remote.
+3. Picks the first CGNAT IPv4 address (`100.64.0.0/10`).
+4. Persists it to `~/.config/auberge/hosts.toml` under the host's `tailscale_ip` field.
+
+## Why
+
+Once cached, `auberge dns set-all --host <name>` automatically points tailnet-only subdomains (apps with `tailnet_only: true` in their playbook meta — currently `bichon` and `paperless`) at this IP, without needing per-app `<app>_tailscale_ip` keys in `config.toml`.
+
+## Examples
+
+```bash
+# Detect for a specific host
+auberge host detect-tailscale-ip auberge
+
+# Interactive (prompts for host)
+auberge host detect-tailscale-ip
+```
+
+After running, `hosts.toml` gains a line like:
+
+```toml
+[[hosts]]
+name = "auberge"
+address = "203.0.113.10"
+# …
+tailscale_ip = "100.99.62.26"
+```
+
+## Failure modes
+
+- **SSH key not found**: run `auberge ssh keygen --host <name>` first.
+- **`tailscale` not on the remote `PATH`**: install Tailscale on the host (Auberge's `infrastructure` role does this).
+- **No CGNAT IPv4 returned**: the Tailscale daemon may not be `Running`; check `systemctl status tailscaled` on the host.
+
+## Related
+
+- [auberge dns set-all](../dns/set-all.md) — consumer of `tailscale_ip`
+- [Tailnet-only Subdomains](../../dns/batch-operations.md#tailnet-only-subdomains)
+- [Hosts Configuration](../../configuration/hosts.md)

--- a/docs/configuration/hosts.md
+++ b/docs/configuration/hosts.md
@@ -37,7 +37,12 @@ port = 22
 tags = ["production"]
 description = "Main VPS"
 ssh_key = "~/.ssh/identities/sripwoud_auberge"
+tailscale_ip = "100.99.62.26"  # optional, see below
 ```
+
+### Optional fields
+
+- `tailscale_ip` — cached Tailscale CGNAT IPv4 of the host. Populated by [`auberge host detect-tailscale-ip <name>`](../cli-reference/host/detect-tailscale-ip.md) and consumed by `auberge dns set-all` to auto-fill DNS records for tailnet-only apps without per-app overrides.
 
 ## Ansible Inventory (Recommended for developers)
 

--- a/docs/dns/batch-operations.md
+++ b/docs/dns/batch-operations.md
@@ -61,14 +61,36 @@ Some services should be reachable only by Tailscale network members while still 
 
 ### Configuration
 
-In `~/.config/auberge/config.toml`, set both a subdomain and a Tailscale IP for the app:
+There are two ways to tell `dns set-all` which IP to use for a tailnet-only app. Pick whichever fits your layout.
+
+**Option A — host-wide cache (recommended).** When all tailnet-only apps on a host share the same Tailscale IP, cache it once on the host record:
+
+```bash
+auberge host detect-tailscale-ip auberge
+```
+
+This SSHs the host, reads `tailscale ip -4`, and writes `tailscale_ip = "100.x.y.z"` into the host's entry in `~/.config/auberge/hosts.toml`. Apps whose playbook meta declares `tailnet_only: true` (currently `bichon` and `paperless`) then automatically pick up this IP — no per-app config needed.
+
+**Option B — per-app override.** Set both a subdomain and an explicit Tailscale IP in `~/.config/auberge/config.toml`:
 
 ```toml
 paperless_subdomain = "paperless"
 paperless_tailscale_ip = "100.x.y.z"
 ```
 
-When `<app>_tailscale_ip` is present, `dns set-all` automatically uses that IP for the app's A record instead of the server's public IP.
+Use this when an app needs a _different_ Tailscale IP than the host (rare).
+
+### Resolution chain
+
+For each subdomain, `dns set-all` picks the IP in this order:
+
+1. `<app>_tailscale_ip` in `config.toml` (per-app override, when set)
+2. `host.tailscale_ip` in `hosts.toml` (when the playbook meta has `tailnet_only: true` and `--host` was used)
+3. The host's public IP (default, public apps)
+
+Passing `--ip <addr>` bypasses (2) — when you're being explicit, the CLI does not second-guess.
+
+`dns set-all` bails fast when a tailnet-only app has no resolvable Tailscale IP, since pointing such DNS at the public IP would silently break access (Caddy binds only to the Tailnet interface).
 
 ### Prerequisites
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1526,6 +1526,7 @@ mod tests {
             description: None,
             python_interpreter: None,
             become_method: "sudo".to_string(),
+            tailscale_ip: None,
         }
     }
 

--- a/src/commands/dns.rs
+++ b/src/commands/dns.rs
@@ -309,6 +309,7 @@ pub async fn run_dns_set_all(
     continue_on_error: bool,
     production: bool,
 ) -> Result<()> {
+    use crate::hosts::HostManager;
     use crate::services::dns::{SubdomainEntry, discover_subdomains};
     use crate::services::inventory::discover_hosts_with_ips;
     use std::collections::HashSet;
@@ -341,7 +342,17 @@ pub async fn run_dns_set_all(
         _ => unreachable!(),
     };
 
+    // When `--host` is used, look up the host's cached Tailscale IP so we can
+    // auto-fill `ip_override` for tailnet-only apps. With `--ip` the user is
+    // being explicit; we don't second-guess.
+    let host_tailscale_ip: Option<String> = host
+        .as_deref()
+        .and_then(|name| HostManager::get_host(name).ok())
+        .and_then(|h| h.tailscale_ip);
+
     let mut discovered = discover_subdomains();
+
+    apply_tailnet_only_fallback(&mut discovered, host_tailscale_ip.as_deref())?;
 
     if strict && discovered.is_empty() {
         eyre::bail!("No subdomain environment variables found");
@@ -456,5 +467,115 @@ pub async fn run_dns_set_all(
         std::process::exit(1);
     }
 
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_tailnet_only_fallback;
+    use crate::services::dns::SubdomainEntry;
+    use std::collections::HashMap;
+
+    fn entry(subdomain: &str, ip_override: Option<&str>) -> SubdomainEntry {
+        SubdomainEntry {
+            subdomain: subdomain.to_string(),
+            ip_override: ip_override.map(String::from),
+        }
+    }
+
+    #[test]
+    fn fills_tailnet_only_app_when_host_has_tailscale_ip() {
+        let mut discovered = HashMap::new();
+        discovered.insert("bichon".to_string(), entry("bichon", None));
+
+        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
+
+        assert_eq!(
+            discovered["bichon"].ip_override.as_deref(),
+            Some("100.64.0.5")
+        );
+    }
+
+    #[test]
+    fn preserves_explicit_override_for_tailnet_only_app() {
+        let mut discovered = HashMap::new();
+        discovered.insert("bichon".to_string(), entry("bichon", Some("100.42.42.42")));
+
+        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
+
+        assert_eq!(
+            discovered["bichon"].ip_override.as_deref(),
+            Some("100.42.42.42"),
+        );
+    }
+
+    #[test]
+    fn leaves_public_app_unchanged_even_with_host_tailscale_ip() {
+        let mut discovered = HashMap::new();
+        discovered.insert("freshrss".to_string(), entry("rss", None));
+
+        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
+
+        assert!(discovered["freshrss"].ip_override.is_none());
+    }
+
+    #[test]
+    fn fails_fast_when_tailnet_only_app_has_no_tailscale_ip() {
+        let mut discovered = HashMap::new();
+        discovered.insert("bichon".to_string(), entry("bichon", None));
+
+        let err = apply_tailnet_only_fallback(&mut discovered, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("bichon"));
+        assert!(msg.contains("tailnet-only"));
+    }
+
+    #[test]
+    fn ignores_apps_with_missing_meta_files() {
+        let mut discovered = HashMap::new();
+        discovered.insert(
+            "nonexistent_app_xyz".to_string(),
+            entry("nonexistent_app_xyz", None),
+        );
+
+        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
+
+        assert!(discovered["nonexistent_app_xyz"].ip_override.is_none());
+    }
+}
+
+/// For each discovered subdomain whose playbook meta declares
+/// `tailnet_only: true` and which lacks an explicit `<app>_tailscale_ip`
+/// override, fill `ip_override` from the host's cached Tailscale IP.
+///
+/// Bails when a tailnet-only app has no resolvable Tailscale IP — pointing
+/// such an app at the host's public IP would be silently broken (Caddy binds
+/// only to the Tailscale interface), so failing fast surfaces the missing
+/// configuration to the user.
+fn apply_tailnet_only_fallback(
+    discovered: &mut std::collections::HashMap<String, crate::services::dns::SubdomainEntry>,
+    host_tailscale_ip: Option<&str>,
+) -> Result<()> {
+    use crate::playbook_meta::PlaybookMeta;
+
+    for (app, entry) in discovered.iter_mut() {
+        if entry.ip_override.is_some() {
+            continue;
+        }
+        let Some(meta) = PlaybookMeta::load_for_app(app)? else {
+            continue;
+        };
+        if !meta.tailnet_only {
+            continue;
+        }
+        match host_tailscale_ip {
+            Some(ip) => entry.ip_override = Some(ip.to_string()),
+            None => eyre::bail!(
+                "App '{app}' is tailnet-only but no Tailscale IP is available. \
+                 Either pass --host (after running `auberge host detect-tailscale-ip <name>`), \
+                 or set `{app}_tailscale_ip` in config.toml."
+            ),
+        }
+    }
     Ok(())
 }

--- a/src/commands/dns.rs
+++ b/src/commands/dns.rs
@@ -360,15 +360,13 @@ pub async fn run_dns_set_all(
 
     let mut discovered = discover_subdomains();
 
-    apply_tailnet_only_fallback(&mut discovered, host_tailscale_ip.as_deref())?;
-
     if strict && discovered.is_empty() {
         eyre::bail!("No subdomain environment variables found");
     }
 
     let skip_set: HashSet<_> = skip.iter().cloned().collect();
 
-    let subdomains_to_process: Vec<(String, SubdomainEntry)> = if !subdomains.is_empty() {
+    let mut subdomains_to_process: Vec<(String, SubdomainEntry)> = if !subdomains.is_empty() {
         subdomains
             .into_iter()
             .filter(|s| !skip_set.contains(s))
@@ -385,6 +383,11 @@ pub async fn run_dns_set_all(
         output::info("No subdomains to process");
         return Ok(());
     }
+
+    // Apply the tailnet-only fallback only to records that survived `--skip`
+    // / `--subdomains` filtering — otherwise an excluded tailnet-only app with
+    // no cached IP would still abort the run.
+    apply_tailnet_only_fallback(&mut subdomains_to_process, host_tailscale_ip.as_deref())?;
 
     if dry_run {
         output::info("DRY RUN - Would create the following A records:");
@@ -482,57 +485,57 @@ pub async fn run_dns_set_all(
 mod tests {
     use super::apply_tailnet_only_fallback;
     use crate::services::dns::SubdomainEntry;
-    use std::collections::HashMap;
 
-    fn entry(subdomain: &str, ip_override: Option<&str>) -> SubdomainEntry {
-        SubdomainEntry {
-            subdomain: subdomain.to_string(),
-            ip_override: ip_override.map(String::from),
-        }
+    fn entries(items: &[(&str, &str, Option<&str>)]) -> Vec<(String, SubdomainEntry)> {
+        items
+            .iter()
+            .map(|(app, subdomain, ip_override)| {
+                (
+                    app.to_string(),
+                    SubdomainEntry {
+                        subdomain: subdomain.to_string(),
+                        ip_override: ip_override.map(String::from),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn find<'a>(v: &'a [(String, SubdomainEntry)], app: &str) -> &'a SubdomainEntry {
+        &v.iter().find(|(a, _)| a == app).unwrap().1
     }
 
     #[test]
     fn fills_tailnet_only_app_when_host_has_tailscale_ip() {
-        let mut discovered = HashMap::new();
-        discovered.insert("bichon".to_string(), entry("bichon", None));
-
-        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
-
+        let mut v = entries(&[("bichon", "bichon", None)]);
+        apply_tailnet_only_fallback(&mut v, Some("100.64.0.5")).unwrap();
         assert_eq!(
-            discovered["bichon"].ip_override.as_deref(),
+            find(&v, "bichon").ip_override.as_deref(),
             Some("100.64.0.5")
         );
     }
 
     #[test]
     fn preserves_explicit_override_for_tailnet_only_app() {
-        let mut discovered = HashMap::new();
-        discovered.insert("bichon".to_string(), entry("bichon", Some("100.42.42.42")));
-
-        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
-
+        let mut v = entries(&[("bichon", "bichon", Some("100.42.42.42"))]);
+        apply_tailnet_only_fallback(&mut v, Some("100.64.0.5")).unwrap();
         assert_eq!(
-            discovered["bichon"].ip_override.as_deref(),
+            find(&v, "bichon").ip_override.as_deref(),
             Some("100.42.42.42"),
         );
     }
 
     #[test]
     fn leaves_public_app_unchanged_even_with_host_tailscale_ip() {
-        let mut discovered = HashMap::new();
-        discovered.insert("freshrss".to_string(), entry("rss", None));
-
-        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
-
-        assert!(discovered["freshrss"].ip_override.is_none());
+        let mut v = entries(&[("freshrss", "rss", None)]);
+        apply_tailnet_only_fallback(&mut v, Some("100.64.0.5")).unwrap();
+        assert!(find(&v, "freshrss").ip_override.is_none());
     }
 
     #[test]
     fn fails_fast_when_tailnet_only_app_has_no_tailscale_ip() {
-        let mut discovered = HashMap::new();
-        discovered.insert("bichon".to_string(), entry("bichon", None));
-
-        let err = apply_tailnet_only_fallback(&mut discovered, None).unwrap_err();
+        let mut v = entries(&[("bichon", "bichon", None)]);
+        let err = apply_tailnet_only_fallback(&mut v, None).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("bichon"));
         assert!(msg.contains("tailnet-only"));
@@ -540,19 +543,23 @@ mod tests {
 
     #[test]
     fn ignores_apps_with_missing_meta_files() {
-        let mut discovered = HashMap::new();
-        discovered.insert(
-            "nonexistent_app_xyz".to_string(),
-            entry("nonexistent_app_xyz", None),
-        );
+        let mut v = entries(&[("nonexistent_app_xyz", "nonexistent_app_xyz", None)]);
+        apply_tailnet_only_fallback(&mut v, Some("100.64.0.5")).unwrap();
+        assert!(find(&v, "nonexistent_app_xyz").ip_override.is_none());
+    }
 
-        apply_tailnet_only_fallback(&mut discovered, Some("100.64.0.5")).unwrap();
-
-        assert!(discovered["nonexistent_app_xyz"].ip_override.is_none());
+    #[test]
+    fn does_not_touch_entries_outside_the_processed_slice() {
+        // Simulates the post-filter behavior: when bichon was excluded via
+        // --skip, it's not in the slice, so even without a host_tailscale_ip
+        // we don't bail.
+        let mut v = entries(&[("freshrss", "rss", None)]);
+        apply_tailnet_only_fallback(&mut v, None).unwrap();
+        assert!(find(&v, "freshrss").ip_override.is_none());
     }
 }
 
-/// For each discovered subdomain whose playbook meta declares
+/// For each subdomain entry being processed whose playbook meta declares
 /// `tailnet_only: true` and which lacks an explicit `<app>_tailscale_ip`
 /// override, fill `ip_override` from the host's cached Tailscale IP.
 ///
@@ -561,12 +568,12 @@ mod tests {
 /// only to the Tailscale interface), so failing fast surfaces the missing
 /// configuration to the user.
 fn apply_tailnet_only_fallback(
-    discovered: &mut std::collections::HashMap<String, crate::services::dns::SubdomainEntry>,
+    entries: &mut [(String, crate::services::dns::SubdomainEntry)],
     host_tailscale_ip: Option<&str>,
 ) -> Result<()> {
     use crate::playbook_meta::PlaybookMeta;
 
-    for (app, entry) in discovered.iter_mut() {
+    for (app, entry) in entries.iter_mut() {
         if entry.ip_override.is_some() {
             continue;
         }

--- a/src/commands/dns.rs
+++ b/src/commands/dns.rs
@@ -345,10 +345,18 @@ pub async fn run_dns_set_all(
     // When `--host` is used, look up the host's cached Tailscale IP so we can
     // auto-fill `ip_override` for tailnet-only apps. With `--ip` the user is
     // being explicit; we don't second-guess.
-    let host_tailscale_ip: Option<String> = host
-        .as_deref()
-        .and_then(|name| HostManager::get_host(name).ok())
-        .and_then(|h| h.tailscale_ip);
+    //
+    // `load_hosts()?` propagates parse/IO errors so a malformed `hosts.toml`
+    // surfaces here instead of being silently treated as "no cached IP" —
+    // missing-host vs malformed-file diverge intentionally.
+    let host_tailscale_ip: Option<String> = if let Some(name) = host.as_deref() {
+        HostManager::load_hosts()?
+            .into_iter()
+            .find(|h| h.name == name)
+            .and_then(|h| h.tailscale_ip)
+    } else {
+        None
+    };
 
     let mut discovered = discover_subdomains();
 

--- a/src/commands/dns.rs
+++ b/src/commands/dns.rs
@@ -387,7 +387,12 @@ pub async fn run_dns_set_all(
     // Apply the tailnet-only fallback only to records that survived `--skip`
     // / `--subdomains` filtering — otherwise an excluded tailnet-only app with
     // no cached IP would still abort the run.
-    apply_tailnet_only_fallback(&mut subdomains_to_process, host_tailscale_ip.as_deref())?;
+    //
+    // Skip entirely when `--ip` was used: the user is being explicit and the
+    // host-cache fallback should not second-guess (or bail on) that.
+    if host.is_some() {
+        apply_tailnet_only_fallback(&mut subdomains_to_process, host_tailscale_ip.as_deref())?;
+    }
 
     if dry_run {
         output::info("DRY RUN - Would create the following A records:");

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -236,6 +236,7 @@ pub fn run_host_add(args: AddHostArgs) -> Result<()> {
         description: args.description,
         python_interpreter: None,
         become_method: "sudo".to_string(),
+        tailscale_ip: None,
     };
 
     HostManager::add_host(host)?;
@@ -359,6 +360,7 @@ pub fn run_host_edit(name: String) -> Result<()> {
         },
         python_interpreter: host.python_interpreter,
         become_method: host.become_method,
+        tailscale_ip: host.tailscale_ip,
     };
 
     HostManager::update_host(&name, updated_host)?;

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -1,9 +1,11 @@
 use crate::hosts::{Host, HostManager};
 use crate::output;
 use crate::prompt::{confirm, select_item};
+use crate::ssh_session::SshSession;
 use clap::Subcommand;
 use dialoguer::{Input, theme::ColorfulTheme};
 use eyre::Result;
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use tabled::Tabled;
 
@@ -90,6 +92,14 @@ pub enum HostCommands {
     Edit {
         #[arg(help = "Host name")]
         name: String,
+    },
+    #[command(
+        alias = "dti",
+        about = "Detect and cache the host's Tailscale IPv4 (queries the host via SSH)"
+    )]
+    DetectTailscaleIp {
+        #[arg(help = "Host name (omit to be prompted)")]
+        name: Option<String>,
     },
 }
 
@@ -306,6 +316,79 @@ pub fn run_host_show(name: String, output: Option<String>) -> Result<()> {
     Ok(())
 }
 
+pub fn run_host_detect_tailscale_ip(name_arg: Option<String>) -> Result<()> {
+    let host = crate::hosts::select_or_arg(name_arg)?;
+    let ssh_key = resolve_ssh_key(&host)?;
+    let session = SshSession::new(&host, &ssh_key);
+
+    output::info(&format!(
+        "Querying Tailscale IPv4 on {}@{}…",
+        host.user, host.address
+    ));
+
+    let out = session.run("tailscale ip -4")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let stderr = stderr.trim();
+        if stderr.is_empty() {
+            eyre::bail!("`tailscale ip -4` failed on {}", host.name);
+        }
+        eyre::bail!("`tailscale ip -4` failed on {}: {}", host.name, stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let detected = parse_tailscale_cgnat_ipv4(&stdout).ok_or_else(|| {
+        eyre::eyre!(
+            "No Tailscale CGNAT IPv4 found in `tailscale ip -4` output for {}: {:?}",
+            host.name,
+            stdout.trim()
+        )
+    })?;
+
+    let mut updated = host.clone();
+    updated.tailscale_ip = Some(detected.clone());
+    HostManager::update_host(&host.name, updated)?;
+
+    output::success(&format!(
+        "Cached tailscale_ip={} for host '{}'",
+        detected, host.name
+    ));
+    Ok(())
+}
+
+fn resolve_ssh_key(host: &Host) -> Result<PathBuf> {
+    let key = match host.ssh_key.as_ref() {
+        Some(p) => PathBuf::from(p),
+        None => dirs::home_dir()
+            .ok_or_else(|| eyre::eyre!("Could not determine home directory"))?
+            .join(format!(".ssh/identities/{}_{}", host.user, host.name)),
+    };
+    if !key.exists() {
+        eyre::bail!(
+            "SSH key not found: {}. Run 'auberge ssh keygen --host {}' first.",
+            key.display(),
+            host.name
+        );
+    }
+    Ok(key)
+}
+
+fn parse_tailscale_cgnat_ipv4(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .find_map(|line| {
+            let addr = line.parse::<Ipv4Addr>().ok()?;
+            is_cgnat_ipv4(&addr).then(|| addr.to_string())
+        })
+}
+
+fn is_cgnat_ipv4(addr: &Ipv4Addr) -> bool {
+    let octets = addr.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
 pub fn run_host_edit(name: String) -> Result<()> {
     let host = HostManager::get_host(&name)?;
 
@@ -367,4 +450,49 @@ pub fn run_host_edit(name: String) -> Result<()> {
     output::success(&format!("Host '{}' updated", name));
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cgnat_classification() {
+        assert!(is_cgnat_ipv4(&"100.64.0.1".parse().unwrap()));
+        assert!(is_cgnat_ipv4(&"100.99.62.26".parse().unwrap()));
+        assert!(is_cgnat_ipv4(&"100.127.255.254".parse().unwrap()));
+
+        assert!(!is_cgnat_ipv4(&"100.63.255.255".parse().unwrap()));
+        assert!(!is_cgnat_ipv4(&"100.128.0.0".parse().unwrap()));
+        assert!(!is_cgnat_ipv4(&"10.0.0.1".parse().unwrap()));
+        assert!(!is_cgnat_ipv4(&"192.168.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn parses_first_cgnat_ipv4_from_tailscale_output() {
+        let stdout = "100.99.62.26\n";
+        assert_eq!(
+            parse_tailscale_cgnat_ipv4(stdout),
+            Some("100.99.62.26".to_string())
+        );
+    }
+
+    #[test]
+    fn skips_blank_lines_and_non_cgnat_lines() {
+        let stdout = "\n203.0.113.10\n100.99.62.26\nfd7a:115c:a1e0::1\n";
+        assert_eq!(
+            parse_tailscale_cgnat_ipv4(stdout),
+            Some("100.99.62.26".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_cgnat_present() {
+        assert_eq!(parse_tailscale_cgnat_ipv4(""), None);
+        assert_eq!(parse_tailscale_cgnat_ipv4("203.0.113.10\n"), None);
+        assert_eq!(
+            parse_tailscale_cgnat_ipv4("not-an-ip\nfd7a:115c:a1e0::1\n"),
+            None
+        );
+    }
 }

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -358,7 +358,7 @@ pub fn run_host_detect_tailscale_ip(name_arg: Option<String>) -> Result<()> {
 
 fn resolve_ssh_key(host: &Host) -> Result<PathBuf> {
     let key = match host.ssh_key.as_ref() {
-        Some(p) => PathBuf::from(p),
+        Some(p) => PathBuf::from(shellexpand::tilde(p).into_owned()),
         None => dirs::home_dir()
             .ok_or_else(|| eyre::eyre!("Could not determine home directory"))?
             .join(format!(".ssh/identities/{}_{}", host.user, host.name)),

--- a/src/hosts.rs
+++ b/src/hosts.rs
@@ -21,6 +21,8 @@ pub struct Host {
     pub python_interpreter: Option<String>,
     #[serde(default = "default_become_method")]
     pub become_method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tailscale_ip: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -183,6 +185,7 @@ mod tests {
             description: Some("Test host".to_string()),
             python_interpreter: None,
             become_method: "sudo".to_string(),
+            tailscale_ip: None,
         };
 
         let config = HostsConfig { hosts: vec![host] };
@@ -208,5 +211,47 @@ mod tests {
         assert_eq!(config.hosts[0].port, 22);
         assert_eq!(config.hosts[0].become_method, "sudo");
         assert!(config.hosts[0].tags.is_empty());
+        assert!(config.hosts[0].tailscale_ip.is_none());
+    }
+
+    #[test]
+    fn test_tailscale_ip_round_trip() {
+        let host = Host {
+            name: "vps".to_string(),
+            address: "203.0.113.10".to_string(),
+            user: "admin".to_string(),
+            port: 22,
+            ssh_key: None,
+            tags: vec![],
+            description: None,
+            python_interpreter: None,
+            become_method: "sudo".to_string(),
+            tailscale_ip: Some("100.64.0.5".to_string()),
+        };
+
+        let serialized = toml::to_string(&HostsConfig { hosts: vec![host] }).unwrap();
+        assert!(serialized.contains("tailscale_ip = \"100.64.0.5\""));
+
+        let parsed: HostsConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(parsed.hosts[0].tailscale_ip.as_deref(), Some("100.64.0.5"));
+    }
+
+    #[test]
+    fn test_tailscale_ip_omitted_when_none() {
+        let host = Host {
+            name: "vps".to_string(),
+            address: "203.0.113.10".to_string(),
+            user: "admin".to_string(),
+            port: 22,
+            ssh_key: None,
+            tags: vec![],
+            description: None,
+            python_interpreter: None,
+            become_method: "sudo".to_string(),
+            tailscale_ip: None,
+        };
+
+        let serialized = toml::to_string(&HostsConfig { hosts: vec![host] }).unwrap();
+        assert!(!serialized.contains("tailscale_ip"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ use commands::headscale::{
     run_headscale_remove_user,
 };
 use commands::host::{
-    AddHostArgs, HostCommands, run_host_add, run_host_edit, run_host_list, run_host_remove,
-    run_host_show,
+    AddHostArgs, HostCommands, run_host_add, run_host_detect_tailscale_ip, run_host_edit,
+    run_host_list, run_host_remove, run_host_show,
 };
 use commands::select::{SelectCommands, run_select_host, run_select_playbook};
 use commands::ssh::{SshCommands, run_ssh_add_key, run_ssh_keygen};
@@ -133,6 +133,7 @@ async fn main() -> Result<()> {
             HostCommands::Remove { name, yes } => run_host_remove(name, yes),
             HostCommands::Show { name, output } => run_host_show(name, output),
             HostCommands::Edit { name } => run_host_edit(name),
+            HostCommands::DetectTailscaleIp { name } => run_host_detect_tailscale_ip(name),
         },
         Commands::Ansible(cmd) => match cmd {
             AnsibleCommands::Run {

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -66,6 +66,17 @@ impl PlaybookMeta {
         serde_yaml::from_str(&contents)
             .wrap_err_with(|| format!("Failed to parse Playbook Meta from {}", path.display()))
     }
+
+    /// Load the meta for an app/playbook by stem name (e.g. `"bichon"`).
+    /// Returns `Ok(None)` if no meta file exists.
+    pub fn load_for_app(app: &str) -> Result<Option<Self>> {
+        let assets = crate::ansible_assets::AnsibleAssets::prepare()?;
+        let path = assets.playbooks_dir().join(format!("{app}.meta.yml"));
+        if !path.exists() {
+            return Ok(None);
+        }
+        Self::load(&path).map(Some)
+    }
 }
 
 #[cfg(test)]

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -9,6 +9,8 @@ pub struct PlaybookMeta {
     pub required_keys: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backup: Option<BackupRecipe>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub tailnet_only: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -303,6 +305,25 @@ mod tests {
         let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(meta.required_keys, vec!["foo", "bar"]);
         assert!(meta.backup.is_none());
+        assert!(!meta.tailnet_only);
+    }
+
+    #[test]
+    fn test_bichon_meta_is_tailnet_only() {
+        let meta = load_meta("bichon");
+        assert!(meta.tailnet_only);
+    }
+
+    #[test]
+    fn test_paperless_meta_is_tailnet_only() {
+        let meta = load_meta("paperless");
+        assert!(meta.tailnet_only);
+    }
+
+    #[test]
+    fn test_public_app_meta_defaults_to_not_tailnet_only() {
+        let meta = load_meta("freshrss");
+        assert!(!meta.tailnet_only);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes the need to declare `<app>_tailscale_ip` per app in `config.toml` for every tailnet-only service that lives on the same host. Tailscale IPs are now cached on the host record (`hosts.toml`) and consumed automatically by `auberge dns set-all`.

## Why

Today, every tailnet-only app (paperless, bichon, …) requires its own `<app>_tailscale_ip` key in `config.toml`. With multiple such apps on one VPS that's pure duplication — and easy to forget when adding a new private app, which then silently breaks because Caddy binds only to the Tailnet interface while DNS points at the public IP.

## Design

Two pieces of new state, one piece of new behaviour:

- **Host record** now carries an optional `tailscale_ip` field (cached value, populated once per host).
- **Playbook meta** declares `tailnet_only: true` for apps whose Caddy config binds only to the Tailnet interface (set on `bichon` and `paperless`).
- **`auberge dns set-all --host <name>`** auto-fills `ip_override` for any subdomain whose meta is `tailnet_only: true` and which lacks an explicit `<app>_tailscale_ip` override, using `host.tailscale_ip`. Bails fast when a tailnet-only app has no resolvable Tailscale IP rather than silently pointing DNS at the public IP.

A new subcommand `auberge host detect-tailscale-ip <name>` SSHs the host, runs `tailscale ip -4`, picks the first CGNAT IPv4, and persists it.

## Resolution chain

For each subdomain in `dns set-all`:

1. `<app>_tailscale_ip` from `config.toml` (explicit per-app override) — wins when set
2. `host.tailscale_ip` from `hosts.toml` (when `meta.tailnet_only` is true and `--host` was used)
3. The host's public IP (default, public apps)

`--ip <addr>` bypasses (2) — when the user is being explicit, we don't second-guess.

## Commits

- `feat(hosts): add optional tailscale_ip field to Host` — schema only
- `feat(host): add \`host detect-tailscale-ip\` subcommand` — populator
- `feat(playbook-meta): add \`tailnet_only\` flag and mark bichon/paperless` — declarative signal
- `feat(dns): fall back to host.tailscale_ip for tailnet-only apps` — wiring + tests

## Test plan

- [x] Existing 252 tests still pass; 12 new tests added (264 total green)
- [x] `cargo build` clean (no new warnings)
- [x] `clippy`, `dprint`, and `ansible-lint` pre-commit hooks pass on each commit
- [ ] Manual: run `auberge host detect-tailscale-ip auberge` against the live VPS and confirm `~/.config/auberge/hosts.toml` gains a `tailscale_ip` line
- [ ] Manual: run `auberge dns set-all --host auberge --dry-run` after removing `paperless_tailscale_ip` from `config.toml` and confirm paperless still points at the cached Tailscale IP
- [ ] Manual: deploy bichon end-to-end with no `bichon_tailscale_ip` set and confirm DNS points at the Tailscale CGNAT IP