### PR TITLE
chore: release v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.3](https://github.com/sripwoud/auberge/compare/v0.14.2...v0.14.3) - 2026-06-10
+
+### Added
+
+- *(baikal)* host-sanitized Busy Feed (Baikal + optional iCloud) behind a token ([#355](https://github.com/sripwoud/auberge/pull/355))
+
+### Fixed
+
+- *(blocky)* skip api.tailscale.com DNS calls on Headscale tailnets ([#357](https://github.com/sripwoud/auberge/pull/357))
+
 ## [0.14.2](https://github.com/sripwoud/auberge/compare/v0.14.1...v0.14.2) - 2026-05-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.2 -> 0.14.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.3](https://github.com/sripwoud/auberge/compare/v0.14.2...v0.14.3) - 2026-06-10

### Added

- *(baikal)* host-sanitized Busy Feed (Baikal + optional iCloud) behind a token ([#355](https://github.com/sripwoud/auberge/pull/355))

### Fixed

- *(blocky)* skip api.tailscale.com DNS calls on Headscale tailnets ([#357](https://github.com/sripwoud/auberge/pull/357))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).