### PR TITLE
chore: release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2](https://github.com/sripwoud/auberge/compare/v0.14.1...v0.14.2) - 2026-05-20
+
+### Fixed
+
+- *(gokapi)* set MaxFileSizeMB and MaxMemory to unblock uploads ([#353](https://github.com/sripwoud/auberge/pull/353))
+- *(gokapi)* set RedirectUrl to avoid root URL meta-refresh loop ([#352](https://github.com/sripwoud/auberge/pull/352))
+- *(gokapi)* GOKAPI_PORT env must be bare digits (parsed as int) ([#350](https://github.com/sripwoud/auberge/pull/350))
+
 ## [0.14.1](https://github.com/sripwoud/auberge/compare/v0.14.0...v0.14.1) - 2026-05-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.1 -> 0.14.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.2](https://github.com/sripwoud/auberge/compare/v0.14.1...v0.14.2) - 2026-05-20

### Fixed

- *(gokapi)* set MaxFileSizeMB and MaxMemory to unblock uploads ([#353](https://github.com/sripwoud/auberge/pull/353))
- *(gokapi)* set RedirectUrl to avoid root URL meta-refresh loop ([#352](https://github.com/sripwoud/auberge/pull/352))
- *(gokapi)* GOKAPI_PORT env must be bare digits (parsed as int) ([#350](https://github.com/sripwoud/auberge/pull/350))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).