### PR TITLE
fix(caddy): pin xcaddy plugins and rebuild on stamp drift

### DIFF
--- a/ansible/roles/caddy/defaults/main.yml
+++ b/ansible/roles/caddy/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+caddy_l4_version: "v0.1.0"
+caddy_cloudflare_plugin_version: "v0.2.4"
+caddy_webdav_version: "fa2f366b0d75e54c2e381c0aefc3a8df8bf5794b"
+
+caddy_binary: /usr/local/bin/caddy
+caddy_build_id_file: /usr/local/bin/.caddy-build-id
+caddy_build_id: "l4-{{ caddy_l4_version }}-cf-{{ caddy_cloudflare_plugin_version }}-webdav-{{ caddy_webdav_version }}"

--- a/ansible/roles/caddy/tasks/main.yml
+++ b/ansible/roles/caddy/tasks/main.yml
@@ -32,16 +32,41 @@
         name: xcaddy
         state: present
 
+    - name: Check installed Caddy build id
+      ansible.builtin.stat:
+        path: "{{ caddy_build_id_file }}"
+      register: caddy_build_id_stat
+
+    - name: Read installed Caddy build id
+      when: caddy_build_id_stat.stat.exists
+      ansible.builtin.slurp:
+        src: "{{ caddy_build_id_file }}"
+      register: caddy_installed_build_id_raw
+
+    - name: Set installed Caddy build id fact
+      ansible.builtin.set_fact:
+        caddy_installed_build_id: "{{ caddy_installed_build_id_raw.content | b64decode | trim if caddy_build_id_stat.stat.exists else '' }}"
+
     - name: Build Caddy with custom modules
+      when: caddy_installed_build_id != caddy_build_id
       ansible.builtin.command: |
         xcaddy build \
-          --with github.com/mholt/caddy-l4 \
-          --with github.com/mholt/caddy-webdav \
-          --with github.com/caddy-dns/cloudflare \
-          --output /usr/local/bin/caddy
-      args:
-        creates: /usr/local/bin/caddy
+          --with github.com/mholt/caddy-l4@{{ caddy_l4_version }} \
+          --with github.com/mholt/caddy-webdav@{{ caddy_webdav_version }} \
+          --with github.com/caddy-dns/cloudflare@{{ caddy_cloudflare_plugin_version }} \
+          --output {{ caddy_binary }}
       register: caddy_build_result
+      changed_when: caddy_build_result.rc == 0
+      notify: Restart caddy
+
+    - name: Write installed Caddy build id
+      when: caddy_installed_build_id != caddy_build_id
+      ansible.builtin.copy:
+        content: "{{ caddy_build_id }}"
+        dest: "{{ caddy_build_id_file }}"
+        owner: root
+        group: root
+        mode: "0644"
 
     - name: Create Caddy group
       ansible.builtin.group:


### PR DESCRIPTION
The `caddy-dns/cloudflare` plugin's API-token format-validation regex predates the new Cloudflare scoped-token formats (`cfut_…` / `cfat_…`). On 2026-05-06 a token rotation tripped that regex on the existing build, caddy refused to load config, and every Public/Tailnet App went dark until an operator SSH'd in and rebuilt by hand. Auberge's own Cloudflare client accepts the new formats — the failure was strictly the stale plugin's pre-flight check.

Two interlocking changes, both required:

1. **Pin all three plugins** — `caddy-l4@v0.1.0`, `caddy-webdav@fa2f366…` (no upstream tags, pinned to commit SHA), `caddy-dns/cloudflare@v0.2.4`. The cloudflare pin picks up [caddy-dns/cloudflare#123](https://github.com/caddy-dns/cloudflare/pull/123) which extends the regex.
2. **Replace `creates:` with a version-stamp pattern** — mirrors `roles/bichon`. Build-id encodes all pinned versions, written to `/usr/local/bin/.caddy-build-id`. xcaddy runs only on stamp drift; rebuild notifies `Restart caddy` so the new binary takes effect immediately.

Pinning without a rebuild trigger freezes a different version forever; a rebuild trigger without pins re-resolves `latest` non-deterministically. Each on its own is incomplete.

### Files

| File | Change |
| --- | --- |
| `ansible/roles/caddy/defaults/main.yml` | new — version pins + `caddy_build_id` |
| `ansible/roles/caddy/tasks/main.yml` | stat → slurp → set_fact → conditional build → conditional stamp write |

### Test plan

- [x] `ansible-lint roles/caddy/` passes at production profile
- [ ] Clean re-deploy: `caddy version` reports the pinned versions, `/usr/local/bin/.caddy-build-id` matches `caddy_build_id`
- [ ] Re-run with no defaults change: `Build Caddy` and `Write installed Caddy build id` both skipped, no caddy restart
- [ ] Bump `caddy_cloudflare_plugin_version` in defaults: next deploy rebuilds and restarts caddy

> [!NOTE]
> ADR-0005 — Caddy is a Substrate App; staleness here cascades to every Public/Tailnet App. Same fragility class motivated this fix.

Closes #323