### PR TITLE
fix(hermes): gate standalone playbook on hermes group membership

### DIFF
--- a/ansible/playbooks/hermes.yml
+++ b/ansible/playbooks/hermes.yml
@@ -6,3 +6,4 @@
   roles:
     - role: hermes
       tags: [hermes]
+      when: "'hermes' in group_names"

--- a/docs/applications/overview.md
+++ b/docs/applications/overview.md
@@ -4,8 +4,8 @@ Auberge deploys a curated stack of self-hosted FOSS applications. All services r
 
 ## Infrastructure
 
-| Application                            | Description                        |
-| -------------------------------------- | ---------------------------------- |
+| Application                                         | Description                        |
+| --------------------------------------------------- | ---------------------------------- |
 | [Caddy](applications/infrastructure/caddy.md)       | Reverse proxy with automatic HTTPS |
 | [Cockpit](applications/infrastructure/cockpit.md)   | Web-based server administration    |
 | [fail2ban](applications/infrastructure/fail2ban.md) | Intrusion prevention system        |
@@ -13,8 +13,8 @@ Auberge deploys a curated stack of self-hosted FOSS applications. All services r
 
 ## Networking
 
-| Application                          | Description                          |
-| ------------------------------------ | ------------------------------------ |
+| Application                                       | Description                          |
+| ------------------------------------------------- | ------------------------------------ |
 | [Blocky](applications/networking/blocky.md)       | DNS server with ad/tracking blocking |
 | [Headscale](applications/networking/headscale.md) | Self-hosted Tailscale control server |
 | [WireGuard](applications/networking/wireguard.md) | Fast, modern VPN                     |
@@ -22,8 +22,8 @@ Auberge deploys a curated stack of self-hosted FOSS applications. All services r
 
 ## Apps
 
-| Application                        | Description                             |
-| ---------------------------------- | --------------------------------------- |
+| Application                                     | Description                             |
+| ----------------------------------------------- | --------------------------------------- |
 | [Baikal](applications/apps/baikal.md)           | CalDAV/CardDAV server                   |
 | [Bichon](applications/apps/bichon.md)           | Email archiving and search              |
 | [Grimmory](applications/apps/grimmory.md)       | Multi-user digital library              |
@@ -38,14 +38,14 @@ Auberge deploys a curated stack of self-hosted FOSS applications. All services r
 
 ## Notifications
 
-| Application              | Description                               |
-| ------------------------ | ----------------------------------------- |
+| Application                           | Description                               |
+| ------------------------------------- | ----------------------------------------- |
 | [TGTG Bot](applications/apps/tgtg.md) | Too Good To Go availability notifications |
 
 ## AI
 
-| Application                    | Description                          |
-| ------------------------------ | ------------------------------------ |
+| Application                                 | Description                          |
+| ------------------------------------------- | ------------------------------------ |
 | [Hermes Agent](applications/apps/hermes.md) | Self-improving personal AI assistant |
 
 ## Deployment

--- a/docs/cli-reference/auberge.md
+++ b/docs/cli-reference/auberge.md
@@ -18,8 +18,8 @@ auberge [GLOBAL OPTIONS] <COMMAND>
 
 ## Commands
 
-| Command                               | Alias | Purpose                             |
-| ------------------------------------- | ----- | ----------------------------------- |
+| Command                                             | Alias | Purpose                             |
+| --------------------------------------------------- | ----- | ----------------------------------- |
 | [deploy](cli-reference/deploy.md)                   | `dp`  | Deploy apps with auto-hardening     |
 | [ansible](cli-reference/ansible/run.md)             | `a`   | Run Ansible playbooks               |
 | [backup](cli-reference/backup/create.md)            | `b`   | Backup / restore / push / prune     |

--- a/docs/troubleshooting/ansible-errors.md
+++ b/docs/troubleshooting/ansible-errors.md
@@ -4,7 +4,7 @@
 
 | Error                            | Cause                                | Fix                                                                                 |
 | -------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------- |
-| `UNREACHABLE`                    | SSH connectivity                     | See [SSH Problems](troubleshooting/ssh-problems.md)                                                 |
+| `UNREACHABLE`                    | SSH connectivity                     | See [SSH Problems](troubleshooting/ssh-problems.md)                                 |
 | `Permission denied`              | ansible user lacks passwordless sudo | `ssh ansible@vps "sudo -n true"`; re-bootstrap if needed                            |
 | `apt lock`                       | Concurrent apt process               | Wait 60s; or via console: `sudo killall apt apt-get && sudo rm /var/lib/dpkg/lock*` |
 | `Package not found`              | Stale apt cache                      | `ssh ansible@vps "sudo apt update"`                                                 |

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -34,7 +34,7 @@ auberge config set KEY value
 
 | Error                        | Cause                                | Fix                                                                                                     |
 | ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `"Unreachable"`              | SSH connectivity failure             | See [SSH Problems](troubleshooting/ssh-problems.md)                                                                     |
+| `"Unreachable"`              | SSH connectivity failure             | See [SSH Problems](troubleshooting/ssh-problems.md)                                                     |
 | `"Permission denied"` (sudo) | ansible user lacks passwordless sudo | `ssh ansible@vps "sudo -n true"`; re-run `auberge ansible bootstrap my-vps --ip 203.0.113.10` if needed |
 | Handler not running          | Config task reported no change       | Restart manually: `ssh ansible@vps "sudo systemctl restart service-name"`                               |
 


### PR DESCRIPTION
Running the standalone `hermes.yml` against the wrong host silently installed the full Hermes agent (uv venv, systemd user service, Telegram gateway) onto an untagged VPS. This guard makes the play a no-op on any host lacking the `hermes` tag.

## Root cause
- `hermes.yml` ran the role on `hosts: vps` with **no group guard**, while `apps.yml` gates the same role with `when: "'hermes' in group_names"` (`apps.yml:14`).
- `auberge ansible run` defaults the host picker to the first host (`auberge`), so an accidental Enter deploys Hermes to the wrong box. Only `openclaw` carries the `hermes` tag.

## Change
One-line guard on `ansible/playbooks/hermes.yml`, mirroring `apps.yml`:
```yaml
    - role: hermes
      tags: [hermes]
      when: "'hermes' in group_names"
```

## Test plan
- [x] `ansible-lint` passes (pre-commit, `production` profile)
- [ ] `auberge ansible run -H auberge -p ~/.local/share/auberge/ansible/playbooks/hermes.yml --check` → role tasks report `skipping` (untagged host)
- [ ] `auberge ansible run -H openclaw -p ~/.local/share/auberge/ansible/playbooks/hermes.yml --check` → tasks evaluate normally

> [!NOTE]
> Surfaced alongside #363 (`ansible run -p <name>` not resolving bare playbook names).
> Second commit (`chore: apply dprint formatting to docs tables`) is incidental: pre-existing dprint drift on `master` that the `stage = "*"` pre-commit hook auto-corrects on any commit. Kept separate from the fix.