### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/sripwoud/auberge/compare/v0.14.0...v0.14.1) - 2026-05-20
+
+### Fixed
+
+- *(gokapi)* bind address requires colon prefix (:PORT) ([#348](https://github.com/sripwoud/auberge/pull/348))
+
+### Other
+
+- update gokapi page
+
 ## [0.14.0](https://github.com/sripwoud/auberge/compare/v0.13.0...v0.14.0) - 2026-05-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.0 -> 0.14.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.1](https://github.com/sripwoud/auberge/compare/v0.14.0...v0.14.1) - 2026-05-20

### Fixed

- *(gokapi)* bind address requires colon prefix (:PORT) ([#348](https://github.com/sripwoud/auberge/pull/348))

### Other

- update gokapi page
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).