### PR TITLE
fix(dns): call existing get_resolved instead of nonexistent get_secret

### DIFF
--- a/src/services/dns.rs
+++ b/src/services/dns.rs
@@ -89,7 +89,7 @@ impl DnsService {
         let config = Config::load()?;
 
         let api_token = config
-            .get_secret("cloudflare_dns_api_token")?
+            .get_resolved("cloudflare_dns_api_token")?
             .filter(|v| !v.is_empty())
             .ok_or_else(|| eyre::eyre!("cloudflare_dns_api_token not set in config"))?;
 


### PR DESCRIPTION
## Summary
- PR #305 introduced a call to `Config::get_secret`, a method that does not exist on `Config`.
- The tree has failed to compile since #305 merged — `cargo test`, `cargo build`, and `mise run test` all error out at `src/services/dns.rs:92` with `E0599: no method named get_secret found for struct Config`.
- The intended API is `Config::get_resolved`, which runs `resolve_value` on the raw TOML string and handles the `!`-prefixed shell-command secret references the original PR was wiring up.

## Root cause
The commit message of #305 said "Switch to `Config::get_secret()`", but no such method was ever added — the helper was named `get_resolved` from the start (introduced in `843165e refactor(config): merge Config+UserConfig...`). This appears to have slipped past CI; worth confirming whether `cargo test` is actually gating PRs on `master`.

## Test plan
- [x] `mise run test` passes locally (301 tests run, 301 passed, 1 skipped)
- [x] `cargo clippy` and `dprint fmt` clean (pre-commit hooks)
- [ ] CI green on this PR