### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/sripwoud/auberge/compare/v0.10.1...v0.10.2) - 2026-05-05
+
+### Added
+
+- *(dns)* auto-fill tailnet-only DNS overrides from host tailscale_ip cache ([#282](https://github.com/sripwoud/auberge/pull/282))
+
 ## [0.10.1](https://github.com/sripwoud/auberge/compare/v0.10.0...v0.10.1) - 2026-05-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.10.1 -> 0.10.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.2](https://github.com/sripwoud/auberge/compare/v0.10.1...v0.10.2) - 2026-05-05

### Added

- *(dns)* auto-fill tailnet-only DNS overrides from host tailscale_ip cache ([#282](https://github.com/sripwoud/auberge/pull/282))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).