### PR TITLE
chore: release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/sripwoud/auberge/compare/v0.12.0...v0.12.1) - 2026-05-08
+
+### Added
+
+- *(bichon)* add reconcile-folders command ([#331](https://github.com/sripwoud/auberge/pull/331))
+
+### Other
+
+- *(bichon)* first-time setup and archived-then-expunge playbook ([#330](https://github.com/sripwoud/auberge/pull/330))
+
 ## [0.12.0](https://github.com/sripwoud/auberge/compare/v0.11.0...v0.12.0) - 2026-05-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.12.0 -> 0.12.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.1](https://github.com/sripwoud/auberge/compare/v0.12.0...v0.12.1) - 2026-05-08

### Added

- *(bichon)* add reconcile-folders command ([#331](https://github.com/sripwoud/auberge/pull/331))

### Other

- *(bichon)* first-time setup and archived-then-expunge playbook ([#330](https://github.com/sripwoud/auberge/pull/330))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).