### PR TITLE
fix(blocky): skip api.tailscale.com DNS calls on Headscale tailnets

### DIFF
--- a/ansible/roles/blocky/tasks/main.yml
+++ b/ansible/roles/blocky/tasks/main.yml
@@ -231,6 +231,7 @@
 
 - name: Configure Tailscale DNS to use Blocky
   when:
+    - tailscale_login_server is not defined or tailscale_login_server | length == 0
     - tailscale_api_key is defined and tailscale_api_key | length > 0
     - blocky_tailscale_ipv4 is defined and blocky_tailscale_ipv4 | length > 0
   no_log: true


### PR DESCRIPTION
On Headscale tailnets, `auberge deploy` failed with a `401 Unauthorized` from `api.tailscale.com` whenever a stale `tailscale_api_key` was set — blocking the entire deploy, since `blocky` is a Substrate App that runs every deploy (ADR-0005).

## Cause

The *Configure Tailscale DNS to use Blocky* block hits the official Tailscale API but only guarded on `tailscale_api_key` being non-empty. Headscale operators with a leftover key reach `api.tailscale.com`, which rejects it.

On Headscale, split-DNS routing to Blocky is already handled declaratively by the `headscale` role (`headscale-config.yaml.j2` → `dns.nameservers.split`). The block should not run there at all.

## Fix

Add one `when` condition gating the block to official Tailscale only — `tailscale_login_server` empty (non-empty ⇒ Headscale, per its Key Registry doc):

`ansible/roles/blocky/tasks/main.yml`
```yaml
when:
  - tailscale_login_server is not defined or tailscale_login_server | length == 0
  - tailscale_api_key is defined and tailscale_api_key | length > 0
  - blocky_tailscale_ipv4 is defined and blocky_tailscale_ipv4 | length > 0
```

The `is not defined` branch avoids an undefined-variable error since the `tailscale` role default may not be in `blocky`'s scope.

## Test plan

- [x] `ansible-lint` passes (production profile, 0 failures/warnings)
- [x] Official Tailscale (`tailscale_login_server` empty): all three conditions hold → block runs, behavior unchanged
- [x] Headscale (`tailscale_login_server` set): first condition false → block skipped, no `api.tailscale.com` call, no 401

Closes #356