### PR TITLE
feat(deploy): auto-tunnel first-deploy setup wizard

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,14 @@ _Avoid_: Infrastructure component, shared service, platform service
 The act of making an App's hostname resolvable, performed during deploy. For Public Apps it is a Cloudflare A record; for Tailnet-only Apps it is a Blocky `customDNS` entry. Either is part of `auberge deploy`'s success criterion — a deploy that completes without a working DNS answer is treated as a failure.
 _Avoid_: DNS setup, record creation, A-record provisioning
 
+**First-Deploy Bootstrap**:
+The one-time interactive step required by some Apps before DNS Publication can safely complete — typically an unauthenticated setup wizard that creates the first admin account. Declared on a Playbook Meta via a `first_deploy_setup` block (port, marker path, setup URL path). `auberge deploy` orchestrates it by spawning a local SSH tunnel to the wizard port, opening the operator's browser, polling for the Bootstrap Marker, then re-running the Playbook so the gated Caddy + DNS tasks execute. See ADR-0009.
+_Avoid_: Setup wizard, bootstrap step, initial setup
+
+**Bootstrap Marker**:
+A file path on the remote whose presence indicates a First-Deploy Bootstrap has completed (e.g. Gokapi's `/var/lib/gokapi/config/config.json`, written by the wizard on success). The Ansible role's `when:` clauses already gate public exposure on this file's existence; auberge polls it via SSH during the bootstrap window to know when to tear down the tunnel and re-run the Playbook.
+_Avoid_: Sentinel, lock file, setup flag
+
 **Backup Recipe**:
 The declarative `backup:` section of a Playbook Meta describing how to back up the App: services to stop, paths to rsync, optional database dump, optional `post_restore_command`. Pure data — no imperative branching. Most Recipes capture an App's on-disk state directly; for Bichon the Recipe rsyncs an **Email Archive** instead, see ADR-0006.
 _Avoid_: Backup config, backup plan, strategy
@@ -93,6 +101,7 @@ _Avoid_: Logger, reporter
 - The **Recipe Executor** consumes one **Backup Recipe**; the **Backup Session** consumes many.
 - All runners report through **Progress**; none touch terminal output directly.
 - An **App** is either a **Public App** or a **Tailnet-only App**, determined by the `tailnet_only` flag in its **Playbook Meta**. **DNS Publication** is dispatched accordingly.
+- A **Playbook Meta** declares zero or one **First-Deploy Bootstrap**. When declared, **DNS Publication** waits for the **Bootstrap Marker** to appear before completing.
 
 ## Example dialogue
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "include_dir",
  "indicatif",
  "minijinja",
+ "open",
  "openssl",
  "regex",
  "reqwest",
@@ -1514,6 +1515,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1874,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1988,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ shell-escape = "0.1.5"
 ctrlc = "3.5.2"
 hickory-resolver = { version = "0.26", features = ["tokio"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+open = "5"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/ansible/playbooks/gokapi.meta.yml
+++ b/ansible/playbooks/gokapi.meta.yml
@@ -6,3 +6,8 @@ backup:
   systemd_services: [gokapi]
   paths: [/var/lib/gokapi]
   owner: [gokapi, gokapi]
+first_deploy_setup:
+  port: 53842
+  marker_path: /var/lib/gokapi/config/config.json
+  setup_url_path: /setup
+  wizard_name: Gokapi setup wizard

--- a/meta/adr/0009-first-deploy-bootstrap-via-ssh-tunnel.md
+++ b/meta/adr/0009-first-deploy-bootstrap-via-ssh-tunnel.md
@@ -1,0 +1,81 @@
+# ADR-0009: First-Deploy Bootstrap orchestrated via auberge-driven SSH tunnel
+
+## Status
+
+Accepted, 2026-05-20.
+
+## Decision
+
+Introduce a **First-Deploy Bootstrap** concept: an optional declaration on a Playbook Meta that an App requires a one-time interactive setup step before public DNS Publication can complete. `auberge deploy` orchestrates this step automatically — spawning a local SSH tunnel to the wizard port, opening the operator's browser, polling for a **Bootstrap Marker** file on the remote, and re-running the same playbook to land Caddy + DNS once the marker appears.
+
+Apps that need this declare:
+
+```yaml
+first_deploy_setup:
+  port: 53842
+  marker_path: /var/lib/gokapi/config/config.json
+  setup_url_path: /setup
+  wizard_name: Gokapi setup wizard
+```
+
+Only Gokapi declares it today. The concept generalises to any future App with the same "unauthenticated bootstrap endpoint + post-setup marker file" shape (vaultwarden's first-admin signup, n8n, etc.).
+
+## Why
+
+Gokapi (#338) exposes an unauthenticated `/setup` endpoint on first boot. Whoever reaches `/setup` first creates the admin account, so it must not be publicly reachable before the operator finishes the wizard. The Ansible role gates Caddy + DNS Publication on `/var/lib/gokapi/config/config.json` existing on the remote — the marker the wizard writes when it completes.
+
+Before this ADR, the operator's workflow was:
+
+1. `auberge deploy` — installs binary + service. Gated tasks skip silently. Deploy reports success even though DNS Publication didn't happen.
+2. Read the playbook's `debug` task output (easy to miss in rolled-up output) to find the SSH tunnel command, run it manually, complete the wizard.
+3. `auberge deploy` — second invocation lands Caddy + DNS.
+
+Three problems:
+
+- Step 1's "success" message is wrong by CONTEXT.md's definition of DNS Publication ("a deploy that completes without a working DNS answer is treated as a failure"). The operator has to read the debug message to know the deploy is half-done.
+- Step 2's incantation is forgettable and reinventable per-app.
+- Step 3 doubles the deploy command count for the lifetime of every gated App.
+
+Pulling the orchestration into auberge collapses the three steps into one `auberge deploy` invocation while preserving the security posture exactly.
+
+## Security posture
+
+The auto-tunnel matches the manual tunnel byte-for-byte:
+
+- UFW continues to default-deny inbound on the wizard port. The wizard is never publicly reachable.
+- Tunnel traffic flows inside the SSH-encrypted channel; UFW only ever sees a connection on port 22.
+- Wizard authentication is delegated to SSH key auth (same trust set as the operator's existing access).
+- The tunnel is ephemeral — RAII-guarded for teardown on completion, panic, or Ctrl+C.
+
+The change moves a step from the operator's shell history to auberge's process tree. No new attack surface; no new public exposure; no new long-lived state.
+
+## Considered alternatives
+
+- **Template `config.json` directly and skip the wizard entirely.** Rejected for now. Auberge's Config already knows the admin username and password, so a templated `config.json` could land in one deploy with zero interaction. But the operator loses the wizard's optional surface (OAuth providers, storage backends, smtp config) unless every field is added to the Key Registry, and any upstream Gokapi schema change silently breaks the template. Reasonable to revisit if a CI-driven disaster-recovery flow ever needs unattended Gokapi rebuilds — at that point the schema-coupling cost is worth paying.
+
+- **Bind the wizard to the Tailscale interface during bootstrap.** Rejected. Would require Gokapi to support per-interface binding (not verified) and reuses the same trust set as SSH anyway. The SSH path is already there and standard; no new dependency on the mesh being up before the App is.
+
+- **Time-boxed public exposure: open the firewall + create DNS for N minutes, then revert.** Rejected as actively unsafe. Even a 5-minute window of the unauthenticated wizard on the public internet is a race condition the operator can lose to a port scanner.
+
+- **Keep the manual tunnel, just make the instructions louder.** Rejected. The problem isn't discoverability of the instructions; the problem is that two deploy invocations are needed for one deployment, and the friction compounds linearly with the number of Apps that adopt the pattern.
+
+## Consequences
+
+**Positive:**
+
+- One `auberge deploy` invocation completes the deployment, including DNS Publication, for an App with a First-Deploy Bootstrap.
+- The Playbook Meta is the single source of truth for the bootstrap shape — no per-App orchestration code in `deploy.rs`.
+- Future Apps with the same shape (vaultwarden first-admin, n8n, gitea bootstrap-token) reuse the mechanism by adding a single block to their meta.
+- Non-interactive deploys (no TTY — CI, scripts) skip the auto-tunnel and print the manual instructions instead, preserving today's behaviour for unattended runs.
+
+**Negative:**
+
+- Auberge gains a runtime dependency on `xdg-open`/`open`/`start` (via the `open` crate) for browser launch. Failure to open a browser falls back to printing the URL, so this is graceful, but it's one more thing that can not-quite-work on exotic environments.
+- The `gokapi` role's `debug` task with manual instructions (lines 156-173) becomes mostly dead weight when auberge drives the flow. Left in place for now to support raw `ansible-playbook` invocations outside auberge.
+- Polling the marker file via SSH every 3s during the wizard window means a few dozen SSH connections per bootstrap. SSH connection multiplexing (`ControlMaster auto`) is already configured in `src/ssh_session.rs`, so the cost is one TCP handshake amortised over all the polls.
+
+## References
+
+- Issue #343 — feature request.
+- ADR-0008 — introduces Gokapi as the App that motivated this concept.
+- Role: `ansible/roles/gokapi/tasks/main.yml:132-173` — the gating logic this ADR wraps with auberge orchestration.

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,6 +1,9 @@
 use crate::ansible_assets::AnsibleAssets;
+use crate::commands::host::resolve_ssh_key;
 use crate::config::Config;
+use crate::hosts::HostManager;
 use crate::output;
+use crate::playbook_meta::PlaybookMeta;
 use crate::prompt::{confirm, select_multi};
 use crate::services::ansible_runner::{InventoryHost, run_playbook};
 use crate::services::dependency_resolver::{
@@ -9,7 +12,9 @@ use crate::services::dependency_resolver::{
 use crate::services::dns_verify::{
     AppVerifyConfig, HickoryLookup, app_verify_config, format_dns_error, verify_a_record,
 };
+use crate::services::first_deploy_bootstrap;
 use crate::services::inventory::{Host, select_or_arg};
+use crate::ssh_session::SshSession;
 use clap::Args;
 use eyre::Result;
 
@@ -209,6 +214,56 @@ fn run_dns_checks_for_run(
     Ok(())
 }
 
+fn meta_candidates_for_run(run: &PlaybookRun) -> Vec<std::path::PathBuf> {
+    let Some(parent) = run.path.parent() else {
+        return Vec::new();
+    };
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+    if run.is_apps() {
+        for tag in &run.tags {
+            candidates.push(parent.join(format!("{tag}.meta.yml")));
+        }
+    } else if let Some(stem) = run.path.file_stem().and_then(|s| s.to_str()) {
+        candidates.push(parent.join(format!("{stem}.meta.yml")));
+    }
+    candidates
+}
+
+fn maybe_run_first_deploy_bootstrap(run: &PlaybookRun, host_name: &str) -> Result<bool> {
+    let pending_setups: Vec<_> = meta_candidates_for_run(run)
+        .into_iter()
+        .filter(|p| p.exists())
+        .map(|p| PlaybookMeta::load(&p))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .filter_map(|m| m.first_deploy_setup)
+        .collect();
+
+    if pending_setups.is_empty() {
+        return Ok(false);
+    }
+
+    let host = HostManager::get_host(host_name).map_err(|e| {
+        eyre::eyre!(
+            "Cannot resolve host '{}' from hosts.toml for first-deploy bootstrap: {}. Add it with 'auberge host add'.",
+            host_name,
+            e
+        )
+    })?;
+    let ssh_key = resolve_ssh_key(&host)?;
+    let session = SshSession::new(&host, &ssh_key);
+
+    let mut ran_any = false;
+    for setup in &pending_setups {
+        if first_deploy_bootstrap::marker_exists(&session, &setup.marker_path)? {
+            continue;
+        }
+        first_deploy_bootstrap::run_bootstrap(&session, setup)?;
+        ran_any = true;
+    }
+    Ok(ran_any)
+}
+
 pub fn run_deploy(cmd: DeployCmd) -> Result<()> {
     let available_apps = get_app_names()?;
     if available_apps.is_empty() {
@@ -318,6 +373,34 @@ pub fn run_deploy(cmd: DeployCmd) -> Result<()> {
         output::success(&format!("{} completed successfully", playbook_name));
 
         if !cmd.check {
+            if maybe_run_first_deploy_bootstrap(run, &host.name)? {
+                output::info(&format!(
+                    "Re-running {} to deploy reverse proxy and DNS after first-deploy bootstrap",
+                    playbook_name
+                ));
+                let mut progress = crate::services::progress::TerminalProgress::new("");
+                let result = run_playbook(
+                    preflight,
+                    &run.path,
+                    &inventory_host,
+                    cmd.check,
+                    run_tags,
+                    None,
+                    None,
+                    false,
+                    false,
+                    &mut progress,
+                )?;
+                if !result.success {
+                    eyre::bail!(
+                        "{} re-run after bootstrap failed with exit code {}",
+                        playbook_name,
+                        result.exit_code
+                    );
+                }
+                output::success(&format!("{} completed after bootstrap", playbook_name));
+            }
+
             run_dns_checks_for_run(run, &config, &host, cmd.verify_public_dns)?;
         }
     }
@@ -356,6 +439,45 @@ mod tests {
     fn test_validate_apps_empty_requested() {
         let available = vec!["paperless".to_string()];
         assert!(validate_apps(&[], &available).is_ok());
+    }
+
+    #[test]
+    fn test_meta_candidates_for_apps_run_uses_per_tag_files() {
+        let assets = AnsibleAssets::prepare().unwrap();
+        let apps_path = std::fs::canonicalize(assets.playbooks_dir().join("apps.yml")).unwrap();
+        let run = PlaybookRun {
+            path: apps_path,
+            tags: vec!["gokapi".to_string(), "freshrss".to_string()],
+        };
+        let candidates = meta_candidates_for_run(&run);
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates[0].ends_with("gokapi.meta.yml"));
+        assert!(candidates[1].ends_with("freshrss.meta.yml"));
+    }
+
+    #[test]
+    fn test_meta_candidates_for_direct_playbook_uses_playbook_stem() {
+        let assets = AnsibleAssets::prepare().unwrap();
+        let gokapi_path = std::fs::canonicalize(assets.playbooks_dir().join("gokapi.yml")).unwrap();
+        let run = PlaybookRun {
+            path: gokapi_path,
+            tags: vec![],
+        };
+        let candidates = meta_candidates_for_run(&run);
+        assert_eq!(candidates.len(), 1);
+        assert!(candidates[0].ends_with("gokapi.meta.yml"));
+    }
+
+    #[test]
+    fn test_meta_candidates_for_apps_run_with_no_tags_is_empty() {
+        let assets = AnsibleAssets::prepare().unwrap();
+        let apps_path = std::fs::canonicalize(assets.playbooks_dir().join("apps.yml")).unwrap();
+        let run = PlaybookRun {
+            path: apps_path,
+            tags: vec![],
+        };
+        let candidates = meta_candidates_for_run(&run);
+        assert!(candidates.is_empty());
     }
 
     #[test]

--- a/src/commands/host.rs
+++ b/src/commands/host.rs
@@ -348,7 +348,7 @@ pub fn run_host_detect_tailscale_ip(name_arg: Option<String>) -> Result<()> {
     Ok(())
 }
 
-fn resolve_ssh_key(host: &Host) -> Result<PathBuf> {
+pub fn resolve_ssh_key(host: &Host) -> Result<PathBuf> {
     let key = match host.ssh_key.as_ref() {
         Some(p) => PathBuf::from(shellexpand::tilde(p).into_owned()),
         None => dirs::home_dir()

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -13,6 +13,16 @@ pub struct PlaybookMeta {
     pub tailnet_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subdomain: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_deploy_setup: Option<FirstDeploySetup>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FirstDeploySetup {
+    pub port: u16,
+    pub marker_path: String,
+    pub setup_url_path: String,
+    pub wizard_name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -195,6 +205,42 @@ mod tests {
             backup.owner,
             Some(("gokapi".to_string(), "gokapi".to_string()))
         );
+    }
+
+    #[test]
+    fn test_gokapi_meta_first_deploy_setup() {
+        let setup = load_meta("gokapi")
+            .first_deploy_setup
+            .expect("gokapi declares first_deploy_setup");
+        assert_eq!(setup.port, 53842);
+        assert_eq!(setup.marker_path, "/var/lib/gokapi/config/config.json");
+        assert_eq!(setup.setup_url_path, "/setup");
+        assert_eq!(setup.wizard_name, "Gokapi setup wizard");
+    }
+
+    #[test]
+    fn test_meta_without_first_deploy_setup_parses_to_none() {
+        let yaml = "required_keys: []\n";
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        assert!(meta.first_deploy_setup.is_none());
+    }
+
+    #[test]
+    fn test_first_deploy_setup_all_fields_parse() {
+        let yaml = r#"
+required_keys: []
+first_deploy_setup:
+  port: 8443
+  marker_path: /var/lib/app/.bootstrap_done
+  setup_url_path: /install
+  wizard_name: App setup
+"#;
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        let setup = meta.first_deploy_setup.expect("first_deploy_setup present");
+        assert_eq!(setup.port, 8443);
+        assert_eq!(setup.marker_path, "/var/lib/app/.bootstrap_done");
+        assert_eq!(setup.setup_url_path, "/install");
+        assert_eq!(setup.wizard_name, "App setup");
     }
 
     #[test]

--- a/src/services.rs
+++ b/src/services.rs
@@ -4,5 +4,6 @@ pub mod bichon;
 pub mod dependency_resolver;
 pub mod dns;
 pub mod dns_verify;
+pub mod first_deploy_bootstrap;
 pub mod inventory;
 pub mod progress;

--- a/src/services/first_deploy_bootstrap.rs
+++ b/src/services/first_deploy_bootstrap.rs
@@ -1,0 +1,207 @@
+use crate::output;
+use crate::playbook_meta::FirstDeploySetup;
+use crate::ssh_session::SshSession;
+use eyre::{Result, WrapErr};
+use std::io::IsTerminal;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(3);
+const POLL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+pub struct TunnelHandle {
+    child: Option<Child>,
+}
+
+impl TunnelHandle {
+    pub fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+}
+
+impl Drop for TunnelHandle {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+pub fn marker_exists(ssh: &SshSession<'_>, marker_path: &str) -> Result<bool> {
+    let out = ssh
+        .run_raw(&["test", "-e", marker_path])
+        .wrap_err_with(|| format!("Failed to check for bootstrap marker at {marker_path}"))?;
+    Ok(out.status.success())
+}
+
+pub fn spawn_local_forward(ssh: &SshSession<'_>, port: u16) -> Result<TunnelHandle> {
+    let forward = format!("{port}:127.0.0.1:{port}");
+    let mut cmd = Command::new("ssh");
+    cmd.args(ssh.ssh_args());
+    cmd.args(["-N", "-L", &forward]);
+    let child = cmd
+        .spawn()
+        .wrap_err_with(|| format!("Failed to spawn SSH local forward on port {port}"))?;
+    thread::sleep(Duration::from_millis(500));
+    Ok(TunnelHandle::new(child))
+}
+
+pub fn wait_for_marker<F>(check: F, interval: Duration, timeout: Duration) -> Result<()>
+where
+    F: Fn() -> Result<bool>,
+{
+    let start = Instant::now();
+    loop {
+        if check()? {
+            return Ok(());
+        }
+        if start.elapsed() >= timeout {
+            eyre::bail!(
+                "Timed out waiting for Bootstrap Marker after {} seconds",
+                timeout.as_secs()
+            );
+        }
+        thread::sleep(interval);
+    }
+}
+
+pub fn run_bootstrap(ssh: &SshSession<'_>, setup: &FirstDeploySetup) -> Result<()> {
+    if marker_exists(ssh, &setup.marker_path)? {
+        return Ok(());
+    }
+
+    let url = format!("http://localhost:{}{}", setup.port, setup.setup_url_path);
+
+    if !std::io::stderr().is_terminal() {
+        print_manual_instructions(ssh, setup, &url);
+        eyre::bail!(
+            "{} requires interactive setup; rerun in a terminal or follow the manual instructions above",
+            setup.wizard_name
+        );
+    }
+
+    output::info(&format!("{} requires one-time setup.", setup.wizard_name));
+    output::info(&format!(
+        "Opening SSH tunnel to {}@{}:{} and launching browser at {}",
+        ssh.host.user, ssh.host.address, setup.port, url
+    ));
+
+    let _tunnel = spawn_local_forward(ssh, setup.port)?;
+
+    if let Err(e) = open::that(&url) {
+        output::warn(&format!(
+            "Could not open browser automatically ({e}). Open this URL manually: {url}"
+        ));
+    }
+
+    output::info(&format!(
+        "Waiting for {} to complete (polling {} every {}s, Ctrl+C to abort)",
+        setup.wizard_name,
+        setup.marker_path,
+        POLL_INTERVAL.as_secs()
+    ));
+
+    wait_for_marker(
+        || marker_exists(ssh, &setup.marker_path),
+        POLL_INTERVAL,
+        POLL_TIMEOUT,
+    )?;
+
+    output::success(&format!("{} completed.", setup.wizard_name));
+    Ok(())
+}
+
+fn print_manual_instructions(ssh: &SshSession<'_>, setup: &FirstDeploySetup, url: &str) {
+    eprintln!();
+    output::warn(&format!(
+        "{} requires one-time interactive setup (non-interactive terminal detected)",
+        setup.wizard_name
+    ));
+    eprintln!(
+        "  1. From your laptop, open an SSH tunnel:\n     ssh -L {port}:127.0.0.1:{port} {user}@{addr}",
+        port = setup.port,
+        user = ssh.host.user,
+        addr = ssh.host.address,
+    );
+    eprintln!("  2. In a browser, open:\n     {url}");
+    eprintln!("  3. Complete the wizard, then re-run `auberge deploy` so Caddy + DNS land.",);
+    eprintln!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn wait_for_marker_returns_immediately_when_already_present() {
+        let result = wait_for_marker(
+            || Ok(true),
+            Duration::from_millis(1),
+            Duration::from_millis(100),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn wait_for_marker_polls_until_present() {
+        let attempts = Cell::new(0);
+        let result = wait_for_marker(
+            || {
+                let n = attempts.get();
+                attempts.set(n + 1);
+                Ok(n >= 3)
+            },
+            Duration::from_millis(1),
+            Duration::from_millis(500),
+        );
+        assert!(result.is_ok());
+        assert_eq!(attempts.get(), 4);
+    }
+
+    #[test]
+    fn wait_for_marker_times_out() {
+        let result = wait_for_marker(
+            || Ok(false),
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Timed out"));
+    }
+
+    #[test]
+    fn wait_for_marker_propagates_check_error() {
+        let result = wait_for_marker(
+            || eyre::bail!("SSH connection refused"),
+            Duration::from_millis(1),
+            Duration::from_millis(100),
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("SSH connection refused"));
+    }
+
+    #[test]
+    fn tunnel_handle_kills_child_on_drop() {
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        {
+            let _h = TunnelHandle::new(child);
+        }
+        thread::sleep(Duration::from_millis(50));
+        let status = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .expect("kill -0");
+        assert!(
+            !status.success(),
+            "child process should be dead after TunnelHandle drop"
+        );
+    }
+}


### PR DESCRIPTION
First-deploy of Gokapi (and any future App with an unauthenticated bootstrap) now completes in one `auberge deploy` invocation. Closes #343. Rationale and considered alternatives in ADR-0009.

```
master ← #X (this)
```

## What changes for the operator

Today: `auberge deploy gokapi` → installs binary → halts silently because Caddy + DNS are gated → operator reads the playbook's `debug` task → runs `ssh -L 53842:127.0.0.1:53842 host` → completes wizard → `auberge deploy gokapi` again.

After: `auberge deploy gokapi` → installs binary → auberge SSH-checks the Bootstrap Marker → finds it absent → spawns the tunnel + opens browser → polls until marker present → kills tunnel → re-runs the playbook → DNS verifies → done.

## Stack

| Anchor | File | Assertion |
|--------|------|-----------|
| Schema | `src/playbook_meta.rs:17,19-25` | `PlaybookMeta` gains `first_deploy_setup: Option<FirstDeploySetup>`; new struct has `port`/`marker_path`/`setup_url_path`/`wizard_name`. |
| Declaration | `ansible/playbooks/gokapi.meta.yml` | Gokapi declares it. No other App does. |
| Orchestration | `src/services/first_deploy_bootstrap.rs` | `run_bootstrap`, `marker_exists`, `spawn_local_forward`, `wait_for_marker`, `TunnelHandle` (RAII). |
| Integration | `src/commands/deploy.rs:280-335` | `maybe_run_first_deploy_bootstrap` + per-tag meta lookup for `apps.yml` runs. |
| Domain | `CONTEXT.md`, `meta/adr/0009-*.md` | New terms: **First-Deploy Bootstrap**, **Bootstrap Marker**. |

## Test plan

- [x] `cargo test` — 343 passed, 0 failed (was 335 + 8 new).
- [x] `cargo clippy --all-targets` — no new warnings on touched files.
- [x] `cargo fmt --check` — clean.
- [x] Pre-commit hooks (clippy --fix, ansible-lint, dprint) — clean.
- [x] Schema parsing: `test_gokapi_meta_first_deploy_setup`, `test_meta_without_first_deploy_setup_parses_to_none`, `test_first_deploy_setup_all_fields_parse`.
- [x] Polling: `wait_for_marker_returns_immediately_when_already_present`, `wait_for_marker_polls_until_present`, `wait_for_marker_times_out`, `wait_for_marker_propagates_check_error`.
- [x] Tunnel teardown: `tunnel_handle_kills_child_on_drop` verifies the RAII guard kills the child SSH on drop (regression test for the "tunnel lingers if auberge panics" failure mode).
- [x] Dispatcher: `test_meta_candidates_for_apps_run_uses_per_tag_files`, `test_meta_candidates_for_direct_playbook_uses_playbook_stem`, `test_meta_candidates_for_apps_run_with_no_tags_is_empty`.
- [ ] Live verification: redeploy Gokapi on a clean VPS state to confirm the end-to-end flow lands DNS in one invocation. Will exercise post-merge.

## Security

> [!IMPORTANT]
> Same posture as today's manual flow. UFW still default-denies inbound on the wizard port; tunnel traffic flows inside the SSH-encrypted channel; auth is delegated to SSH key auth. The change moves a step from the operator's shell to auberge's process tree — no new attack surface.

## Out of scope

- The `gokapi` role's `debug` task with manual instructions (`ansible/roles/gokapi/tasks/main.yml:156-173`) is left in place to support raw `ansible-playbook` invocations outside auberge. Removal can come later if we drop that support.
- Templated `config.json` (skip the wizard entirely) is the natural next step for unattended/disaster-recovery deploys but adds schema coupling to upstream Gokapi. Deferred until a CI rebuild flow exists. See ADR-0009 "Considered alternatives".