### PR TITLE
chore: release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/sripwoud/auberge/compare/v0.10.2...v0.10.3) - 2026-05-05
+
+### Added
+
+- runtime DNS verification at end of `auberge deploy` ([#296](https://github.com/sripwoud/auberge/pull/296))
+- *(cli)* add --no-color flag and centralize color handling ([#298](https://github.com/sripwoud/auberge/pull/298))
+- *(cli)* make positional args optional with interactive prompts ([#293](https://github.com/sripwoud/auberge/pull/293))
+- *(dns)* add delete subcommand ([#292](https://github.com/sripwoud/auberge/pull/292))
+- *(dns)* publish tailnet-only apps via blocky and headscale split-DNS ([#290](https://github.com/sripwoud/auberge/pull/290))
+
+### Fixed
+
+- *(bichon)* correct upstream release URL pattern ([#285](https://github.com/sripwoud/auberge/pull/285))
+
+### Other
+
+- *(dns)* drop Cloudflare records for paperless and cockpit ([#299](https://github.com/sripwoud/auberge/pull/299))
+- update adr
+- update adr
+
 ## [0.10.2](https://github.com/sripwoud/auberge/compare/v0.10.1...v0.10.2) - 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.10.2 -> 0.10.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.3](https://github.com/sripwoud/auberge/compare/v0.10.2...v0.10.3) - 2026-05-05

### Added

- runtime DNS verification at end of `auberge deploy` ([#296](https://github.com/sripwoud/auberge/pull/296))
- *(cli)* add --no-color flag and centralize color handling ([#298](https://github.com/sripwoud/auberge/pull/298))
- *(cli)* make positional args optional with interactive prompts ([#293](https://github.com/sripwoud/auberge/pull/293))
- *(dns)* add delete subcommand ([#292](https://github.com/sripwoud/auberge/pull/292))
- *(dns)* publish tailnet-only apps via blocky and headscale split-DNS ([#290](https://github.com/sripwoud/auberge/pull/290))

### Fixed

- *(bichon)* correct upstream release URL pattern ([#285](https://github.com/sripwoud/auberge/pull/285))

### Other

- *(dns)* drop Cloudflare records for paperless and cockpit ([#299](https://github.com/sripwoud/auberge/pull/299))
- update adr
- update adr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).