### PR TITLE
fix(gokapi): GOKAPI_PORT env must be bare digits (parsed as int)

### DIFF
--- a/ansible/roles/gokapi/templates/gokapi.service.j2
+++ b/ansible/roles/gokapi/templates/gokapi.service.j2
@@ -10,7 +10,7 @@ Group={{ gokapi_sys_group }}
 WorkingDirectory={{ gokapi_data_dir }}
 Environment=GOKAPI_CONFIG_DIR={{ gokapi_config_dir }}
 Environment=GOKAPI_DATA_DIR={{ gokapi_data_dir }}/data
-Environment=GOKAPI_PORT=:{{ gokapi_port }}
+Environment=GOKAPI_PORT={{ gokapi_port }}
 Environment=GOKAPI_USE_CLOUDFLARE=true
 Environment=GOKAPI_TRUSTED_PROXIES=127.0.0.1
 ExecStart={{ gokapi_install_path }}/gokapi


### PR DESCRIPTION
Follow-up to #348. Service still 502s; new failure mode at startup:

```
Error parsing env variables: env: parse error on field "WebserverPort"
of type "int": strconv.ParseInt: parsing ":53842": invalid syntax
```

## Why #348 wasn't enough

Gokapi v2.2.4 exposes the port through two surfaces with **opposite** syntactic requirements:

| Source | Go type | Required form |
| --- | --- | --- |
| env `GOKAPI_PORT` | `int` (`WebserverPort` field) | `53842` |
| `config.json` `Port` | `string` → `net.Listen` | `:53842` |

#348 correctly added the colon to both. The config.json change is the one that reaches `net.Listen` (confirmed by tracing: original error said `address 53842: missing port`, and the historical wizard-bootstrapped hosts wrote `":53842"` to config.json and worked). The env-var change crashed env decoding before Listen was ever reached.

## Fix

Revert only the env var to bare digits. Config.json's `Port` keeps `:` from #348's still-in-place migration task and template.

## Test plan

- [ ] `auberge deploy --tags gokapi`
- [ ] `systemctl status gokapi.service` → `active (running)`
- [ ] `curl -sI https://partage.sripwoud.xyz/` → `200 OK`
- [ ] Journal shows `Binding webserver to 53842` followed by no further errors