### PR TITLE
fix(gokapi): set RedirectUrl to avoid root URL meta-refresh loop

### DIFF
--- a/ansible/roles/gokapi/defaults/main.yml
+++ b/ansible/roles/gokapi/defaults/main.yml
@@ -5,6 +5,7 @@ gokapi_sys_user: gokapi
 gokapi_sys_group: gokapi
 gokapi_port: 53842
 gokapi_domain: "{{ gokapi_subdomain }}.{{ domain }}"
+gokapi_redirect_url: "/admin"
 gokapi_version: "2.2.4"
 gokapi_archive_url: "https://github.com/Forceu/Gokapi/releases/download/v{{ gokapi_version }}/gokapi-{{ gokapi_version }}_linux-amd64.zip"
 gokapi_archive_sha256: "51dbf724c94f8afa0b40fb1ef63a1fe418e7996e7b9536e1f0a5da695b8e18ef"

--- a/ansible/roles/gokapi/tasks/main.yml
+++ b/ansible/roles/gokapi/tasks/main.yml
@@ -140,6 +140,13 @@
         replace: '"Port": ":\1"'
       notify: Restart gokapi
 
+    - name: Migrate empty RedirectUrl to {{ gokapi_redirect_url }} (Gokapi emits a broken meta-refresh on root URL when RedirectUrl is empty)
+      ansible.builtin.replace:
+        path: "{{ gokapi_config_dir }}/config.json"
+        regexp: '"RedirectUrl":\s*""'
+        replace: '"RedirectUrl": "{{ gokapi_redirect_url }}"'
+      notify: Restart gokapi
+
     - name: Deploy Gokapi systemd service file
       ansible.builtin.template:
         src: templates/gokapi.service.j2

--- a/ansible/roles/gokapi/templates/config.json.j2
+++ b/ansible/roles/gokapi/templates/config.json.j2
@@ -5,6 +5,7 @@
   },
   "Port": ":{{ gokapi_port }}",
   "ServerUrl": "https://{{ gokapi_domain }}/",
+  "RedirectUrl": "{{ gokapi_redirect_url }}",
   "DataDir": "{{ gokapi_data_dir }}/data",
   "DatabaseUrl": "sqlite://{{ gokapi_data_dir }}/gokapi.sqlite",
   "ConfigVersion": 22,


### PR DESCRIPTION
Visiting `partage.sripwoud.xyz/` flickered between `/` and `/index` in browsers. Gokapi emits a meta-refresh tag with an empty `URL=` when its `RedirectUrl` field is unset, and browsers resolve empty meta-refresh URLs inconsistently (current document URL vs. base URL vs. referrer) — producing the loop.

Defaults `RedirectUrl` to `/admin` so unauthenticated root visitors land on the login page. Friends with direct file links (`/<id>`) are unaffected; they never touch root.

## Changes

| File | Change |
|---|---|
| `defaults/main.yml` | `gokapi_redirect_url: "/admin"` |
| `templates/config.json.j2` | adds `"RedirectUrl": "{{ gokapi_redirect_url }}"` |
| `tasks/main.yml` | new `replace` migration: empty `RedirectUrl` → `/admin` |

Migration regex matches only `"RedirectUrl": ""` — operator customizations via the admin UI survive redeploy. Mirrors the existing `Port` migration pattern.

## Verification

Already hot-fixed on the live host. Redirect chain now terminates:

```
/       → /index
/index  → /admin
/admin  → /login   ← real Gokapi UI
```

## Test plan

- [x] Hot-fix applied to `auberge`; `partage.sripwoud.xyz` no longer flickers
- [ ] `auberge deploy --tags gokapi` on a host with pre-existing empty `RedirectUrl` → migration triggers, restart fires
- [ ] Re-run deploy → migration idempotent (no change reported)