### PR TITLE
fix(dns): resolve cloudflare token via secret reference

### DIFF
--- a/src/services/dns.rs
+++ b/src/services/dns.rs
@@ -88,7 +88,7 @@ impl DnsService {
         let config = Config::load()?;
 
         let api_token = config
-            .get("cloudflare_dns_api_token")
+            .get_secret("cloudflare_dns_api_token")?
             .filter(|v| !v.is_empty())
             .ok_or_else(|| eyre::eyre!("cloudflare_dns_api_token not set in config"))?;
 


### PR DESCRIPTION
## Summary
- `DnsService::new_with_production` read `cloudflare_dns_api_token` via `Config::get()`, which returns the raw TOML value. When the token is stored as a `!`-prefixed secret reference (e.g. `!pass auberge/cloudflare-dns-token`), the literal string was sent as the Bearer token, so every DNS subcommand failed with Cloudflare error `6111: Invalid format for Authorization header` (HTTP 400).
- Switch to `Config::get_secret()`, which executes the shell command and returns the resolved token. This matches the resolution path Ansible runs already use via `flatten_for_ansible` → `flatten_toml` → `resolve_value`.

## Repro (before)
```
$ auberge dns delete -s cockpit
Error:
   0: Failed to list zones: HTTP 400 Bad Request
      6003: Invalid request headers ({"error_chain": Array [Object {"code": Number(6111), "message": String("Invalid format for Authorization header")}]})
```

## Test plan
- [x] `cargo build` — clean (only pre-existing warnings).
- [x] `cargo test` — 281/281 passing.
- [ ] Manual: `auberge dns status`, `auberge dns delete -s <sub>` with a `!pass …` token in `~/.config/auberge/config.toml`.