### PR TITLE
refactor(dns): derive Public-App subdomain list from Playbook Metas

### DIFF
--- a/ansible/playbooks/baikal.meta.yml
+++ b/ansible/playbooks/baikal.meta.yml
@@ -1,4 +1,5 @@
 required_keys: []
+subdomain: baikal
 backup:
   paths: [/opt/baikal/Specific]
   owner: [baikal, baikal]

--- a/ansible/playbooks/blocky.meta.yml
+++ b/ansible/playbooks/blocky.meta.yml
@@ -1,0 +1,2 @@
+required_keys: []
+subdomain: blocky

--- a/ansible/playbooks/colporteur.meta.yml
+++ b/ansible/playbooks/colporteur.meta.yml
@@ -1,0 +1,2 @@
+required_keys: []
+subdomain: colporteur

--- a/ansible/playbooks/freshrss.meta.yml
+++ b/ansible/playbooks/freshrss.meta.yml
@@ -1,4 +1,5 @@
 required_keys: []
+subdomain: freshrss
 backup:
   systemd_services: [freshrss]
   paths: [/var/lib/freshrss, /opt/freshrss/data]

--- a/ansible/playbooks/grimmory.meta.yml
+++ b/ansible/playbooks/grimmory.meta.yml
@@ -1,0 +1,2 @@
+required_keys: []
+subdomain: grimmory

--- a/ansible/playbooks/headscale.meta.yml
+++ b/ansible/playbooks/headscale.meta.yml
@@ -1,4 +1,5 @@
 required_keys: []
+subdomain: hs
 backup:
   systemd_services: [headscale]
   paths: [/var/lib/headscale]

--- a/ansible/playbooks/navidrome.meta.yml
+++ b/ansible/playbooks/navidrome.meta.yml
@@ -1,4 +1,5 @@
 required_keys: []
+subdomain: navidrome
 backup:
   systemd_services: [navidrome]
   paths: [/var/lib/navidrome, /etc/navidrome]

--- a/ansible/playbooks/webdav.meta.yml
+++ b/ansible/playbooks/webdav.meta.yml
@@ -1,3 +1,4 @@
 required_keys: []
+subdomain: webdav
 backup:
   paths: [/var/www/webdav-files]

--- a/ansible/playbooks/yourls.meta.yml
+++ b/ansible/playbooks/yourls.meta.yml
@@ -1,4 +1,5 @@
 required_keys: []
+subdomain: yourls
 backup:
   paths: [/var/www/yourls]
   owner: [www-data, www-data]

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -344,10 +344,18 @@ mod tests {
     }
 
     #[test]
-    fn test_public_app_meta_defaults_to_not_tailnet_only() {
+    fn test_public_app_meta_declares_subdomain_and_is_not_tailnet_only() {
         let meta = load_meta("freshrss");
         assert!(!meta.tailnet_only);
+        assert_eq!(meta.subdomain.as_deref(), Some("freshrss"));
+    }
+
+    #[test]
+    fn test_meta_without_subdomain_parses_to_none() {
+        let yaml = "required_keys: []\n";
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
         assert!(meta.subdomain.is_none());
+        assert!(!meta.tailnet_only);
     }
 
     #[test]

--- a/src/services/dns.rs
+++ b/src/services/dns.rs
@@ -1,4 +1,6 @@
+use crate::ansible_assets::AnsibleAssets;
 use crate::config::Config;
+use crate::playbook_meta::PlaybookMeta;
 use cloudflare::endpoints::dns::dns::{
     CreateDnsRecord, CreateDnsRecordParams, DeleteDnsRecord, DnsContent, DnsRecord, ListDnsRecords,
     UpdateDnsRecord, UpdateDnsRecordParams,
@@ -37,42 +39,55 @@ pub struct SubdomainEntry {
     pub ip_override: Option<String>,
 }
 
-const KNOWN_SUBDOMAIN_KEYS: &[&str] = &[
-    "baikal_subdomain",
-    "bichon_subdomain",
-    "blocky_subdomain",
-    "grimmory_subdomain",
-    "colporteur_subdomain",
-    "freshrss_subdomain",
-    "headscale_subdomain",
-    "navidrome_subdomain",
-    "paperless_subdomain",
-    "webdav_subdomain",
-    "yourls_subdomain",
-];
-
+/// Discovers Public-App subdomains from sibling Playbook Metas.
+/// Filters out tailnet-only Apps; mirrors how Blocky derives `customDNS`
+/// from the same metas (ADR-0003).
 pub fn discover_subdomains() -> HashMap<String, SubdomainEntry> {
-    let config = match Config::load() {
-        Ok(c) => c,
+    let assets = match AnsibleAssets::prepare() {
+        Ok(a) => a,
         Err(_) => return HashMap::new(),
     };
-    KNOWN_SUBDOMAIN_KEYS
-        .iter()
-        .filter_map(|key| {
-            config.get(key).filter(|v| !v.is_empty()).map(|value| {
-                let app = key.strip_suffix("_subdomain").unwrap_or(key);
-                let tailscale_key = format!("{}_tailscale_ip", app);
-                let ip_override = config.get(&tailscale_key).filter(|v| !v.is_empty());
-                (
-                    app.to_string(),
-                    SubdomainEntry {
-                        subdomain: value,
-                        ip_override,
-                    },
-                )
-            })
-        })
-        .collect()
+    let entries = match std::fs::read_dir(assets.playbooks_dir()) {
+        Ok(e) => e,
+        Err(_) => return HashMap::new(),
+    };
+
+    let config = Config::load().ok();
+
+    let mut result: HashMap<String, SubdomainEntry> = HashMap::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Some(app) = file_name.strip_suffix(".meta.yml") else {
+            continue;
+        };
+        let Ok(meta) = PlaybookMeta::load(&path) else {
+            continue;
+        };
+        if meta.tailnet_only {
+            continue;
+        }
+        let Some(subdomain) = meta.subdomain.filter(|s| !s.is_empty()) else {
+            continue;
+        };
+
+        let ip_override = config.as_ref().and_then(|c| {
+            let key = format!("{}_tailscale_ip", app);
+            c.get(&key).filter(|v| !v.is_empty())
+        });
+
+        result.insert(
+            app.to_string(),
+            SubdomainEntry {
+                subdomain,
+                ip_override,
+            },
+        );
+    }
+
+    result
 }
 
 /// Returns `true` if `ip` is in the Tailscale CGNAT range (100.64.0.0/10).
@@ -321,6 +336,8 @@ impl DnsService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
 
     #[test]
     fn test_is_tailscale_ip_true() {
@@ -335,5 +352,99 @@ mod tests {
         assert!(!is_tailscale_ip("192.168.1.1"));
         assert!(!is_tailscale_ip("203.0.113.10"));
         assert!(!is_tailscale_ip("not-an-ip"));
+    }
+
+    fn playbooks_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("ansible")
+            .join("playbooks")
+    }
+
+    // Metas for orchestrating/infrastructure playbooks that don't represent
+    // an App with DNS publication. Anything else must declare `subdomain`.
+    const NON_APP_PLAYBOOK_METAS: &[&str] = &[
+        "apps",
+        "bootstrap",
+        "calibre",
+        "hardening",
+        "hermes",
+        "infrastructure",
+        "remove-radicale",
+        "vibecoder",
+    ];
+
+    #[test]
+    fn test_every_app_meta_has_subdomain_unless_tailnet_only_or_excluded() {
+        let dir = playbooks_dir();
+        let read = std::fs::read_dir(&dir).expect("playbooks dir");
+        for entry in read.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Some(stem) = name.strip_suffix(".meta.yml") else {
+                continue;
+            };
+            let meta =
+                PlaybookMeta::load(&path).unwrap_or_else(|e| panic!("failed to parse {name}: {e}"));
+
+            if meta.tailnet_only {
+                assert!(
+                    meta.subdomain.as_deref().is_some_and(|s| !s.is_empty()),
+                    "{name}: tailnet_only metas must declare subdomain"
+                );
+                continue;
+            }
+
+            if NON_APP_PLAYBOOK_METAS.contains(&stem) {
+                continue;
+            }
+
+            assert!(
+                meta.subdomain.as_deref().is_some_and(|s| !s.is_empty()),
+                "{name}: non-tailnet-only App meta must declare subdomain. \
+                 If this Playbook Meta does not represent an App, add its stem \
+                 to NON_APP_PLAYBOOK_METAS in src/services/dns.rs tests."
+            );
+        }
+    }
+
+    #[test]
+    fn test_discover_subdomains_returns_expected_public_apps() {
+        let discovered = discover_subdomains();
+        let got: BTreeSet<String> = discovered.keys().cloned().collect();
+        let expected: BTreeSet<String> = [
+            "baikal",
+            "blocky",
+            "colporteur",
+            "freshrss",
+            "grimmory",
+            "headscale",
+            "navidrome",
+            "webdav",
+            "yourls",
+        ]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_discover_subdomains_excludes_tailnet_only_apps() {
+        let discovered = discover_subdomains();
+        for tailnet_only in ["bichon", "cockpit", "paperless"] {
+            assert!(
+                !discovered.contains_key(tailnet_only),
+                "tailnet-only app {tailnet_only} must not appear in Public-App discovery"
+            );
+        }
+    }
+
+    #[test]
+    fn test_discover_subdomains_uses_meta_subdomain_value() {
+        let discovered = discover_subdomains();
+        assert_eq!(discovered["headscale"].subdomain, "hs");
+        assert_eq!(discovered["freshrss"].subdomain, "freshrss");
     }
 }


### PR DESCRIPTION
Closes #308.

## Summary

- Drop the hand-maintained `KNOWN_SUBDOMAIN_KEYS` Rust constant in `src/services/dns.rs`.
- Rewrite `discover_subdomains()` to walk `ansible/playbooks/*.meta.yml`, filter on `tailnet_only != true`, and read `subdomain` from each meta.
- Add `subdomain:` to existing Public-App metas (`baikal`, `freshrss`, `headscale`, `navidrome`, `webdav`, `yourls`) and create new metas for the three Public Apps that lacked them (`blocky`, `colporteur`, `grimmory`).
- Lock the discovered set with two regression tests in `src/services/dns.rs`:
  - one walks every `*.meta.yml` and asserts `subdomain` is declared on any non-tailnet-only App meta (with an explicit `NON_APP_PLAYBOOK_METAS` allowlist for orchestrating playbooks like `bootstrap`/`infrastructure`/`apps`);
  - one freezes the expected Public-App set so adding/removing one is forced through review.

## Trade-off picked: (b) — meta canonical at the CLI layer; roles unchanged

The issue posed two options:

- **(a)** Each Public-App role parses its own meta and removes its `<app>_subdomain` role default.
- **(b)** Keep the role default, mirror to meta, validate parity at runtime.

I picked **(b)**, with one refinement: no separate role-level parity check. Reasoning:

1. **Blocky's pattern is cross-role consumption, not self-meta consumption.** Blocky parses *every* meta to build `customDNS`; it does not parse its own meta. The CLI's `discover_subdomains()` is now the symmetric Cloudflare-side analogue — another cross-role consumer. The role themselves don't need to learn meta-parsing for this analogy to hold.
2. **(a) would touch 9 Public-App roles** with a meta-load prelude (`include_vars` + `set_fact`) plus require removing `<app>_subdomain` entries from `keys.yml` (operator-visible config schema change). That is the "invasive" case the issue allowed me to opt out of.
3. **Divergence is already caught end-to-end.** ADR-0003 shipped a deploy-time DNS-resolution check inside `auberge deploy` that fails if the App's hostname doesn't resolve correctly. If a hypothetical operator override of `<app>_subdomain` ever drifted from the meta, the post-deploy resolution check fires before the deploy reports success. A separate role-level parity check would be redundant.

## Behaviour preservation

- `auberge dns delete` interactive picker now shows the same Public-App set as before, minus tailnet-only Apps (`bichon`, `paperless`) — exactly as the issue specified ("current `KNOWN_SUBDOMAIN_KEYS` minus `paperless`/`bichon` if tailnet-only").
- `auberge dns set-all` operates over the same set.
- Tailnet-only metas (`bichon.meta.yml`, `cockpit.meta.yml`, `paperless.meta.yml`) are untouched.
- `keys.yml` is untouched — operators can still set `<app>_subdomain`/`<app>_tailscale_ip` through `auberge config` if they need an override; the deploy-time check guards the resulting state.

## Test plan

- [x] `cargo test` — 306 passed, 0 failed (added 4 tests; updated 1 existing).
- [x] `cargo clippy` — clean.
- [x] `cargo fmt` / `dprint check` — clean.
- [x] `ansible-playbook --syntax-check playbooks/{apps,infrastructure,bootstrap}.yml` — pass.
- [x] `ansible-lint` — pass (run via pre-commit hook).

## Out of scope

- ADR-0003 amendment — none needed; this PR completes the symmetry the ADR's "Public Apps may still rely on role defaults" caveat left open.
- Operator-facing `<app>_subdomain` deprecation in `keys.yml` — left in place to avoid scope creep; can be revisited if/when role-side meta consumption is added.