### PR TITLE
fix(gokapi): bind address requires colon prefix (:PORT)

### DIFF
--- a/ansible/roles/gokapi/tasks/main.yml
+++ b/ansible/roles/gokapi/tasks/main.yml
@@ -133,6 +133,13 @@
         force: false
       notify: Restart gokapi
 
+    - name: Migrate existing config.json Port to bind-address form (Gokapi >=2.2.4 requires ":N", not "N")
+      ansible.builtin.replace:
+        path: "{{ gokapi_config_dir }}/config.json"
+        regexp: '"Port":\s*"([0-9]+)"'
+        replace: '"Port": ":\1"'
+      notify: Restart gokapi
+
     - name: Deploy Gokapi systemd service file
       ansible.builtin.template:
         src: templates/gokapi.service.j2

--- a/ansible/roles/gokapi/templates/config.json.j2
+++ b/ansible/roles/gokapi/templates/config.json.j2
@@ -3,7 +3,7 @@
     "Method": 0,
     "Username": "{{ gokapi_admin_user }}"
   },
-  "Port": "{{ gokapi_port }}",
+  "Port": ":{{ gokapi_port }}",
   "ServerUrl": "https://{{ gokapi_domain }}/",
   "DataDir": "{{ gokapi_data_dir }}/data",
   "DatabaseUrl": "sqlite://{{ gokapi_data_dir }}/gokapi.sqlite",

--- a/ansible/roles/gokapi/templates/gokapi.service.j2
+++ b/ansible/roles/gokapi/templates/gokapi.service.j2
@@ -10,7 +10,7 @@ Group={{ gokapi_sys_group }}
 WorkingDirectory={{ gokapi_data_dir }}
 Environment=GOKAPI_CONFIG_DIR={{ gokapi_config_dir }}
 Environment=GOKAPI_DATA_DIR={{ gokapi_data_dir }}/data
-Environment=GOKAPI_PORT={{ gokapi_port }}
+Environment=GOKAPI_PORT=:{{ gokapi_port }}
 Environment=GOKAPI_USE_CLOUDFLARE=true
 Environment=GOKAPI_TRUSTED_PROXIES=127.0.0.1
 ExecStart={{ gokapi_install_path }}/gokapi


### PR DESCRIPTION
Service crash-looping on `partage.sripwoud.xyz`; Caddy returns 502.

## Root cause

Gokapi v2.2.4 passes the configured `Port` straight to `net.Listen`. A bare `"53842"` is parsed as hostname-with-missing-port:

```
Binding webserver to 53842
2026/05/20 15:50:35 listen tcp: address 53842: missing port in address
gokapi.service: Main process exited, code=exited, status=1/FAILURE
```

Both `config.json.j2` and `gokapi.service.j2` (env `GOKAPI_PORT`) were templated with bare port, introduced by #346's headless-bootstrap path.

## Fix

| File | Change |
| --- | --- |
| `ansible/roles/gokapi/templates/config.json.j2` | `"Port": ":{{ gokapi_port }}"` |
| `ansible/roles/gokapi/templates/gokapi.service.j2` | `Environment=GOKAPI_PORT=:{{ gokapi_port }}` |
| `ansible/roles/gokapi/tasks/main.yml` | `replace` task migrates existing `config.json` |

The role's `config.json` template uses `force: false` to preserve admin-UI edits, so template-only fixes don't repair already-bootstrapped hosts. The `replace` regex `"Port":\s*"([0-9]+)"` is naturally idempotent — once rewritten to `":53842"`, the `[0-9]+` anchor no longer matches.

## Test plan

- [ ] `auberge deploy --tags gokapi` on `auberge`
- [ ] `systemctl status gokapi.service` → `active (running)`
- [ ] `curl -sI https://partage.sripwoud.xyz/` → `200 OK`
- [ ] Second `auberge deploy --tags gokapi` reports the `replace` task as unchanged