### PR TITLE
fix(caddy): order after tailscaled and auto-restart on failure

### DIFF
--- a/ansible/roles/caddy/files/caddy.service
+++ b/ansible/roles/caddy/files/caddy.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Caddy
 Documentation=https://caddyserver.com/docs/
-After=network.target network-online.target
+After=network.target network-online.target tailscaled.service
+Wants=tailscaled.service
 Requires=network-online.target
 
 [Service]
@@ -15,6 +16,8 @@ LimitNOFILE=1048576
 PrivateTmp=true
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+Restart=on-failure
+RestartSec=10s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
After a reboot, Caddy raced ahead of `tailscaled`, failed to bind the Tailscale IP, and stayed dead — taking every `tailnet_only` App (paperless, etc.) offline until manual restart.

## What was broken

Paperless on the `auberge` host stopped serving after a Cockpit-driven Debian update reboot. Diagnosis:

```
Status: "loading new config: http app module: start: listening on
        100.99.62.26:443: listen tcp 100.99.62.26:443: bind: cannot
        assign requested address"
Active: failed (Result: exit-code) since Mon 2026-05-18 10:38:04 UTC
```

Paperless's own `systemd` services were healthy. Blocky's DNS publication was intact. Caddy alone was down — for 7h — and Tailnet-only Apps reach paperless _through_ Caddy on the tailnet interface (ADR-0005).

## Root cause

| Layer | Behavior |
|---|---|
| `caddy.service` | `After=network-online.target` only |
| `network-online.target` | Satisfied by primary NIC; ignores Tailscale |
| `tailscaled` | Brings up `tailscale0` _asynchronously_ after control-plane auth |
| Caddyfile | Binds to `100.99.62.26:443` (Tailnet-only enforcement) |
| systemd | Started Caddy + tailscaled in parallel; Caddy lost the race |
| Caddy unit | No `Restart=`, so it stayed `failed` indefinitely |

Before this reboot the host had been up long enough that the race never re-triggered. Cockpit's update applied a kernel + initramfs, triggering the reboot that exposed it.

## Fix

`ansible/roles/caddy/files/caddy.service`:

```diff
-After=network.target network-online.target
+After=network.target network-online.target tailscaled.service
+Wants=tailscaled.service
 Requires=network-online.target
 ...
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+Restart=on-failure
+RestartSec=10s
```

Two complementary mechanisms:

- **Ordering** (`After=tailscaled.service` + `Wants=tailscaled.service`) — start Caddy after Tailscale's daemon, and pull tailscaled in if it isn't enabled.
- **Auto-restart** (`Restart=on-failure` + `RestartSec=10s`) — `tailscaled` being _started_ ≠ `tailscale0` having an _IP_; auto-retry catches the residual race instead of leaving the service dead.

## Deploy

`auberge deploy --tags caddy` against the `auberge` host. The role's existing `Restart caddy` handler runs `daemon-reload` + `state: restarted`, so the new unit installs cleanly with no manual steps.

## Test plan

- [x] manually restarted Caddy on `auberge` to recover paperless (immediate fix; pre-PR)
- [ ] `auberge deploy --tags caddy` applies the unit change
- [ ] `systemctl cat caddy` shows the new `After=`/`Wants=`/`Restart=` lines
- [ ] reboot the host; Caddy comes up green without manual intervention