### PR TITLE
chore: release v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.4](https://github.com/sripwoud/auberge/compare/v0.14.3...v0.14.4) - 2026-06-20
+
+### Added
+
+- *(swap)* provision 4G swap file via infrastructure playbook ([#360](https://github.com/sripwoud/auberge/pull/360))
+
+### Fixed
+
+- *(hooks)* bump hk config schema to 1.47.0 ([#359](https://github.com/sripwoud/auberge/pull/359))
+
 ## [0.14.3](https://github.com/sripwoud/auberge/compare/v0.14.2...v0.14.3) - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "auberge"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.3 -> 0.14.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.4](https://github.com/sripwoud/auberge/compare/v0.14.3...v0.14.4) - 2026-06-20

### Added

- *(swap)* provision 4G swap file via infrastructure playbook ([#360](https://github.com/sripwoud/auberge/pull/360))

### Fixed

- *(hooks)* bump hk config schema to 1.47.0 ([#359](https://github.com/sripwoud/auberge/pull/359))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).