### PR TITLE
chore: release v0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.5](https://github.com/sripwoud/auberge/compare/v0.14.4...v0.14.5) - 2026-07-19
+
+### Added
+
+- *(cli)* make standalone playbooks reachable via ansible run -t ([#369](https://github.com/sripwoud/auberge/pull/369))
+
+### Fixed
+
+- *(cli)* resolve bare playbook name in ansible run -p ([#364](https://github.com/sripwoud/auberge/pull/364))
+- *(hermes)* gate standalone playbook on hermes group membership ([#366](https://github.com/sripwoud/auberge/pull/366))
+
+### Other
+
+- suppress rust/cleartext-logging via advanced CodeQL setup ([#370](https://github.com/sripwoud/auberge/pull/370))
+- *(deps)* resolve dependabot alerts for serde_with and atty ([#367](https://github.com/sripwoud/auberge/pull/367))
+- fmt
+- fix internal links for Docsify root-relative resolution ([#362](https://github.com/sripwoud/auberge/pull/362))
+
 ## [0.14.4](https://github.com/sripwoud/auberge/compare/v0.14.3...v0.14.4) - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auberge"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.4 -> 0.14.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.5](https://github.com/sripwoud/auberge/compare/v0.14.4...v0.14.5) - 2026-07-19

### Added

- *(cli)* make standalone playbooks reachable via ansible run -t ([#369](https://github.com/sripwoud/auberge/pull/369))

### Fixed

- *(cli)* resolve bare playbook name in ansible run -p ([#364](https://github.com/sripwoud/auberge/pull/364))
- *(hermes)* gate standalone playbook on hermes group membership ([#366](https://github.com/sripwoud/auberge/pull/366))

### Other

- suppress rust/cleartext-logging via advanced CodeQL setup ([#370](https://github.com/sripwoud/auberge/pull/370))
- *(deps)* resolve dependabot alerts for serde_with and atty ([#367](https://github.com/sripwoud/auberge/pull/367))
- fmt
- fix internal links for Docsify root-relative resolution ([#362](https://github.com/sripwoud/auberge/pull/362))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).