### PR TITLE
fix(cli): resolve bare playbook name in ansible run -p

### DIFF
--- a/src/commands/ansible.rs
+++ b/src/commands/ansible.rs
@@ -68,9 +68,41 @@ fn validate_config_for_playbook(playbook_name: &str, tags: Option<&[String]>) ->
     config.preflight_for(playbook_name, tags)
 }
 
+fn resolve_playbook_name(arg: &Path, playbooks: &[PathBuf]) -> Result<PathBuf> {
+    let query = arg
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| eyre::eyre!("Invalid playbook name: {}", arg.display()))?;
+
+    if let Some(found) = playbooks
+        .iter()
+        .find(|p| p.file_stem().and_then(|s| s.to_str()) == Some(query))
+    {
+        return Ok(found.clone());
+    }
+
+    let mut names: Vec<&str> = playbooks
+        .iter()
+        .filter_map(|p| p.file_stem().and_then(|s| s.to_str()))
+        .collect();
+    names.sort_unstable();
+
+    eyre::bail!(
+        "Playbook '{}' not found. Available playbooks: {}",
+        query,
+        names.join(", ")
+    )
+}
+
 fn select_or_use_playbook(playbook_arg: Option<PathBuf>) -> Result<PathBuf> {
     match playbook_arg {
-        Some(path) => Ok(path),
+        Some(path) => {
+            if path.is_file() {
+                return Ok(path);
+            }
+            let playbooks = get_playbooks(None)?;
+            resolve_playbook_name(&path, &playbooks)
+        }
         None => {
             let playbooks = get_playbooks(None)?;
             select_item(
@@ -537,5 +569,41 @@ mod tests {
         assert!(validate_ip("localhost").is_err());
         assert!(validate_ip("192.168.1.1 ").is_err());
         assert!(validate_ip(" 192.168.1.1").is_err());
+    }
+
+    fn sample_playbooks() -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("/pb/hardening.yml"),
+            PathBuf::from("/pb/infrastructure.yml"),
+            PathBuf::from("/pb/apps.yml"),
+            PathBuf::from("/pb/hermes.yml"),
+        ]
+    }
+
+    #[test]
+    fn test_resolve_playbook_name_bare() {
+        let resolved = resolve_playbook_name(Path::new("hermes"), &sample_playbooks()).unwrap();
+        assert_eq!(resolved, PathBuf::from("/pb/hermes.yml"));
+    }
+
+    #[test]
+    fn test_resolve_playbook_name_with_yml_extension() {
+        let resolved = resolve_playbook_name(Path::new("hermes.yml"), &sample_playbooks()).unwrap();
+        assert_eq!(resolved, PathBuf::from("/pb/hermes.yml"));
+    }
+
+    #[test]
+    fn test_resolve_playbook_name_ignores_leading_dirs() {
+        let resolved =
+            resolve_playbook_name(Path::new("some/dir/apps.yml"), &sample_playbooks()).unwrap();
+        assert_eq!(resolved, PathBuf::from("/pb/apps.yml"));
+    }
+
+    #[test]
+    fn test_resolve_playbook_name_unknown_lists_available() {
+        let err = resolve_playbook_name(Path::new("nope"), &sample_playbooks()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Playbook 'nope' not found"));
+        assert!(msg.contains("apps, hardening, hermes, infrastructure"));
     }
 }

--- a/src/services/inventory.rs
+++ b/src/services/inventory.rs
@@ -283,10 +283,15 @@ pub fn get_playbooks(playbooks_path: Option<&Path>) -> Result<Vec<PathBuf>> {
         .wrap_err_with(|| format!("Failed to read {}", path.display()))?
         .filter_map(|entry| entry.ok())
         .filter(|entry| {
-            entry
-                .path()
+            let path = entry.path();
+            let is_yaml = path
                 .extension()
-                .is_some_and(|ext| ext == "yml" || ext == "yaml")
+                .is_some_and(|ext| ext == "yml" || ext == "yaml");
+            let is_meta = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .is_some_and(|stem| stem.ends_with(".meta"));
+            is_yaml && !is_meta
         })
         .filter_map(|entry| std::fs::canonicalize(entry.path()).ok())
         .collect();
@@ -298,4 +303,26 @@ pub fn get_playbooks(playbooks_path: Option<&Path>) -> Result<Vec<PathBuf>> {
     }
 
     Ok(playbooks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_get_playbooks_excludes_meta_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        for file in ["hermes.yml", "hermes.meta.yml", "apps.yml", "apps.meta.yml"] {
+            fs::write(dir.path().join(file), "---\n").unwrap();
+        }
+
+        let playbooks = get_playbooks(Some(dir.path())).unwrap();
+        let stems: Vec<String> = playbooks
+            .iter()
+            .map(|p| p.file_stem().and_then(|s| s.to_str()).unwrap().to_string())
+            .collect();
+
+        assert_eq!(stems, vec!["apps", "hermes"]);
+    }
 }


### PR DESCRIPTION
`auberge ansible run -p hermes` failed with ansible's `the playbook: hermes could not be found`. `-p` forwarded its value verbatim, resolving against cwd instead of the extracted playbooks dir (`~/.local/share/auberge/ansible/playbooks/`). The only non-interactive path was a full absolute path.

Now `-p <name>` resolves a bare playbook name (or `name.yml`, or a stray-dir path) against the playbooks dir by file stem.

## Resolution order — `select_or_use_playbook`
1. `path.is_file()` → use verbatim (preserves the full-path workaround)
2. else match `file_stem` against `get_playbooks()` → return that path
3. else fail early listing valid names — before spawning `ansible-playbook`

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `-p hermes` | ansible: `playbook could not be found` | resolves `hermes.yml` ✅ |
| `-p hermes.yml` | same (cwd-relative) | resolves `hermes.yml` ✅ |
| `-p ~/.local/.../hermes.yml` | works | works (unchanged) ✅ |
| `-p nope` | cryptic ansible error | `Playbook 'nope' not found. Available playbooks: apps, baikal, ...` ✅ |

## Secondary fix
`get_playbooks()` filtered by extension only, so `.meta.yml` sidecars (metadata, not playbooks) leaked into the interactive picker as runnable and into the resolver's name list. Now excluded by `.meta` stem suffix.

## Test plan
- [x] `resolve_playbook_name`: bare name, `.yml` extension, leading dirs, unknown-name error listing
- [x] `get_playbooks` excludes `.meta.yml` sidecars (temp-dir fixture)
- [x] full suite: 338 passed, 0 failed
- [x] `cargo fmt --check` clean; no new clippy warnings in changed files

> [!NOTE]
> Out of scope: `-t hermes` (tag resolution) still only knows the aggregators `hardening`/`infrastructure`/`apps`. The issue's Expected section specifies `-p` only; tag-resolution semantics for standalone playbooks are a larger change.

Closes #363
