### PR TITLE
chore: release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2](https://github.com/sripwoud/auberge/compare/v0.12.1...v0.12.2) - 2026-05-08
+
+### Fixed
+
+- *(bichon)* decode real API response shapes in reconcile-folders
+
+### Other
+
+- compress docs
+- update ADR
+
 ## [0.12.1](https://github.com/sripwoud/auberge/compare/v0.12.0...v0.12.1) - 2026-05-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.12.1 -> 0.12.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.2](https://github.com/sripwoud/auberge/compare/v0.12.1...v0.12.2) - 2026-05-08

### Fixed

- *(bichon)* decode real API response shapes in reconcile-folders

### Other

- compress docs
- update ADR
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).