### PR TITLE
chore: release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3](https://github.com/sripwoud/auberge/compare/v0.12.2...v0.12.3) - 2026-05-18
+
+### Fixed
+
+- *(caddy)* order after tailscaled and auto-restart on failure ([#337](https://github.com/sripwoud/auberge/pull/337))
+- *(bichon)* tolerate empty response body on sync_folders apply ([#335](https://github.com/sripwoud/auberge/pull/335))
+
 ## [0.12.2](https://github.com/sripwoud/auberge/compare/v0.12.1...v0.12.2) - 2026-05-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.12.2 -> 0.12.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.3](https://github.com/sripwoud/auberge/compare/v0.12.2...v0.12.3) - 2026-05-18

### Fixed

- *(caddy)* order after tailscaled and auto-restart on failure ([#337](https://github.com/sripwoud/auberge/pull/337))
- *(bichon)* tolerate empty response body on sync_folders apply ([#335](https://github.com/sripwoud/auberge/pull/335))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).