### PR TITLE
fix(bichon): correct upstream release URL pattern

### DIFF
--- a/ansible/roles/bichon/defaults/main.yml
+++ b/ansible/roles/bichon/defaults/main.yml
@@ -15,4 +15,4 @@ bichon_domain: "{{ bichon_subdomain }}.{{ domain }}"
 bichon_public_url: "https://{{ bichon_domain }}"
 bichon_encrypt_password_file: "{{ bichon_install_dir }}/encrypt.password"
 
-bichon_release_url: "https://github.com/rustmailer/bichon/releases/download/v{{ bichon_version }}/bichon-x86_64-unknown-linux-gnu.tar.gz"
+bichon_release_url: "https://github.com/rustmailer/bichon/releases/download/{{ bichon_version }}/bichon-{{ bichon_version }}-x86_64-unknown-linux-gnu.tar.gz"


### PR DESCRIPTION
## Summary

- Upstream `rustmailer/bichon` tags releases as bare `{version}` (no `v` prefix) and names assets `bichon-{version}-{target}.tar.gz`
- The role's `bichon_release_url` was wrong since the role landed in #121 — never noticed because the `bichon_installed_version != bichon_version` upgrade gate was always false on subsequent runs after the initial install
- Re-running deploy with a new `bichon_version` now triggers a real download → 404

## Repro

Before fix:
```
HTTP Error 404: Not Found
url: https://github.com/rustmailer/bichon/releases/download/v0.3.7/bichon-x86_64-unknown-linux-gnu.tar.gz
```

After fix the URL resolves to:
```
https://github.com/rustmailer/bichon/releases/download/0.3.7/bichon-0.3.7-x86_64-unknown-linux-gnu.tar.gz
```

Verified the tarball layout is flat (`./bichon`, `./bichonctl`, `./bichon-admin`, `./LICENSE`, `./README.md`), so the existing `unarchive` task continues to work without changes.

## Test plan

- [ ] `auberge deploy` against an auberge host with bichon enabled completes without HTTP 404
- [ ] `systemctl status bichon` reports active on the target host
- [ ] `/opt/bichon/version` matches `bichon_version`