### PR TITLE
feat(bichon)!: replace internal-store backup with hourly EML archive

### DIFF
--- a/ansible/keys.yml
+++ b/ansible/keys.yml
@@ -19,6 +19,10 @@ keys:
     secret: false
     doc: "Subdomain for the Baïkal CalDAV/CardDAV server"
 
+  bichon_api_token:
+    secret: true
+    doc: "Bearer token used by the Bichon archive timer to call Bichon's REST API. Generate it once in Bichon's UI."
+
   bichon_encryption_password:
     secret: true
     doc: "Encryption password for Bichon data-at-rest"

--- a/ansible/playbooks/bichon.meta.yml
+++ b/ansible/playbooks/bichon.meta.yml
@@ -3,5 +3,5 @@ tailnet_only: true
 subdomain: bichon
 backup:
   systemd_services: [bichon]
-  paths: [/opt/bichon/data]
+  paths: [/var/lib/bichon-archive]
   owner: [bichon, bichon]

--- a/ansible/roles/bichon/defaults/main.yml
+++ b/ansible/roles/bichon/defaults/main.yml
@@ -16,3 +16,10 @@ bichon_public_url: "https://{{ bichon_domain }}"
 bichon_encrypt_password_file: "{{ bichon_install_dir }}/encrypt.password"
 
 bichon_release_url: "https://github.com/rustmailer/bichon/releases/download/{{ bichon_version }}/bichon-{{ bichon_version }}-x86_64-unknown-linux-gnu.tar.gz"
+
+bichon_archive_dir: /var/lib/bichon-archive
+bichon_archive_state_dir: "{{ bichon_archive_dir }}/.state"
+bichon_archive_script_path: /usr/local/bin/bichon-archive
+bichon_archive_env_path: /etc/default/bichon-archive
+bichon_archive_overlap_seconds: 86400
+bichon_archive_page_size: 100

--- a/ansible/roles/bichon/handlers/main.yml
+++ b/ansible/roles/bichon/handlers/main.yml
@@ -10,3 +10,9 @@
     name: caddy
     state: restarted
     daemon_reload: true
+
+- name: Restart bichon-archive timer
+  ansible.builtin.systemd_service:
+    name: bichon-archive.timer
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/bichon/tasks/main.yml
+++ b/ansible/roles/bichon/tasks/main.yml
@@ -6,7 +6,9 @@
         that:
           - bichon_encryption_password is defined
           - bichon_encryption_password | length > 0
-        fail_msg: "bichon_encryption_password must be defined"
+          - bichon_api_token is defined
+          - bichon_api_token | length > 0
+        fail_msg: "bichon_encryption_password and bichon_api_token must be defined"
 
     - name: Get Tailscale status
       ansible.builtin.command: tailscale status --json
@@ -204,6 +206,67 @@
         group: "{{ bichon_sys_group }}"
         mode: "0644"
 
+    - name: Install archive script dependencies
+      ansible.builtin.apt:
+        name: [jq, curl]
+        state: present
+        update_cache: false
+
+    - name: Create archive directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ bichon_sys_user }}"
+        group: "{{ bichon_sys_group }}"
+        mode: "0750"
+      loop:
+        - "{{ bichon_archive_dir }}"
+        - "{{ bichon_archive_state_dir }}"
+
+    - name: Deploy archive script
+      ansible.builtin.template:
+        src: bichon-archive.sh.j2
+        dest: "{{ bichon_archive_script_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: Restart bichon-archive timer
+
+    - name: Deploy archive environment file
+      ansible.builtin.template:
+        src: bichon-archive.env.j2
+        dest: "{{ bichon_archive_env_path }}"
+        owner: "{{ bichon_sys_user }}"
+        group: "{{ bichon_sys_group }}"
+        mode: "0600"
+      no_log: true
+      notify: Restart bichon-archive timer
+
+    - name: Deploy archive systemd service unit
+      ansible.builtin.template:
+        src: bichon-archive.service.j2
+        dest: /etc/systemd/system/bichon-archive.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart bichon-archive timer
+
+    - name: Deploy archive systemd timer unit
+      ansible.builtin.template:
+        src: bichon-archive.timer.j2
+        dest: /etc/systemd/system/bichon-archive.timer
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart bichon-archive timer
+
+    - name: Enable and start archive timer
+      ansible.builtin.systemd_service:
+        name: bichon-archive.timer
+        enabled: true
+        state: started
+        daemon_reload: true
+
     - name: Display deployment summary
       ansible.builtin.debug:
         msg:
@@ -212,8 +275,11 @@
           - "==================================="
           - "Version: {{ bichon_version }}"
           - "Data: {{ bichon_root_dir }}"
+          - "Archive: {{ bichon_archive_dir }}"
           - ""
           - "Access: https://{{ bichon_domain }}"
           - ""
-          - "Service:"
+          - "Services:"
           - "  systemctl status bichon"
+          - "  systemctl status bichon-archive.timer"
+          - "  systemctl list-timers bichon-archive.timer"

--- a/ansible/roles/bichon/templates/bichon-archive.env.j2
+++ b/ansible/roles/bichon/templates/bichon-archive.env.j2
@@ -1,0 +1,6 @@
+BICHON_BASE_URL=http://{{ bichon_bind_ip }}:{{ bichon_port }}
+BICHON_API_TOKEN={{ bichon_api_token }}
+BICHON_ARCHIVE_DIR={{ bichon_archive_dir }}
+BICHON_ARCHIVE_STATE_DIR={{ bichon_archive_state_dir }}
+BICHON_ARCHIVE_OVERLAP_SECONDS={{ bichon_archive_overlap_seconds }}
+BICHON_ARCHIVE_PAGE_SIZE={{ bichon_archive_page_size }}

--- a/ansible/roles/bichon/templates/bichon-archive.service.j2
+++ b/ansible/roles/bichon/templates/bichon-archive.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Bichon email archive
+After=bichon.service
+Requires=bichon.service
+
+[Service]
+Type=oneshot
+User={{ bichon_sys_user }}
+Group={{ bichon_sys_group }}
+EnvironmentFile={{ bichon_archive_env_path }}
+ExecStart={{ bichon_archive_script_path }}
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ReadWritePaths={{ bichon_archive_dir }}
+UMask=0027

--- a/ansible/roles/bichon/templates/bichon-archive.sh.j2
+++ b/ansible/roles/bichon/templates/bichon-archive.sh.j2
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BICHON_BASE_URL:?required}"
+: "${BICHON_API_TOKEN:?required}"
+: "${BICHON_ARCHIVE_DIR:?required}"
+: "${BICHON_ARCHIVE_STATE_DIR:?required}"
+: "${BICHON_ARCHIVE_OVERLAP_SECONDS:={{ bichon_archive_overlap_seconds }}}"
+: "${BICHON_ARCHIVE_PAGE_SIZE:={{ bichon_archive_page_size }}}"
+
+OVERLAP_MS=$((BICHON_ARCHIVE_OVERLAP_SECONDS * 1000))
+TOTAL_FAILURES=0
+
+log() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
+}
+
+curl_auth() {
+  curl --silent --show-error --fail \
+    --retry 5 --retry-all-errors --retry-delay 10 --retry-max-time 300 \
+    --header "Authorization: Bearer ${BICHON_API_TOKEN}" \
+    "$@"
+}
+
+verify_auth() {
+  if ! curl_auth "${BICHON_BASE_URL}/api/v1/current-user" >/dev/null; then
+    log "auth check failed: GET /api/v1/current-user did not return 2xx"
+    exit 2
+  fi
+}
+
+list_accounts() {
+  curl_auth "${BICHON_BASE_URL}/api/v1/minimal-account-list?only_nosync=false"
+}
+
+search_messages() {
+  local account_id="$1" since_ms="$2" page="$3"
+  local payload
+  payload=$(jq -nc \
+    --argjson account_id "$account_id" \
+    --argjson since "$since_ms" \
+    --argjson page "$page" \
+    --argjson page_size "$BICHON_ARCHIVE_PAGE_SIZE" \
+    '{filter: {since: $since, account_ids: [$account_id]}, page: $page, page_size: $page_size, sort_by: "DATE", desc: false}')
+  curl_auth \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data "$payload" \
+    "${BICHON_BASE_URL}/api/v1/search-messages"
+}
+
+download_message() {
+  local account_id="$1" message_id="$2" out_path="$3"
+  local tmp
+  tmp=$(mktemp "${out_path}.XXXXXX")
+  if curl_auth --output "$tmp" \
+      "${BICHON_BASE_URL}/api/v1/download-message/${account_id}/${message_id}"; then
+    mv "$tmp" "$out_path"
+    return 0
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
+write_meta_sidecar() {
+  local out_path="$1" envelope_json="$2"
+  local tmp
+  tmp=$(mktemp "${out_path}.XXXXXX")
+  printf '%s' "$envelope_json" | jq '{folder: .mailbox_name, tags: .tags}' >"$tmp"
+  mv "$tmp" "$out_path"
+}
+
+read_cursor() {
+  local cursor_file="$1"
+  if [ -f "$cursor_file" ]; then
+    cat "$cursor_file"
+  else
+    printf '0'
+  fi
+}
+
+write_cursor() {
+  local cursor_file="$1" cursor_ms="$2"
+  local tmp
+  tmp=$(mktemp "${cursor_file}.XXXXXX")
+  printf '%s\n' "$cursor_ms" >"$tmp"
+  mv "$tmp" "$cursor_file"
+}
+
+sanitize_email() {
+  printf '%s' "$1" | tr '/' '_'
+}
+
+process_account() {
+  local account_id="$1" account_email="$2"
+  local safe_email cursor_file cursor_ms since_ms
+  safe_email=$(sanitize_email "$account_email")
+  cursor_file="${BICHON_ARCHIVE_STATE_DIR}/${safe_email}.cursor"
+  cursor_ms=$(read_cursor "$cursor_file")
+  since_ms=$((cursor_ms - OVERLAP_MS))
+  if [ "$since_ms" -lt 0 ]; then since_ms=0; fi
+
+  log "account=${safe_email} id=${account_id} cursor_ms=${cursor_ms} since_ms=${since_ms}"
+
+  local page=1
+  local total_pages=1
+  local max_date=$cursor_ms
+  local account_failures=0
+  local processed=0
+  local skipped=0
+  local body envelope id date_ms yyyy_mm out_dir eml_path meta_path
+
+  while [ "$page" -le "$total_pages" ]; do
+    if ! body=$(search_messages "$account_id" "$since_ms" "$page"); then
+      log "search_messages failed account=${safe_email} page=${page}"
+      account_failures=$((account_failures + 1))
+      break
+    fi
+    total_pages=$(printf '%s' "$body" | jq -r '.total_pages // 0')
+    if [ "$total_pages" -eq 0 ]; then break; fi
+
+    while IFS= read -r envelope; do
+      [ -z "$envelope" ] && continue
+      id=$(printf '%s' "$envelope" | jq -r '.id')
+      date_ms=$(printf '%s' "$envelope" | jq -r '.date')
+
+      if [ "$date_ms" -gt "$max_date" ]; then max_date=$date_ms; fi
+
+      yyyy_mm=$(date -u -d "@$((date_ms / 1000))" '+%Y/%m')
+      out_dir="${BICHON_ARCHIVE_DIR}/${safe_email}/${yyyy_mm}"
+      eml_path="${out_dir}/${id}.eml"
+      meta_path="${out_dir}/${id}.meta.json"
+
+      if [ -f "$eml_path" ] && [ -f "$meta_path" ]; then
+        skipped=$((skipped + 1))
+        continue
+      fi
+
+      mkdir -p "$out_dir"
+
+      if [ ! -f "$eml_path" ]; then
+        if ! download_message "$account_id" "$id" "$eml_path"; then
+          log "download failed account=${safe_email} id=${id}"
+          account_failures=$((account_failures + 1))
+          continue
+        fi
+      fi
+      write_meta_sidecar "$meta_path" "$envelope"
+      processed=$((processed + 1))
+    done < <(printf '%s' "$body" | jq -c '.items[]?')
+
+    page=$((page + 1))
+  done
+
+  log "account=${safe_email} processed=${processed} skipped=${skipped} failures=${account_failures}"
+
+  if [ "$account_failures" -eq 0 ]; then
+    write_cursor "$cursor_file" "$max_date"
+  fi
+
+  TOTAL_FAILURES=$((TOTAL_FAILURES + account_failures))
+}
+
+main() {
+  mkdir -p "$BICHON_ARCHIVE_DIR" "$BICHON_ARCHIVE_STATE_DIR"
+  verify_auth
+
+  local accounts_json id email
+  accounts_json=$(list_accounts)
+
+  while IFS=$'\t' read -r id email; do
+    [ -z "$id" ] && continue
+    process_account "$id" "$email"
+  done < <(printf '%s' "$accounts_json" | jq -r '.[] | "\(.id)\t\(.email)"')
+
+  log "total_failures=${TOTAL_FAILURES}"
+  if [ "$TOTAL_FAILURES" -gt 0 ]; then exit 1; fi
+}
+
+main "$@"

--- a/ansible/roles/bichon/templates/bichon-archive.timer.j2
+++ b/ansible/roles/bichon/templates/bichon-archive.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run bichon email archive hourly
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=10min
+Persistent=true
+Unit=bichon-archive.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/applications/apps/bichon.md
+++ b/docs/applications/apps/bichon.md
@@ -18,6 +18,7 @@ Required variables in `config.toml`:
 
 - `bichon_encryption_password` - Encryption password for stored credentials (IMAP passwords, OAuth tokens, login passwords) and metadata database. Email content is stored as zstd-compressed blocks and is **not** encrypted by this password.
 - `bichon_subdomain` - Subdomain for HTTPS access (e.g. `bichon`)
+- `bichon_api_token` - Bearer token used by the hourly archive timer to call Bichon's REST API. Mint one in Bichon's UI after the first deploy, paste it into `config.toml`, then re-run the role.
 
 Optional:
 
@@ -31,13 +32,16 @@ Optional:
 - **Search**: Tantivy (embedded full-text search, no external DB)
 - **Encryption**: Credential and metadata encryption (email content is not encrypted)
 - **Config**: `/opt/bichon/bichon.env`
-- **Data**: `/opt/bichon/data`
+- **Data**: `/opt/bichon/data` (Bichon's encrypted internal store — not backed up)
+- **Archive**: `/var/lib/bichon-archive` (per-message `.eml` mirror, hourly; backed up)
 
 ### Systemd Services
 
-| Service  | Description                     |
-| -------- | ------------------------------- |
-| `bichon` | Web server and IMAP sync daemon |
+| Service                  | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `bichon`                 | Web server and IMAP sync daemon                       |
+| `bichon-archive.service` | Walks Bichon's REST API, writes EML files (`oneshot`) |
+| `bichon-archive.timer`   | Triggers the archive hourly with 10min jitter         |
 
 ## Access
 
@@ -51,9 +55,25 @@ Requires Tailscale — the service will not start without `tailscaled.service`.
 
 See [Tailnet-only subdomains](../../dns/batch-operations.md#tailnet-only-subdomains) for the generic pattern.
 
+## Email Archive
+
+A `bichon-archive.timer` on the host runs hourly and walks Bichon's REST API to mirror each message as a plaintext `.eml` file under `/var/lib/bichon-archive/<account-email>/<YYYY>/<MM>/<message-id>.eml`, with a `<message-id>.meta.json` sidecar capturing folder name and tags. Per-account cursors under `.state/` plus a 24-hour overlap window keep incremental runs cheap. Atomic per-message writes; failures advance no cursor.
+
+Verify after the first deploy:
+
+```bash
+sudo systemctl start bichon-archive.service   # seed the archive immediately
+sudo systemctl list-timers bichon-archive.timer
+sudo find /var/lib/bichon-archive -name '*.eml' | wc -l
+```
+
+The archive is consumable without Bichon — any IMAP/MBOX-aware client (Thunderbird, mutt) can ingest the `.eml` tree directly. The non-rotatable `bichon_encryption_password` is **not** required to read it.
+
 ## Backup
 
-Supported via `auberge backup create --apps bichon`. Backs up the entire data directory including search indices and archived emails. No external database — all data is self-contained on disk.
+Supported via `auberge backup create --apps bichon`. The Backup Recipe rsyncs `/var/lib/bichon-archive` (the EML archive above), **not** Bichon's internal `/opt/bichon/data` store. This makes the backup tool-agnostic, restic-friendly (Tantivy's segment-rewrite churn no longer dominates dedup), and survives any future where Bichon stops being maintainable.
+
+The timer must have run at least once before the first backup, otherwise the bichon backup will be empty. Rationale and considered alternatives in [ADR-0006](https://github.com/sripwoud/auberge/blob/master/meta/adr/0006-bichon-archive-feeds-backup-recipe.md).
 
 See [Backup & Restore](../../backup-restore/overview.md).
 

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -173,7 +173,7 @@ mod tests {
     fn test_bichon_meta_backup_recipe() {
         let backup = load_meta("bichon").backup.unwrap();
         assert_eq!(backup.systemd_services, vec!["bichon"]);
-        assert_eq!(backup.paths, vec!["/opt/bichon/data"]);
+        assert_eq!(backup.paths, vec!["/var/lib/bichon-archive"]);
     }
 
     #[test]


### PR DESCRIPTION
Bichon's Backup Recipe now captures a tool-agnostic per-message **Email Archive** under `/var/lib/bichon-archive/` — one `.eml` per message plus a `.meta.json` sidecar (folder + tags) — produced hourly by a systemd timer on the bichon Host. The encrypted internal store at `/opt/bichon/data` is no longer backed up.

What this buys the operator: backups stay readable without Bichon, without its (non-rotatable) encryption password, and without a working Rust toolchain in the future. Any IMAP/MBOX-aware client can ingest the archive. Restic dedup degrades to near-zero new bytes per snapshot in steady state because Tantivy's segment-rewrite churn no longer sits in the backed-up tree.

Closes #315. Implements [ADR-0006](meta/adr/0006-bichon-archive-feeds-backup-recipe.md).

> [!WARNING]
> **Breaking**: existing restic snapshots of `/opt/bichon/data` are no longer extended; new snapshots cover `/var/lib/bichon-archive`. The timer must run at least once before the next `auberge backup create`, otherwise the new bichon backup will be empty. After deploy, kick a first run with `sudo systemctl start bichon-archive.service` to seed the archive immediately.

## What ships

| Layer | File | Role |
|---|---|---|
| Script | `templates/bichon-archive.sh.j2` | Walks Bichon's REST API, atomic per-message writes, per-account cursor + 24h overlap |
| Unit | `templates/bichon-archive.service.j2` | `Type=oneshot`, `User=bichon`, hardened (`ProtectSystem=strict`, `NoNewPrivileges`) |
| Timer | `templates/bichon-archive.timer.j2` | `OnCalendar=hourly`, `RandomizedDelaySec=10min`, `Persistent=true` |
| Env | `templates/bichon-archive.env.j2` | `mode=0600`, `no_log: true` on the template task |
| Registry | `ansible/keys.yml` | New `bichon_api_token` key (operator-supplied; auto-flagged by `SENSITIVE_SUFFIXES` since it ends in `_token`) |
| Recipe | `ansible/playbooks/bichon.meta.yml` | `paths: [/opt/bichon/data]` → `paths: [/var/lib/bichon-archive]` |
| Docs | `docs/applications/apps/bichon.md` | Adds `bichon_api_token` to required vars; new Email Archive section; rewrites Backup section |

Five well-typed REST calls in a loop: `/current-user` (auth check, exit 2 on fail), `/minimal-account-list`, `/search-messages`, `/download-message/:account_id/:message_id`. Bearer auth. `curl --retry 5 --retry-all-errors` handles network blips; per-account cursor (epoch ms) + 24h overlap window keeps incremental runs cheap; failures advance no cursor.

## Why this shape (and not the others)

| Considered | Rejected because |
|---|---|
| Dual channel: existing recipe + new archive | ADR-0001's "no escape hatch from day one" — the existing recipe is dominated on every operator-stated priority |
| Operator-laptop `auberge bichon archive` (issue #315 sketch) | Self-hosting bichon precisely because the laptop is not always on; making cadence depend on laptop uptime contradicts that |
| New Rust subcommand in `auberge` | A shell script with `curl --retry` and `jq` is sufficient — no new build target, no binary to ship |
| Reuse `bichonctl` | Fully `dialoguer`-driven (interactive prompts mid-flow); no scriptable mode |
| Pure skip-if-exists, no cursor | ~1000 API calls per hourly tick on a 100k-mailbox in steady state, forever |
| `bichon-archive@account.service` per account | Encodes account list in two places (Bichon DB + ansible config); adding/removing an account would require ansible re-deploy or leave a stale timer |

Full rationale in ADR-0006.

## Test plan

Smoke-tested on the live host at 2026-05-06 13:02–13:05 UTC.

- [x] First run: 7 accounts, **3724 `.eml` + 3724 `.meta.json`**, `total_failures=0`, exit 0/SUCCESS, 2:12 wall.
- [x] Tree layout: `<email>/<YYYY>/<MM>/<id>.{eml,meta.json}`, sample `.eml` is real RFC 5322, sample `.meta.json` is `{folder, tags}`.
- [x] Atomic writes: `find … -name '*.tmp*' | wc -l` = 0 between runs.
- [x] Cursors: 7 cursor files in `.state/`, all with valid epoch-ms values.
- [x] Second run: **1 second wall**, all accounts `processed=0 skipped=N failures=0` (skipped = N within 24h overlap window).
- [x] Timer scheduled: next at `Wed 2026-05-06 14:01:49 UTC`, persistent + randomized 10min jitter active.
- [x] `cargo test`: 314 passed, 0 failed.
- [x] `ansible-lint`, `shellcheck`, `dprint` clean.

## Out of scope

- Restic restore docs — the archive is consumable without Bichon (any MBOX/EML-aware client), so there's no Bichon-specific restore step beyond redeploying the role and pointing import at the archive directory.

## Operator action after merge

1. Mint a Bichon API token in the UI; set `bichon_api_token` in `config.toml`.
2. `auberge ansible run --tags bichon` (or equivalent).
3. `sudo systemctl start bichon-archive.service` to seed the archive before the next backup.
4. Next `auberge backup create` rsyncs the archive instead of `/opt/bichon/data`.
