### PR TITLE
chore(lint): address all clippy warnings

### DIFF
--- a/src/commands/ansible.rs
+++ b/src/commands/ansible.rs
@@ -87,6 +87,7 @@ fn select_or_use_playbook(playbook_arg: Option<PathBuf>) -> Result<PathBuf> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_ansible_run(
     host: Option<String>,
     playbook: Option<PathBuf>,
@@ -240,6 +241,7 @@ fn run_auto_resolved(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_single_playbook(
     host: &Host,
     playbook: &Path,

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -153,11 +153,9 @@ pub fn run_host_add(args: AddHostArgs) -> Result<()> {
 
         select_item(
             &options,
-            |h: &crate::ssh_config::SshConfigHost| {
-                if h.hostname.is_none() {
-                    "Enter manually".to_string()
-                } else {
-                    let addr = h.hostname.as_ref().unwrap();
+            |h: &crate::ssh_config::SshConfigHost| match &h.hostname {
+                None => "Enter manually".to_string(),
+                Some(addr) => {
                     let port = h.port.unwrap_or(22);
                     format!("{} ({}:{})", h.name, addr, port)
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ const DEFAULT_TTL: u32 = 300;
 /// Acts as the Key Registry entry for a given playbook.
 #[derive(Debug)]
 pub struct PlaybookMeta {
+    #[allow(dead_code)]
     pub name: String,
     pub required_keys: Vec<String>,
 }
@@ -87,11 +88,13 @@ fn tag_required_keys(tag: &str) -> &[&'static str] {
 /// which guarantees all required keys are present and resolved.
 #[derive(Debug)]
 pub struct Preflight {
+    #[allow(dead_code)]
     meta: PlaybookMeta,
     flat_vars: HashMap<String, String>,
 }
 
 impl Preflight {
+    #[allow(dead_code)]
     pub fn meta(&self) -> &PlaybookMeta {
         &self.meta
     }
@@ -177,13 +180,6 @@ impl Config {
 
     pub fn get(&self, key: &str) -> Option<String> {
         self.values.get(key).and_then(value_to_string)
-    }
-
-    /// Returns the resolved value for `key`, executing shell commands for
-    /// values prefixed with `!`.  Suitable for sensitive keys stored via
-    /// secret managers (e.g. `restic_password = "!pass auberge/restic"`).
-    pub fn get_secret(&self, key: &str) -> Result<Option<String>> {
-        self.get_resolved(key)
     }
 
     pub fn get_resolved(&self, key: &str) -> Result<Option<String>> {
@@ -600,7 +596,7 @@ mod tests {
         assert!(flat.get("broken_key").is_none());
     }
 
-    // ── get_resolved / get_secret ─────────────────────────────────────────────
+    // ── get_resolved ──────────────────────────────────────────────────────────
 
     #[test]
     fn test_get_resolved_plain_value() {

--- a/src/key_registry.rs
+++ b/src/key_registry.rs
@@ -36,21 +36,25 @@ impl KeyRegistry {
     }
 
     /// Returns the entry for a key by name, if it exists.
+    #[allow(dead_code)]
     pub fn get(&self, key: &str) -> Option<&KeyEntry> {
         self.entries.get(key)
     }
 
     /// Returns an iterator over all (name, entry) pairs in the registry.
+    #[allow(dead_code)]
     pub fn iter(&self) -> impl Iterator<Item = (&String, &KeyEntry)> {
         self.entries.iter()
     }
 
     /// Returns the number of keys in the registry.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
     /// Returns `true` if the registry contains no keys.
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -141,7 +141,7 @@ pub fn run_piped(label: &str, cmd: &mut Command) -> Result<SubprocessResult> {
     std::thread::scope(|s| {
         s.spawn(move || {
             let reader = BufReader::new(stdout);
-            for line in reader.lines().flatten() {
+            for line in reader.lines().map_while(Result::ok) {
                 if emit_subprocess_line(&label_owned, &line) {
                     count_clone.fetch_add(1, Ordering::Relaxed);
                 }
@@ -149,7 +149,7 @@ pub fn run_piped(label: &str, cmd: &mut Command) -> Result<SubprocessResult> {
         });
 
         let reader = BufReader::new(stderr);
-        for line in reader.lines().flatten() {
+        for line in reader.lines().map_while(Result::ok) {
             if emit_subprocess_line(label, &line) {
                 line_count.fetch_add(1, Ordering::Relaxed);
             }

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -88,6 +88,7 @@ fn write_inventory_file(host: &InventoryHost) -> Result<tempfile::NamedTempFile>
     Ok(tmpfile)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_playbook(
     preflight: &Preflight,
     playbook: &Path,

--- a/src/services/backup/executor.rs
+++ b/src/services/backup/executor.rs
@@ -5,6 +5,7 @@ use eyre::Result;
 use std::collections::HashMap;
 use std::path::Path;
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 pub struct RsyncProgress {
     pub bytes_transferred: u64,
@@ -13,6 +14,7 @@ pub struct RsyncProgress {
     pub eta: String,
 }
 
+#[allow(dead_code)]
 pub fn parse_rsync_progress(line: &str) -> Option<RsyncProgress> {
     let line = line.trim_end_matches('\r');
     let fields: Vec<&str> = line.split_whitespace().collect();

--- a/src/services/backup/ssh.rs
+++ b/src/services/backup/ssh.rs
@@ -7,12 +7,14 @@ use std::process::Command;
 #[derive(Debug, Clone)]
 pub struct CommandResult {
     pub success: bool,
+    #[allow(dead_code)]
     pub exit_code: Option<i32>,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
 }
 
 impl CommandResult {
+    #[allow(dead_code)]
     pub fn ok() -> Self {
         Self {
             success: true,


### PR DESCRIPTION
## Summary
- replace `lines().flatten()` with `map_while(Result::ok)` to avoid silently ignoring read errors (`output.rs`)
- replace `is_none()` + `as_ref().unwrap()` with a `match` on `hostname` (`host.rs`)
- silence `dead_code` for fields/methods kept as conceptual API surface (`config.rs`, `key_registry.rs`, `services/backup/*`)
- delete unused `Config::get_secret` (thin alias for `get_resolved` with no callers)
- silence `clippy::too_many_arguments` on `run_ansible_run`, `run_single_playbook`, `run_playbook`, matching the existing convention in `commands/dns.rs`

## Test plan
- [x] `mise run lint-rust` → no warnings
- [x] `mise run test` → 281/281 pass