### PR TITLE
refactor(ansible): move blocky role into infrastructure.yml

### DIFF
--- a/ansible/playbooks/apps.yml
+++ b/ansible/playbooks/apps.yml
@@ -7,8 +7,6 @@
       tags: [apps, storage, caldav, baikal]
     - role: bichon
       tags: [apps, storage, email, bichon]
-    - role: blocky
-      tags: [apps, network, dns, blocky]
     - role: grimmory
       tags: [apps, storage, media, books, grimmory]
     - role: hermes

--- a/ansible/playbooks/infrastructure.yml
+++ b/ansible/playbooks/infrastructure.yml
@@ -12,6 +12,8 @@
       tags: [infrastructure, shell, bash]
     - role: caddy
       tags: [infrastructure, web, proxy, caddy]
+    - role: blocky
+      tags: [infrastructure, network, dns, blocky]
     - role: headscale
       tags: [infrastructure, network, vpn, headscale]
       when: headscale_subdomain is defined and headscale_subdomain | length > 0

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -386,7 +386,7 @@ mod tests {
         assert!(apps.contains(&"paperless".to_string()));
         assert!(apps.contains(&"baikal".to_string()));
         assert!(apps.contains(&"freshrss".to_string()));
-        assert!(apps.contains(&"blocky".to_string()));
         assert!(!apps.contains(&"caddy".to_string()));
+        assert!(!apps.contains(&"blocky".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Moves the Blocky role declaration from `ansible/playbooks/apps.yml` to `ansible/playbooks/infrastructure.yml`, between `caddy` and `headscale`, so substrate ordering reads `caddy → blocky → headscale → tailscale`.
- Swaps the `apps` tag for `infrastructure` (`[infrastructure, network, dns, blocky]`) so Blocky now runs unconditionally on every `auberge deploy`, eliminating the orchestration gap where a fresh Tailnet-only App could deploy successfully while resolving NXDOMAIN.
- Flips the `get_app_names()` test assertion: blocky is no longer operator-selectable as an "app", mirroring the existing assertion for `caddy` and codifying ADR-0005's substrate-placement convention.

Closes #312.

## Why

`auberge deploy <app>` runs the apps play with `--tags <app>`, executing only the named role. With Blocky in `apps.yml`, its `customDNS` never re-rendered against current Playbook Metas unless the operator also ran `auberge deploy blocky` — bichon's `mail.sripwoud.xyz` NXDOMAIN was the canonical instance (ADR-0003 invariant violated). Roles in `infrastructure.yml` run unconditionally, so substrate state stays in sync with App declarations.

## Test plan

Code-level checks (already passing):
- [x] `cargo test` — 309 passed; the flipped `test_get_app_names_returns_roles` assertion now confirms blocky is excluded from the deploy-time app picker.
- [x] `ansible-lint playbooks/apps.yml playbooks/infrastructure.yml` — passes.
- [x] Tag-resolution tests (`test_build_tag_playbook_map`, `test_resolve_app_tag_includes_infrastructure`) — green; the `dns` tag now belongs to `infrastructure.yml` while `network` still spans both playbooks via `wireguard` (apps) and `headscale`/`tailscale`/`blocky` (infra).
- [x] `discover_subdomains()` is meta-driven and unaffected — `blocky.meta.yml` continues to feed Public-App subdomain discovery.

Manual verification (per issue triage; needs live VPS access — owner sign-off):
- [ ] Run `auberge deploy <some-tailnet-only-app>` against a host where Blocky's `customDNS` does not yet contain that app's FQDN; confirm Blocky's config re-renders and reloads during the deploy.
- [ ] From a tailnet client, `dig @<blocky-ip> -p 53 <app>.<domain>` returns the host's Tailscale IP.
- [ ] Run `auberge deploy <some-public-app>` and confirm the Cloudflare A record still publishes successfully — no regression for Public Apps.