### PR TITLE
docs: fix internal links for Docsify root-relative resolution

### DIFF
--- a/docs/about/alternatives.md
+++ b/docs/about/alternatives.md
@@ -91,7 +91,7 @@ The platforms above solve real problems. Auberge targets a narrower set of prior
 - **Pick your tools**: Caddy over Nginx, Blocky over Dnsmasq, Headscale for mesh networking — opinionated defaults, but the Ansible roles are yours to modify
 - **FOSS licensing**: AGPL-3.0, no commercial pivot risk
 
-Auberge is selfware — software I built to manage my own infrastructure. My needs drive every decision. That said, if you share similar priorities — minimal footprint, reproducibility, direct control — you might find it useful too. Contributions, feedback, and ideas are welcome. The [Contributing guide](../development/contributing.md) is a good place to start.
+Auberge is selfware — software I built to manage my own infrastructure. My needs drive every decision. That said, if you share similar priorities — minimal footprint, reproducibility, direct control — you might find it useful too. Contributions, feedback, and ideas are welcome. The [Contributing guide](development/contributing.md) is a good place to start.
 
 The platforms above do more than I need in some places, less in others. Auberge is shaped around my specific priorities.
 

--- a/docs/applications/apps/baikal.md
+++ b/docs/applications/apps/baikal.md
@@ -31,7 +31,7 @@ Birthday sync reads `BDAY` fields from contacts and populates a dedicated "Birth
 sudo systemctl start baikal-birthday-sync.service
 ```
 
-Backed up by default (`/opt/baikal/Specific`). See [Backup & Restore](../../backup-restore/overview.md).
+Backed up by default (`/opt/baikal/Specific`). See [Backup & Restore](backup-restore/overview.md).
 
 ## Busy Feed
 

--- a/docs/applications/apps/bichon.md
+++ b/docs/applications/apps/bichon.md
@@ -2,7 +2,7 @@
 
 Email archiving service with continuous IMAP sync and full-text search. Docs: [github.com/rustmailer/bichon](https://github.com/rustmailer/bichon)
 
-- **URL**: tailnet only — see [Tailnet-only apps](../../cli-reference/dns/set-all.md#tailnet-only-apps)
+- **URL**: tailnet only — see [Tailnet-only apps](cli-reference/dns/set-all.md#tailnet-only-apps)
 - **Port**: internal (Caddy proxy)
 - **Data**: `/opt/bichon/data` (internal store), `/var/lib/bichon-archive` (EML mirror, backed up)
 

--- a/docs/applications/apps/calibre.md
+++ b/docs/applications/apps/calibre.md
@@ -1,6 +1,6 @@
 # Calibre
 
-Calibre-Web ebook library with web reader. Lightweight alternative to [Grimmory](grimmory.md) (~50 MB RAM vs ~1 GB, no MariaDB or JVM). Docs: [calibre-ebook.com](https://calibre-ebook.com)
+Calibre-Web ebook library with web reader. Lightweight alternative to [Grimmory](applications/apps/grimmory.md) (~50 MB RAM vs ~1 GB, no MariaDB or JVM). Docs: [calibre-ebook.com](https://calibre-ebook.com)
 
 - **URL**: `https://{subdomain}.{domain}`
 - **Data**: book library + metadata and user databases on VPS
@@ -13,4 +13,4 @@ auberge deploy calibre
 
 ## Notes
 
-Backed up by default (book library, metadata DB, user DB). See [Backup & Restore](../../backup-restore/overview.md).
+Backed up by default (book library, metadata DB, user DB). See [Backup & Restore](backup-restore/overview.md).

--- a/docs/applications/apps/colporteur.md
+++ b/docs/applications/apps/colporteur.md
@@ -32,7 +32,7 @@ senders = ["hello@newsletter.com"]
 
 ## Notes
 
-?> Set `colporteur_freshrss_sync = true` in `~/.config/auberge/config.toml` to auto-import feeds into [FreshRSS](freshrss.md) on each deploy. Requires FreshRSS on the same server.
+?> Set `colporteur_freshrss_sync = true` in `~/.config/auberge/config.toml` to auto-import feeds into [FreshRSS](applications/apps/freshrss.md) on each deploy. Requires FreshRSS on the same server.
 
 Runs every 15 minutes via systemd timer. Check status:
 

--- a/docs/applications/apps/freshrss.md
+++ b/docs/applications/apps/freshrss.md
@@ -15,4 +15,4 @@ auberge deploy freshrss
 
 Feeds refresh every 15 minutes via `freshrss-update.timer`.
 
-Backed up by default (SQLite DB, config, user data). Supports OPML export/import — see [OPML Management](../../backup-restore/opml-management.md).
+Backed up by default (SQLite DB, config, user data). Supports OPML export/import — see [OPML Management](backup-restore/opml-management.md).

--- a/docs/applications/apps/gokapi.md
+++ b/docs/applications/apps/gokapi.md
@@ -26,4 +26,4 @@ auberge deploy gokapi
 
 ?> Rotating `gokapi_admin_password` is not automatic. Delete the bootstrap marker on the host and redeploy — see [role README](https://github.com/sripwoud/auberge/blob/master/ansible/roles/gokapi/README.md#rotating-the-admin-password).
 
-Replaces the removed `webdav` role for the link-share use case. Gokapi is **not** a WebDAV server — it does not expose its storage over the WebDAV protocol. If you need mountable network storage, use [Syncthing](syncthing.md) instead.
+Replaces the removed `webdav` role for the link-share use case. Gokapi is **not** a WebDAV server — it does not expose its storage over the WebDAV protocol. If you need mountable network storage, use [Syncthing](applications/apps/syncthing.md) instead.

--- a/docs/applications/apps/grimmory.md
+++ b/docs/applications/apps/grimmory.md
@@ -22,4 +22,4 @@ auberge deploy grimmory
 
 ## Notes
 
-Backed up by default (book library + metadata database). See [Backup & Restore](../../backup-restore/overview.md).
+Backed up by default (book library + metadata database). See [Backup & Restore](backup-restore/overview.md).

--- a/docs/applications/apps/navidrome.md
+++ b/docs/applications/apps/navidrome.md
@@ -19,4 +19,4 @@ Sync music files to the VPS:
 auberge sync music --host my-vps --source ~/Music
 ```
 
-Backed up by default (database and config only; music excluded to save space). To include music: `auberge backup create --include-music`. See [Backup & Restore](../../backup-restore/overview.md).
+Backed up by default (database and config only; music excluded to save space). To include music: `auberge backup create --include-music`. See [Backup & Restore](backup-restore/overview.md).

--- a/docs/applications/apps/paperless.md
+++ b/docs/applications/apps/paperless.md
@@ -2,7 +2,7 @@
 
 Document management system for organizing and searching scanned documents. Docs: [docs.paperless-ngx.com](https://docs.paperless-ngx.com)
 
-- **URL**: tailnet only — see [Tailnet-only apps](../../cli-reference/dns/set-all.md#tailnet-only-apps)
+- **URL**: tailnet only — see [Tailnet-only apps](cli-reference/dns/set-all.md#tailnet-only-apps)
 - **Port**: internal (Caddy proxy)
 - **Data**: `/opt/paperless/data`, `/opt/paperless/media`
 

--- a/docs/applications/infrastructure/caddy.md
+++ b/docs/applications/infrastructure/caddy.md
@@ -20,5 +20,5 @@ Auberge configures Caddy to:
 
 ## Related
 
-- [Cloudflare Setup](../../dns/cloudflare-setup.md)
-- [Applications Overview](../overview.md)
+- [Cloudflare Setup](dns/cloudflare-setup.md)
+- [Applications Overview](applications/overview.md)

--- a/docs/applications/infrastructure/cockpit.md
+++ b/docs/applications/infrastructure/cockpit.md
@@ -29,6 +29,6 @@ Cockpit itself listens on `127.0.0.1:9090` (localhost only) via a systemd socket
 
 ## Related
 
-- [Caddy](caddy.md)
-- [Tailscale](../networking/tailscale.md)
-- [Applications Overview](../overview.md)
+- [Caddy](applications/infrastructure/caddy.md)
+- [Tailscale](applications/networking/tailscale.md)
+- [Applications Overview](applications/overview.md)

--- a/docs/applications/infrastructure/fail2ban.md
+++ b/docs/applications/infrastructure/fail2ban.md
@@ -26,4 +26,4 @@ Default thresholds are defined in `ansible/roles/fail2ban/defaults/main.yml`.
 
 ## Related
 
-- [Applications Overview](../overview.md)
+- [Applications Overview](applications/overview.md)

--- a/docs/applications/infrastructure/ufw.md
+++ b/docs/applications/infrastructure/ufw.md
@@ -23,4 +23,4 @@ All other ports are blocked by default.
 
 ## Related
 
-- [Applications Overview](../overview.md)
+- [Applications Overview](applications/overview.md)

--- a/docs/applications/networking/tailscale.md
+++ b/docs/applications/networking/tailscale.md
@@ -12,13 +12,13 @@ auberge ansible run --tags tailscale
 
 ## Configuration
 
-Requires `tailscale_authkey` in `config.toml`. See [Environment Variables](../../configuration/environment-variables.md).
+Requires `tailscale_authkey` in `config.toml`. See [Environment Variables](configuration/environment-variables.md).
 
 ### Optional: DNS Automation
 
 Setting `tailscale_api_key` in `config.toml` enables automated DNS configuration. The Blocky role uses this key to register itself as the tailnet DNS nameserver via the Tailscale API, routing all tailnet client DNS queries through Blocky for ad-blocking.
 
-See [Blocky - Tailscale DNS Integration](./blocky.md#tailscale-dns-integration) for details.
+See [Blocky - Required config](applications/networking/blocky.md#required-config) for details.
 
 ### Server DNS Behavior
 
@@ -26,11 +26,11 @@ The server runs with `accept_dns: false` (the default) to prevent Tailscale from
 
 ## Self-Hosted Control Server
 
-To replace Tailscale SaaS with a self-hosted control plane, see [Headscale](./headscale.md). Set `tailscale_login_server` in `config.toml` to point nodes at your Headscale instance.
+To replace Tailscale SaaS with a self-hosted control plane, see [Headscale](applications/networking/headscale.md). Set `tailscale_login_server` in `config.toml` to point nodes at your Headscale instance.
 
 ## Related
 
-- [Headscale](./headscale.md)
-- [Blocky](./blocky.md)
-- [Environment Variables](../../configuration/environment-variables.md)
-- [Applications Overview](../overview.md)
+- [Headscale](applications/networking/headscale.md)
+- [Blocky](applications/networking/blocky.md)
+- [Environment Variables](configuration/environment-variables.md)
+- [Applications Overview](applications/overview.md)

--- a/docs/applications/networking/wireguard.md
+++ b/docs/applications/networking/wireguard.md
@@ -16,4 +16,4 @@ Auberge sets up WireGuard for secure VPN access to your VPS.
 
 ## Related
 
-- [Applications Overview](../overview.md)
+- [Applications Overview](applications/overview.md)

--- a/docs/applications/overview.md
+++ b/docs/applications/overview.md
@@ -6,51 +6,51 @@ Auberge deploys a curated stack of self-hosted FOSS applications. All services r
 
 | Application                            | Description                        |
 | -------------------------------------- | ---------------------------------- |
-| [Caddy](infrastructure/caddy.md)       | Reverse proxy with automatic HTTPS |
-| [Cockpit](infrastructure/cockpit.md)   | Web-based server administration    |
-| [fail2ban](infrastructure/fail2ban.md) | Intrusion prevention system        |
-| [UFW](infrastructure/ufw.md)           | Uncomplicated firewall             |
+| [Caddy](applications/infrastructure/caddy.md)       | Reverse proxy with automatic HTTPS |
+| [Cockpit](applications/infrastructure/cockpit.md)   | Web-based server administration    |
+| [fail2ban](applications/infrastructure/fail2ban.md) | Intrusion prevention system        |
+| [UFW](applications/infrastructure/ufw.md)           | Uncomplicated firewall             |
 
 ## Networking
 
 | Application                          | Description                          |
 | ------------------------------------ | ------------------------------------ |
-| [Blocky](networking/blocky.md)       | DNS server with ad/tracking blocking |
-| [Headscale](networking/headscale.md) | Self-hosted Tailscale control server |
-| [WireGuard](networking/wireguard.md) | Fast, modern VPN                     |
-| [Tailscale](networking/tailscale.md) | Mesh VPN for secure remote access    |
+| [Blocky](applications/networking/blocky.md)       | DNS server with ad/tracking blocking |
+| [Headscale](applications/networking/headscale.md) | Self-hosted Tailscale control server |
+| [WireGuard](applications/networking/wireguard.md) | Fast, modern VPN                     |
+| [Tailscale](applications/networking/tailscale.md) | Mesh VPN for secure remote access    |
 
 ## Apps
 
 | Application                        | Description                             |
 | ---------------------------------- | --------------------------------------- |
-| [Baikal](apps/baikal.md)           | CalDAV/CardDAV server                   |
-| [Bichon](apps/bichon.md)           | Email archiving and search              |
-| [Grimmory](apps/grimmory.md)       | Multi-user digital library              |
-| [Calibre](apps/calibre.md)         | Ebook library (alternative to Grimmory) |
-| [Colporteur](apps/colporteur.md)   | Newsletter-to-feed converter            |
-| [FreshRSS](apps/freshrss.md)       | RSS feed aggregator                     |
-| [Navidrome](apps/navidrome.md)     | Music streaming server                  |
-| [Paperless-ngx](apps/paperless.md) | Document management system              |
-| [Syncthing](apps/syncthing.md)     | Continuous file synchronization         |
-| [Gokapi](apps/gokapi.md)           | Expiring-link file sharing              |
-| [YOURLS](apps/yourls.md)           | URL shortener                           |
+| [Baikal](applications/apps/baikal.md)           | CalDAV/CardDAV server                   |
+| [Bichon](applications/apps/bichon.md)           | Email archiving and search              |
+| [Grimmory](applications/apps/grimmory.md)       | Multi-user digital library              |
+| [Calibre](applications/apps/calibre.md)         | Ebook library (alternative to Grimmory) |
+| [Colporteur](applications/apps/colporteur.md)   | Newsletter-to-feed converter            |
+| [FreshRSS](applications/apps/freshrss.md)       | RSS feed aggregator                     |
+| [Navidrome](applications/apps/navidrome.md)     | Music streaming server                  |
+| [Paperless-ngx](applications/apps/paperless.md) | Document management system              |
+| [Syncthing](applications/apps/syncthing.md)     | Continuous file synchronization         |
+| [Gokapi](applications/apps/gokapi.md)           | Expiring-link file sharing              |
+| [YOURLS](applications/apps/yourls.md)           | URL shortener                           |
 
 ## Notifications
 
 | Application              | Description                               |
 | ------------------------ | ----------------------------------------- |
-| [TGTG Bot](apps/tgtg.md) | Too Good To Go availability notifications |
+| [TGTG Bot](applications/apps/tgtg.md) | Too Good To Go availability notifications |
 
 ## AI
 
 | Application                    | Description                          |
 | ------------------------------ | ------------------------------------ |
-| [Hermes Agent](apps/hermes.md) | Self-improving personal AI assistant |
+| [Hermes Agent](applications/apps/hermes.md) | Self-improving personal AI assistant |
 
 ## Deployment
 
-All applications are deployed via Ansible playbooks. See [Running Playbooks](../cli-reference/ansible/run.md) for details.
+All applications are deployed via Ansible playbooks. See [Running Playbooks](cli-reference/ansible/run.md) for details.
 
 ```bash
 # Deploy all apps
@@ -62,4 +62,4 @@ auberge deploy baikal
 
 ## Backup Support
 
-All applications support backup and restore. See [Backup & Restore](../backup-restore/overview.md) for details.
+All applications support backup and restore. See [Backup & Restore](backup-restore/overview.md) for details.

--- a/docs/backup-restore/overview.md
+++ b/docs/backup-restore/overview.md
@@ -84,9 +84,9 @@ Local backups can be pushed to an offsite restic repository for disaster recover
 2. Push it offsite with `auberge backup push`
 3. Apply retention policies with `auberge backup prune` (7 daily, 4 weekly, 12 monthly)
 
-For automated daily backups, use `auberge backup sync` which runs the full pipeline (create → push → prune → cleanup) in one command and removes local staging after a successful push. Prune failures are non-fatal. See [backup sync](../cli-reference/backup/sync.md).
+For automated daily backups, use `auberge backup sync` which runs the full pipeline (create → push → prune → cleanup) in one command and removes local staging after a successful push. Prune failures are non-fatal. See [backup sync](cli-reference/backup/sync.md).
 
-For the full end-to-end setup guide (installing dependencies, configuring rclone, setting auberge config), see [backup push](../cli-reference/backup/push.md#setup).
+For the full end-to-end setup guide (installing dependencies, configuring rclone, setting auberge config), see [backup push](cli-reference/backup/push.md#setup).
 
 ### Excluded Files
 

--- a/docs/cli-reference/auberge.md
+++ b/docs/cli-reference/auberge.md
@@ -20,17 +20,17 @@ auberge [GLOBAL OPTIONS] <COMMAND>
 
 | Command                               | Alias | Purpose                             |
 | ------------------------------------- | ----- | ----------------------------------- |
-| [deploy](deploy.md)                   | `dp`  | Deploy apps with auto-hardening     |
-| [ansible](ansible/run.md)             | `a`   | Run Ansible playbooks               |
-| [backup](backup/create.md)            | `b`   | Backup / restore / push / prune     |
-| [dns](dns/list.md)                    | `d`   | Cloudflare DNS management           |
-| [host](host/add.md)                   | `h`   | Manage `hosts.toml`                 |
-| [ssh](ssh/keygen.md)                  | `ss`  | SSH key generation and deployment   |
-| [sync](sync/music.md)                 | `sy`  | rsync media to the VPS              |
-| [headscale](headscale/add-user.md)    | `hs`  | Headscale users and nodes           |
-| [bichon](bichon/reconcile-folders.md) | —     | Bichon folder reconciliation        |
-| [config](config/overview.md)          | `c`   | Manage `config.toml`                |
-| [select](select/host.md)              | `se`  | Interactive host / playbook pickers |
+| [deploy](cli-reference/deploy.md)                   | `dp`  | Deploy apps with auto-hardening     |
+| [ansible](cli-reference/ansible/run.md)             | `a`   | Run Ansible playbooks               |
+| [backup](cli-reference/backup/create.md)            | `b`   | Backup / restore / push / prune     |
+| [dns](cli-reference/dns/list.md)                    | `d`   | Cloudflare DNS management           |
+| [host](cli-reference/host/add.md)                   | `h`   | Manage `hosts.toml`                 |
+| [ssh](cli-reference/ssh/keygen.md)                  | `ss`  | SSH key generation and deployment   |
+| [sync](cli-reference/sync/music.md)                 | `sy`  | rsync media to the VPS              |
+| [headscale](cli-reference/headscale/add-user.md)    | `hs`  | Headscale users and nodes           |
+| [bichon](cli-reference/bichon/reconcile-folders.md) | —     | Bichon folder reconciliation        |
+| [config](cli-reference/config/overview.md)          | `c`   | Manage `config.toml`                |
+| [select](cli-reference/select/host.md)              | `se`  | Interactive host / playbook pickers |
 
 ## Files
 
@@ -41,7 +41,7 @@ auberge [GLOBAL OPTIONS] <COMMAND>
 | Backups  | `~/.local/share/auberge/backups/` |
 | SSH keys | `~/.ssh/identities/`              |
 
-See [Configuration](../configuration/hosts.md) for details on the config files.
+See [Configuration](configuration/hosts.md) for details on the config files.
 
 ## Examples
 

--- a/docs/cli-reference/backup/prune.md
+++ b/docs/cli-reference/backup/prune.md
@@ -20,7 +20,7 @@ auberge backup prune [OPTIONS]
 
 ## Prerequisites
 
-Same as [backup push](push.md) — requires `restic_repository` and `restic_password` config values.
+Same as [backup push](cli-reference/backup/push.md) — requires `restic_repository` and `restic_password` config values.
 
 ## Examples
 

--- a/docs/cli-reference/backup/sync.md
+++ b/docs/cli-reference/backup/sync.md
@@ -28,7 +28,7 @@ The local staging copy is ephemeral — restic handles long-term retention with 
 
 ## Prerequisites
 
-Same as [backup push](push.md) — requires `restic_repository` and `restic_password` config values, plus `restic` and `rclone` installed.
+Same as [backup push](cli-reference/backup/push.md) — requires `restic_repository` and `restic_password` config values, plus `restic` and `rclone` installed.
 
 ## Examples
 

--- a/docs/cli-reference/deploy.md
+++ b/docs/cli-reference/deploy.md
@@ -29,7 +29,7 @@ auberge deploy paperless --host prod --verify-public-dns
 
 ## Execution order
 
-Every deploy runs `hardening → infrastructure → apps` in that order. Hardening (firewall, fail2ban, kernel) is mandatory and untagged. To skip it, use [`auberge ansible run`](ansible/run.md) directly.
+Every deploy runs `hardening → infrastructure → apps` in that order. Hardening (firewall, fail2ban, kernel) is mandatory and untagged. To skip it, use [`auberge ansible run`](cli-reference/ansible/run.md) directly.
 
 The CLI shows the resolved plan before running (suppress with `-f`):
 

--- a/docs/cli-reference/dns/delete.md
+++ b/docs/cli-reference/dns/delete.md
@@ -43,6 +43,6 @@ auberge dns delete -s calibre --production --yes   # CI / no prompts
 | `fqdn`       | string  | Fully-qualified domain name targeted         |
 | `production` | boolean | Whether the production API was used          |
 
-JSON goes to stdout; human-format chrome goes to stderr. The `deleted` field distinguishes an actual deletion from an idempotent no-op — see [ADR-0004](../../../meta/adr/0004-cli-structured-output.md).
+JSON goes to stdout; human-format chrome goes to stderr. The `deleted` field distinguishes an actual deletion from an idempotent no-op — see [ADR-0004](https://github.com/sripwoud/auberge/blob/master/meta/adr/0004-cli-structured-output.md).
 
 </details>

--- a/docs/cli-reference/host/detect-tailscale-ip.md
+++ b/docs/cli-reference/host/detect-tailscale-ip.md
@@ -50,6 +50,6 @@ tailscale_ip = "100.99.62.26"
 
 ## Related
 
-- [auberge dns set-all](../dns/set-all.md) — consumer of `tailscale_ip`
-- [Tailnet-only Subdomains](../../cli-reference/dns/set-all.md#tailnet-only-apps)
-- [Hosts Configuration](../../configuration/hosts.md)
+- [auberge dns set-all](cli-reference/dns/set-all.md) — consumer of `tailscale_ip`
+- [Tailnet-only Subdomains](cli-reference/dns/set-all.md#tailnet-only-apps)
+- [Hosts Configuration](configuration/hosts.md)

--- a/docs/cli-reference/host/show.md
+++ b/docs/cli-reference/host/show.md
@@ -21,7 +21,7 @@ If `NAME` is omitted, you'll be prompted to select a host.
 | -------- | ------------------------------- |
 | NAME     | Host name (omit to be prompted) |
 
-This command has no `--output` flag. Output is always YAML. To get machine-readable JSON for a specific host, use `auberge host list --output json | jq '.[] | select(.name=="myserver")'`. See [ADR-0004](../../../meta/adr/0004-cli-structured-output.md) for the reasoning.
+This command has no `--output` flag. Output is always YAML. To get machine-readable JSON for a specific host, use `auberge host list --output json | jq '.[] | select(.name=="myserver")'`. See [ADR-0004](https://github.com/sripwoud/auberge/blob/master/meta/adr/0004-cli-structured-output.md) for the reasoning.
 
 ## Examples
 

--- a/docs/configuration/ansible-inventory.md
+++ b/docs/configuration/ansible-inventory.md
@@ -63,5 +63,5 @@ auberge ssh keygen --host my-host --user ansible
 
 ## Related
 
-- [Hosts Configuration](./hosts.md) - hosts.toml management
-- [SSH Keys](./ssh-keys.md) - SSH key configuration
+- [Hosts Configuration](configuration/hosts.md) - hosts.toml management
+- [SSH Keys](configuration/ssh-keys.md) - SSH key configuration

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -28,4 +28,4 @@ All values live in `~/.config/auberge/config.toml`. Manage with `auberge config 
 
 ?> **Tailnet-only subdomains**: setting `<app>_tailscale_ip` causes `dns set-all` to point that subdomain's A record at the Tailscale CGNAT IP (`100.64.0.0/10`) instead of the public server IP. Public internet cannot route CGNAT addresses, so no firewall rules are needed. `dns migrate` skips records whose current IP is in the CGNAT range.
 
-?> All values support `!` command syntax to fetch secrets from a password manager: `auberge config set restic_password '!pass show auberge/restic'`. See [Secrets Management](../configuration/secrets.md#password-commands).
+?> All values support `!` command syntax to fetch secrets from a password manager: `auberge config set restic_password '!pass show auberge/restic'`. See [Secrets Management](configuration/secrets.md#password-commands).

--- a/docs/configuration/hosts.md
+++ b/docs/configuration/hosts.md
@@ -42,7 +42,7 @@ tailscale_ip = "100.99.62.26"  # optional, see below
 
 ### Optional fields
 
-- `tailscale_ip` — cached Tailscale CGNAT IPv4 of the host. Populated by [`auberge host detect-tailscale-ip <name>`](../cli-reference/host/detect-tailscale-ip.md) and consumed by `auberge dns set-all` to auto-fill DNS records for tailnet-only apps without per-app overrides.
+- `tailscale_ip` — cached Tailscale CGNAT IPv4 of the host. Populated by [`auberge host detect-tailscale-ip <name>`](cli-reference/host/detect-tailscale-ip.md) and consumed by `auberge dns set-all` to auto-fill DNS records for tailnet-only apps without per-app overrides.
 
 ## Ansible Inventory (Recommended for developers)
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -38,4 +38,4 @@ cargo build       # Build
 cargo test        # Test
 ```
 
-See [Development Setup](setup.md) for details.
+See [Development Setup](development/setup.md) for details.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,4 +14,4 @@ cargo uninstall auberge       # remove
 
 No platform-specific dependencies on Linux or macOS.
 
-Continue: [Quick Start](quick-start.md) · [First Deployment](first-deployment.md)
+Continue: [Quick Start](getting-started/quick-start.md) · [First Deployment](getting-started/first-deployment.md)

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -32,4 +32,4 @@ Backups, DNS sync, and offsite restic snapshots are first-class CLI verbs.
 
 _Selfware_: direct control, no abstraction layers, no container runtime, transparent operations.
 
-Continue: [Quick Start](quick-start.md) · [Installation](installation.md) · [First Deployment](first-deployment.md)
+Continue: [Quick Start](getting-started/quick-start.md) · [Installation](getting-started/installation.md) · [First Deployment](getting-started/first-deployment.md)

--- a/docs/troubleshooting/ansible-errors.md
+++ b/docs/troubleshooting/ansible-errors.md
@@ -4,7 +4,7 @@
 
 | Error                            | Cause                                | Fix                                                                                 |
 | -------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------- |
-| `UNREACHABLE`                    | SSH connectivity                     | See [SSH Problems](ssh-problems.md)                                                 |
+| `UNREACHABLE`                    | SSH connectivity                     | See [SSH Problems](troubleshooting/ssh-problems.md)                                                 |
 | `Permission denied`              | ansible user lacks passwordless sudo | `ssh ansible@vps "sudo -n true"`; re-bootstrap if needed                            |
 | `apt lock`                       | Concurrent apt process               | Wait 60s; or via console: `sudo killall apt apt-get && sudo rm /var/lib/dpkg/lock*` |
 | `Package not found`              | Stale apt cache                      | `ssh ansible@vps "sudo apt update"`                                                 |

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -34,7 +34,7 @@ auberge config set KEY value
 
 | Error                        | Cause                                | Fix                                                                                                     |
 | ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `"Unreachable"`              | SSH connectivity failure             | See [SSH Problems](ssh-problems.md)                                                                     |
+| `"Unreachable"`              | SSH connectivity failure             | See [SSH Problems](troubleshooting/ssh-problems.md)                                                                     |
 | `"Permission denied"` (sudo) | ansible user lacks passwordless sudo | `ssh ansible@vps "sudo -n true"`; re-run `auberge ansible bootstrap my-vps --ip 203.0.113.10` if needed |
 | Handler not running          | Config task reported no change       | Restart manually: `ssh ansible@vps "sudo systemctl restart service-name"`                               |
 
@@ -56,7 +56,7 @@ ssh ansible@vps "journalctl -u caddy -n 50"
 ssh ansible@vps "sudo systemctl restart caddy"
 ```
 
-Causes: Cloudflare API token wrong, DNS not pointing to VPS, port 80/443 blocked. See [DNS Issues](dns-issues.md).
+Causes: Cloudflare API token wrong, DNS not pointing to VPS, port 80/443 blocked. See [DNS Issues](troubleshooting/dns-issues.md).
 
 ## Performance
 


### PR DESCRIPTION
## What

Fixes internal cross-page links across the docs so they resolve correctly under Docsify.

## Why

The site (`docs/index.html`) runs Docsify without `relativePath`, so it defaults to `relativePath: false` — meaning **all relative links are resolved from the `docs/` root, not from the current file's directory**. Many links were written as file-relative paths (`../../backup-restore/overview.md`, `./blocky.md`, `grimmory.md`, …), which Docsify could not resolve at runtime.

This PR rewrites them to the root-relative form Docsify expects (e.g. `backup-restore/overview.md`, `applications/networking/blocky.md`).

It also fixes one stale anchor in `applications/networking/tailscale.md`: the link to Blocky's Tailscale DNS details pointed to a non-existent `#tailscale-dns-integration` heading and now points to the existing `#required-config` section.

## Verification

- Static check: **171/171 internal `.md` links** resolve to existing files as root-relative paths.
- Runtime check against a live `docsify serve docs`: **87/87 unique internal `.md` targets return HTTP 200**.
- Anchors: **0 broken** after the `tailscale.md` fix.