### PR TITLE
fix(bichon): tolerate empty response body on sync_folders apply

### DIFF
--- a/src/commands/bichon/reconcile.rs
+++ b/src/commands/bichon/reconcile.rs
@@ -358,7 +358,7 @@ tailscale_ip = "100.100.100.10"
             .and(body_json(
                 json!({"sync_folders":["INBOX","INBOX/legal-2026"]}),
             ))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok":true})))
+            .respond_with(ResponseTemplate::new(200))
             .expect(1)
             .mount(&server)
             .await;

--- a/src/services/bichon/api.rs
+++ b/src/services/bichon/api.rs
@@ -130,13 +130,12 @@ impl BichonApiClient {
         sync_folders: &[String],
     ) -> Result<()> {
         let payload = AccountUpdateRequest { sync_folders };
-        self.request_json::<_, serde_json::Value>(
+        self.request_empty(
             Method::POST,
             &format!("/api/v1/account/{account_id}"),
             Some(&payload),
         )
         .await
-        .map(|_| ())
     }
 
     async fn request_json<Body, Output>(
@@ -149,9 +148,31 @@ impl BichonApiClient {
         Body: Serialize + ?Sized,
         Output: DeserializeOwned,
     {
+        self.retry(|| self.request_json_once(method.clone(), path, body))
+            .await
+    }
+
+    async fn request_empty<Body>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&Body>,
+    ) -> Result<()>
+    where
+        Body: Serialize + ?Sized,
+    {
+        self.retry(|| async { self.send_once(method.clone(), path, body).await.map(|_| ()) })
+            .await
+    }
+
+    async fn retry<T, F, Fut>(&self, mut op: F) -> Result<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
         let mut last_err: Option<eyre::Report> = None;
         for attempt in 1..=MAX_RETRIES {
-            match self.request_json_once(method.clone(), path, body).await {
+            match op().await {
                 Ok(value) => return Ok(value),
                 Err(err) => {
                     if attempt < MAX_RETRIES && is_retryable(&err) {
@@ -178,6 +199,23 @@ impl BichonApiClient {
         Output: DeserializeOwned,
     {
         let url = format!("{}{}", self.base_url, path);
+        let response = self.send_once(method, path, body).await?;
+        response
+            .json::<Output>()
+            .await
+            .wrap_err_with(|| format!("failed to parse JSON response from {url}"))
+    }
+
+    async fn send_once<Body>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&Body>,
+    ) -> Result<reqwest::Response>
+    where
+        Body: Serialize + ?Sized,
+    {
+        let url = format!("{}{}", self.base_url, path);
         let request = self
             .http
             .request(method, &url)
@@ -195,10 +233,7 @@ impl BichonApiClient {
             let body = response.text().await.unwrap_or_default();
             return Err(eyre::Report::new(BichonApiHttpError { status, url, body }));
         }
-        response
-            .json::<Output>()
-            .await
-            .wrap_err_with(|| format!("failed to parse JSON response from {url}"))
+        Ok(response)
     }
 }
 


### PR DESCRIPTION
`auberge bichon reconcile-folders --apply` failed with `EOF while parsing a value at line 1 column 0` after the server-side write had already succeeded. Real Bichon returns an empty body on `POST /api/v1/account/{id}`; the shared decoder demanded JSON.

```
master ← #X (this)
```

## Repro before this PR

```
$ AUBERGE_DEV=1 auberge bichon reconcile-folders -H auberge --apply
Error:
   0: failed to update sync_folders for dev@sripwoud.xyz
   1: failed to parse JSON response from https://mail.sripwoud.xyz/api/v1/account/6364692087959944
   2: EOF while parsing a value at line 1 column 0
```

The previous run had already mutated 7 accounts server-side before the parser blew up — silent partial apply.

## Root cause

`request_json_once` unconditionally called `.json::<Output>()` on every successful response. `update_account_sync_folders` discarded the result with `.map(|_| ())` anyway. The apply test at `reconcile.rs:361` masked the divergence by returning `{\"ok\":true}` instead of the real empty body.

## Change

| File | Change |
|---|---|
| `src/services/bichon/api.rs` | Extract `send_once` returning validated `Response`; add `request_empty` for fire-and-forget writes; share retry logic via `retry<T, F, Fut>` |
| `src/services/bichon/api.rs` | `update_account_sync_folders` now uses `request_empty` |
| `src/commands/bichon/reconcile.rs` | Apply-path mock returns `ResponseTemplate::new(200)` (no body) to assert the real contract |

## Test plan

- [x] `cargo test --release bichon` — 19/19 pass
- [x] `cargo build --release` clean
- [x] Live `AUBERGE_DEV=1 auberge bichon reconcile-folders -H auberge --apply` — succeeds, idempotent on re-run

[!NOTE]
Second instance of the same mock/prod divergence class — paired with #commit bbe1125 (`PaginatedResponse` + `MailboxAttribute`). Worth a follow-up to harden the test fixtures against this shape of bug, but out of scope here.