### PR TITLE
fix(gokapi): set MaxFileSizeMB and MaxMemory to unblock uploads

### DIFF
--- a/ansible/roles/gokapi/defaults/main.yml
+++ b/ansible/roles/gokapi/defaults/main.yml
@@ -6,6 +6,8 @@ gokapi_sys_group: gokapi
 gokapi_port: 53842
 gokapi_domain: "{{ gokapi_subdomain }}.{{ domain }}"
 gokapi_redirect_url: "/admin"
+gokapi_max_file_size_mb: 102400
+gokapi_max_memory_mb: 50
 gokapi_version: "2.2.4"
 gokapi_archive_url: "https://github.com/Forceu/Gokapi/releases/download/v{{ gokapi_version }}/gokapi-{{ gokapi_version }}_linux-amd64.zip"
 gokapi_archive_sha256: "51dbf724c94f8afa0b40fb1ef63a1fe418e7996e7b9536e1f0a5da695b8e18ef"

--- a/ansible/roles/gokapi/tasks/main.yml
+++ b/ansible/roles/gokapi/tasks/main.yml
@@ -140,11 +140,28 @@
         replace: '"Port": ":\1"'
       notify: Restart gokapi
 
-    - name: Migrate empty RedirectUrl to {{ gokapi_redirect_url }} (Gokapi emits a broken meta-refresh on root URL when RedirectUrl is empty)
+    # Gokapi emits a broken meta-refresh on root URL when RedirectUrl is empty
+    - name: Migrate empty RedirectUrl to {{ gokapi_redirect_url }}
       ansible.builtin.replace:
         path: "{{ gokapi_config_dir }}/config.json"
         regexp: '"RedirectUrl":\s*""'
         replace: '"RedirectUrl": "{{ gokapi_redirect_url }}"'
+      notify: Restart gokapi
+
+    # Gokapi has no runtime fallback; MaxFileSizeMB=0 blocks all uploads with "upload limit exceeded"
+    - name: Migrate MaxFileSizeMB=0 to {{ gokapi_max_file_size_mb }}
+      ansible.builtin.replace:
+        path: "{{ gokapi_config_dir }}/config.json"
+        regexp: '"MaxFileSizeMB":\s*0\b'
+        replace: '"MaxFileSizeMB": {{ gokapi_max_file_size_mb }}'
+      notify: Restart gokapi
+
+    # Gokapi has no runtime fallback; MaxMemory=0 disables multipart memory buffering
+    - name: Migrate MaxMemory=0 to {{ gokapi_max_memory_mb }}
+      ansible.builtin.replace:
+        path: "{{ gokapi_config_dir }}/config.json"
+        regexp: '"MaxMemory":\s*0\b'
+        replace: '"MaxMemory": {{ gokapi_max_memory_mb }}'
       notify: Restart gokapi
 
     - name: Deploy Gokapi systemd service file

--- a/ansible/roles/gokapi/templates/config.json.j2
+++ b/ansible/roles/gokapi/templates/config.json.j2
@@ -9,6 +9,8 @@
   "DataDir": "{{ gokapi_data_dir }}/data",
   "DatabaseUrl": "sqlite://{{ gokapi_data_dir }}/gokapi.sqlite",
   "ConfigVersion": 22,
+  "MaxFileSizeMB": {{ gokapi_max_file_size_mb }},
+  "MaxMemory": {{ gokapi_max_memory_mb }},
   "Encryption": {
     "Level": 0
   }


### PR DESCRIPTION
Admin uploads fail with `upload limit exceeded` immediately. Gokapi rejects every non-empty file because `isAllowedFileSize(size)` returns `size <= int64(MaxFileSizeMB)*1024*1024` — and `MaxFileSizeMB` is `0` in the deployed config.

Gokapi's setup wizard writes `MaxFileSizeMB` (default `102400` = 100 GB) and `MaxMemory` (default `50`) on first run, but our headless bootstrap (`--deployment-password`) skips the wizard. Both fields fall back to Go's zero value. Unlike `ChunkSize` and `MaxParallelUploads`, neither has a runtime fallback in `configuration.Load()`.

```go
// internal/storage/FileServing.go:127
func isAllowedFileSize(size int64) bool {
    return size <= int64(configuration.Get().MaxFileSizeMB)*1024*1024
}
```

## Changes

| File | Change |
|---|---|
| `defaults/main.yml` | `gokapi_max_file_size_mb: 102400`, `gokapi_max_memory_mb: 50` |
| `templates/config.json.j2` | adds `MaxFileSizeMB`, `MaxMemory` |
| `tasks/main.yml` | two `replace` migrations: `0` → defaults |

Migration regexes use `\b` word boundaries so they match only `: 0`, never `: 0,` or `: 102400`. Admin-UI customizations survive redeploys.

## Verification

Hot-fixed on `auberge` before opening this PR. Site no longer rejects uploads.

## Test plan

- [x] Hot-fix applied to live host; admin upload succeeds
- [ ] `auberge deploy --tags gokapi` on host with pre-existing `0` values → migration triggers, restart fires
- [ ] Re-run → migration idempotent

## Related

Same root cause family as #352 (RedirectUrl empty → meta-refresh loop). Both are wizard-set defaults missing from the headless bootstrap path. Could be folded into a single "backfill wizard defaults" follow-up if you want a unified history.