### PR TITLE
fix(blocky): honor operator <app>_subdomain override in tailnet FQDN

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,7 +37,7 @@ An application deployed by a Playbook (e.g. paperless, navidrome, baikal). An Ap
 _Avoid_: Service, package, workload
 
 **Tailnet-only App**:
-An App whose Playbook Meta declares `tailnet_only: true` (and a `subdomain:` field for FQDN composition). Caddy binds only to the host's Tailscale interface; the App's hostname is published only via Blocky's `customDNS` map — derived at deploy time from the meta files of all `tailnet_only` Apps — and does _not_ appear in public DNS. Reachable only by clients on the user's tailnet, via Blocky as resolver. Headscale's `dns.nameservers.split` routes `*.{{ domain }}` queries to Blocky so every tailnet client uses Blocky for the user's domain without manual client-side DoT setup.
+An App whose Playbook Meta declares `tailnet_only: true` (and a `subdomain:` field as the canonical default for FQDN composition). Caddy binds only to the host's Tailscale interface; the App's hostname is published only via Blocky's `customDNS` map — derived at deploy time from the meta files of all `tailnet_only` Apps, with the operator's `<app>_subdomain` in `config.toml` taking precedence over `meta.subdomain` when defined — and does _not_ appear in public DNS. Reachable only by clients on the user's tailnet, via Blocky as resolver. Headscale's `dns.nameservers.split` routes `*.{{ domain }}` queries to Blocky so every tailnet client uses Blocky for the user's domain without manual client-side DoT setup.
 _Avoid_: Private app, internal app, vpn-only app
 
 **Public App**:

--- a/ansible/roles/blocky/tasks/main.yml
+++ b/ansible/roles/blocky/tasks/main.yml
@@ -176,19 +176,26 @@
   loop: "{{ blocky_meta_files_found.files }}"
   register: blocky_meta_slurped
 
-- name: Derive blocky_tailscale_bound_domains from tailnet-only meta files
+- name: Initialize blocky_tailscale_bound_domains
+  run_once: true
+  ansible.builtin.set_fact:
+    blocky_tailscale_bound_domains: []
+
+- name: Append tailnet-only FQDN per meta with operator-override resolution
   run_once: true
   vars:
-    parsed_metas: "{{ blocky_meta_slurped.results | map(attribute='content') | map('b64decode') | map('from_yaml') | list }}"
+    parsed: "{{ item.content | b64decode | from_yaml }}"
+    app_name: "{{ item.source | basename | regex_replace('\\.meta\\.yml$', '') }}"
+    override_var: "{{ app_name + '_subdomain' }}"
+    effective_subdomain: "{{ lookup('vars', override_var, default=parsed.subdomain | default('')) }}"
   ansible.builtin.set_fact:
-    blocky_tailscale_bound_domains: >-
-      {{ parsed_metas
-         | selectattr('tailnet_only', 'defined')
-         | selectattr('tailnet_only', 'equalto', true)
-         | selectattr('subdomain', 'defined')
-         | map(attribute='subdomain')
-         | map('regex_replace', '^(.+)$', '\1.' + domain)
-         | list }}
+    blocky_tailscale_bound_domains: "{{ blocky_tailscale_bound_domains + [effective_subdomain + '.' + domain] }}"
+  when:
+    - parsed.tailnet_only | default(false)
+    - effective_subdomain | length > 0
+  loop: "{{ blocky_meta_slurped.results }}"
+  loop_control:
+    label: "{{ item.source | basename }}"
 
 - name: Configure blocky
   ansible.builtin.template:

--- a/meta/adr/0003-tailnet-only-app-dns.md
+++ b/meta/adr/0003-tailnet-only-app-dns.md
@@ -49,9 +49,16 @@ Three problems accumulated:
 
 ## Implementation notes
 
-### `subdomain` lives in the Playbook Meta
+### `subdomain` lives in the Playbook Meta, with operator override
 
-The Blocky role composes each tailnet-only FQDN from `<meta.subdomain>.<domain>`. Subdomains are otherwise available only as role-default variables (`<app>_subdomain`), which are not in scope when the Blocky role runs (Ansible role defaults are scoped to their owning role). An earlier draft used `lookup('vars', ...)` with a `default=app` fallback, but that worked only because every default happened to equal the app name — silently broken if a role default ever diverged. Promoting `subdomain` to the Playbook Meta puts the FQDN's identity next to the `tailnet_only` flag that gates its publication, eliminating that latent inconsistency. Public Apps may still rely on role defaults; only tailnet-only Apps need the meta declaration.
+The Blocky role composes each tailnet-only FQDN as `<effective_subdomain>.<domain>`, where `effective_subdomain = lookup('vars', '<app>_subdomain', default=meta.subdomain)`. The meta's `subdomain` field is the canonical _default_; the operator's `<app>_subdomain` in `config.toml` (which the CLI propagates to Ansible as an extra-var) is the _override_.
+
+Why both layers:
+
+- Caddy and the TLS-via-DNS-01 cert flow already consume the operator override via the role-default → extra-var precedence (extra-vars beat defaults). For Blocky's FQDN to match Caddy's vhost and the cert's SAN, Blocky must consult the same override.
+- An earlier draft used `lookup('vars', ...)` with `default=app` as the _only_ source. That worked only because every role default happened to equal the app name and would have silently broken if a default ever diverged. Promoting `subdomain` to the meta gave a non-fragile default; layering the override on top restores the operator-renaming UX without reintroducing the original fragility — the meta is consulted unconditionally as the fallback, so a missing extra-var is no longer a silent failure.
+
+App identity for the override lookup is derived from the meta filename (`<app>.meta.yml` → `<app>`), matching the Rust-side convention in `playbook_meta.rs::load_for_app`. Public Apps may still rely on role defaults; only tailnet-only Apps need the meta declaration.
 
 ### Split-DNS target IP auto-detection
 


### PR DESCRIPTION
## Summary

ADR-0003 made `meta.subdomain` the source of truth for tailnet-only FQDN composition, but Caddy and the TLS-via-DNS-01 cert flow already consumed the operator's `<app>_subdomain` override from `config.toml`. Blocky's customDNS task ignored that override, producing a three-way split for any host with a renamed subdomain:

| Consumer | Reads | Effective for `bichon_subdomain = "mail"` |
|---|---|---|
| Caddy vhost | `<app>_subdomain` (via extra-var) | `mail.sripwoud.xyz` |
| TLS cert SAN | `<app>_subdomain` (via extra-var) | `mail.sripwoud.xyz` |
| Blocky `customDNS` | `meta.subdomain` (slurped from YAML) | `bichon.sripwoud.xyz` |

Result: `mail.sripwoud.xyz` returned NXDOMAIN even after a successful deploy.

## Fix

Blocky now composes each tailnet-only FQDN as:

```
effective_subdomain = lookup('vars', '<app>_subdomain', default=meta.subdomain)
fqdn = effective_subdomain + '.' + domain
```

App identity is derived from the meta filename (`<app>.meta.yml`), matching the Rust `PlaybookMeta::load_for_app` convention. The meta's `subdomain` remains the canonical default; the operator override is layered on top via Ansible's standard extra-var → role-default precedence (the same one Caddy already honors).

## Why not the pattern ADR-0003 originally rejected

ADR-0003 rejected `lookup('vars', ...)` *as the source* because it depended on every role default equalling the app name. Here, `lookup` is the *override*; `meta.subdomain` remains the unconditional fallback. A missing extra-var no longer produces a silent failure — it falls through to the meta. ADR-0003's "Implementation notes" section is updated to record this layering.

## Test plan

- [ ] Deploy bichon to a host with `bichon_subdomain = "mail"` in `config.toml`; confirm Blocky's `customDNS` contains `mail.sripwoud.xyz` (not `bichon.sripwoud.xyz`).
- [ ] From a tailnet-connected device using Blocky as resolver: `dig mail.sripwoud.xyz` returns the host's Tailscale CGNAT IP.
- [ ] From off-tailnet (or a non-Blocky resolver): `dig mail.sripwoud.xyz` returns NXDOMAIN (ADR-0003 invariant preserved).
- [ ] Cockpit and paperless (no operator override) still resolve at `cockpit.sripwoud.xyz` / `paperless.sripwoud.xyz` — meta default path unchanged.
- [ ] `ansible-lint` passes on the modified Blocky tasks (verified locally).