### PR TITLE
fix(hooks): bump hk config schema to 1.47.0

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.32.0/hk@1.32.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.32.0/hk@1.32.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Builtins.pkl"
 
 local linters  = new Mapping<String, Step> {
   ["ansible"] {


### PR DESCRIPTION
Restores the `pre-commit` hook, broken repo-wide.

`mise.toml` pins `hk = "latest"` → installs **1.47.0**, but `hk.pkl` amends the config/builtins package from **1.32.0**. The newer runtime can't evaluate the older schema and panics on every commit:

```
Eval error: undefined variable: extra_files
```

Any `git commit` (or `hk run pre-commit` / `hk check`) fails before a single file is checked — independent of staged content.

### Fix
Align both `package://.../hk@<ver>` URLs in `hk.pkl` with the installed `hk` (1.47.0). The 1.32→1.47 config schema is source-compatible — `linters`, `hooks`, and `Step` fields are unchanged.

### Verification
- [x] `hk run pre-commit` → `ansible-lint` passes (production profile), `dprint` clean, exit 0
- [x] This commit was created with the fixed hook active (self-bootstrapping)

> [!NOTE]
> `mise.toml` keeps `hk = "latest"`, so the pin can drift again on the next hk minor that changes the schema. A follow-up could pin `hk` to a fixed version to make the lockstep explicit.