### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/sripwoud/auberge/compare/v0.13.0...v0.14.0) - 2026-05-20
+
+### Added
+
+- *(gokapi)* [**breaking**] headless bootstrap via templated config + --deployment-password ([#346](https://github.com/sripwoud/auberge/pull/346))
+
+### Other
+
+- *(deps)* bump openssl from 0.10.79 to 0.10.80 in the cargo group across 1 directory ([#342](https://github.com/sripwoud/auberge/pull/342))
+
 ## [0.13.0](https://github.com/sripwoud/auberge/compare/v0.12.3...v0.13.0) - 2026-05-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.13.0 -> 0.14.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.0](https://github.com/sripwoud/auberge/compare/v0.13.0...v0.14.0) - 2026-05-20

### Added

- *(gokapi)* [**breaking**] headless bootstrap via templated config + --deployment-password ([#346](https://github.com/sripwoud/auberge/pull/346))

### Other

- *(deps)* bump openssl from 0.10.79 to 0.10.80 in the cargo group across 1 directory ([#342](https://github.com/sripwoud/auberge/pull/342))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).