### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/sripwoud/auberge/compare/v0.10.4...v0.11.0) - 2026-05-06
+
+### Added
+
+- *(blocky)* publish public A record so DoT is reachable off-tailnet ([#321](https://github.com/sripwoud/auberge/pull/321))
+- *(dns)* [**breaking**] skip tailnet-only apps in dns set-all ([#317](https://github.com/sripwoud/auberge/pull/317))
+
+### Other
+
+- *(ansible)* move blocky role into infrastructure.yml ([#318](https://github.com/sripwoud/auberge/pull/318))
+- *(adr)* record substrate-app placement convention
+
 ## [0.10.4](https://github.com/sripwoud/auberge/compare/v0.10.3...v0.10.4) - 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.10.4"
+version = "0.11.0"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.10.4"
+version = "0.11.0"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.10.4 -> 0.11.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/sripwoud/auberge/compare/v0.10.4...v0.11.0) - 2026-05-06

### Added

- *(blocky)* publish public A record so DoT is reachable off-tailnet ([#321](https://github.com/sripwoud/auberge/pull/321))
- *(dns)* [**breaking**] skip tailnet-only apps in dns set-all ([#317](https://github.com/sripwoud/auberge/pull/317))

### Other

- *(ansible)* move blocky role into infrastructure.yml ([#318](https://github.com/sripwoud/auberge/pull/318))
- *(adr)* record substrate-app placement convention
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).