### PR TITLE
feat(swap): provision 4G swap file via infrastructure playbook

### DIFF
--- a/ansible/playbooks/infrastructure.yml
+++ b/ansible/playbooks/infrastructure.yml
@@ -3,6 +3,8 @@
   hosts: vps
   become: true
   roles:
+    - role: swap
+      tags: [infrastructure, system, swap]
     - role: apt
       tags: [infrastructure, packages, apt]
     - role: bash

--- a/ansible/roles/swap/defaults/main.yml
+++ b/ansible/roles/swap/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+swap_file_path: /swapfile
+swap_file_size_mb: 4096
+swap_swappiness: 10

--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Swap File Configuration
+  block:
+    - name: Check whether swap file already exists
+      ansible.builtin.stat:
+        path: "{{ swap_file_path }}"
+      register: swap_file
+
+    - name: Allocate swap file
+      ansible.builtin.command:
+        cmd: "fallocate -l {{ swap_file_size_mb }}M {{ swap_file_path }}"
+        creates: "{{ swap_file_path }}"
+
+    - name: Restrict swap file permissions
+      ansible.builtin.file:
+        path: "{{ swap_file_path }}"
+        owner: root
+        group: root
+        mode: "0600"
+
+    - name: Format swap file
+      ansible.builtin.command:
+        cmd: "mkswap {{ swap_file_path }}"
+      when: not swap_file.stat.exists
+      register: swap_mkswap
+      changed_when: swap_mkswap.rc == 0
+
+    - name: Persist swap file in fstab
+      ansible.posix.mount:
+        path: none
+        src: "{{ swap_file_path }}"
+        fstype: swap
+        opts: sw
+        state: present
+
+    - name: Activate swap file
+      ansible.builtin.command:
+        cmd: "swapon {{ swap_file_path }}"
+      when: not swap_file.stat.exists
+      register: swap_swapon
+      changed_when: swap_swapon.rc == 0
+
+    - name: Set swappiness
+      ansible.posix.sysctl:
+        name: vm.swappiness
+        value: "{{ swap_swappiness }}"
+        state: present
+        sysctl_set: true
+        reload: true


### PR DESCRIPTION
Stops OOM kills on the memory-constrained VPS. Paperless uploads of large PDFs (13 MB, German-scan multi-page) die at thumbnail generation:

```
convert exited -9 ... died with <Signals.SIGKILL: 9>
```

`-9` = killed by signal, not a clean exit — the OOM killer. ImageMagick rasterizes page 0 at `-density 300`; a large page balloons past available RAM, and with **zero swap** there's no overflow buffer, so the kernel SIGKILLs `convert` mid-render. The trailing `NotNullViolation` on `documents_paperlesstask.status` is downstream noise from the worker dying mid-task.

### VPS state at diagnosis
| Resource | Total | Available |
|---|---|---|
| RAM | 3.8 Gi | ~1.1 Gi |
| Swap | **0 B** | 0 B |
| Disk `/` | 118 G | **94 G free** |

RAM-poor but disk-rich → trade cheap idle disk for swap headroom.

### Change
New `swap` role, first in the Layer-2 `infrastructure.yml` (foundational system resource, before `apt`):

| Setting | Default | Why |
|---|---|---|
| `swap_file_size_mb` | `4096` | Doubles effective memory to ~7.8 G |
| `swap_swappiness` | `10` | Engage only under real pressure, not eagerly |
| `swap_file_path` | `/swapfile` | — |

Idempotent: `fallocate` guarded by `creates`; `mkswap`/`swapon` gated on a prior `stat`; fstab via `ansible.posix.mount`; swappiness via `ansible.posix.sysctl` (declared collection dep).

```
master ← #359 (fix-hk-pkl-1.47) ← this
```

### Test plan
- [x] `ansible-lint` passes at the production profile
- [ ] Deploy `infrastructure.yml --tags swap`, confirm `swapon --show` and `free -h` show 4G swap
- [ ] Re-upload the 13 MB PDF to paperless → consumes without SIGKILL

> [!NOTE]
> Pairing with `--concurrency 1` on the celery worker (`paperless-task-queue.service.j2`) would further cap paperless peak RAM — deliberately left out to keep this PR scoped to swap.