### PR TITLE
feat(cli): make standalone playbooks reachable via ansible run -t

### DIFF
--- a/docs/cli-reference/ansible/run.md
+++ b/docs/cli-reference/ansible/run.md
@@ -17,13 +17,14 @@ auberge ansible run [OPTIONS]
 | `--skip-tags TAGS`    | Comma-separated tags to skip                                               | None        |
 | `-f, --force`         | Skip confirmation prompts (CI/CD)                                          | `false`     |
 
-?> **Auto-resolution**: when `--tags` is set and `--playbook` is omitted, app tags (e.g. `paperless`) trigger a full `infrastructure.yml` run first (idempotent), then `apps.yml` with only those tags. Pass `--playbook` to bypass.
+?> **Auto-resolution**: when `--tags` is set and `--playbook` is omitted, app tags (e.g. `paperless`) trigger a full `infrastructure.yml` run first (idempotent), then `apps.yml` with only those tags. A tag matching a standalone playbook name (e.g. `hermes`, `calibre`) runs that playbook in full, after any aggregator runs. Aggregator tags win: `gokapi` resolves as an `apps.yml` tag, not the standalone playbook. Pass `--playbook` to bypass.
 
 ## Examples
 
 ```bash
 auberge ansible run                                                      # interactive
 auberge ansible run --host my-vps --tags paperless                       # auto-resolves infra + apps
+auberge ansible run --host my-vps --tags hermes                          # standalone playbook by name
 auberge ansible run --host my-vps --playbook ansible/playbooks/apps.yml --tags freshrss,baikal --check
 auberge ansible run --host my-vps --skip-tags navidrome -f               # CI/CD
 ```

--- a/src/commands/ansible.rs
+++ b/src/commands/ansible.rs
@@ -2,7 +2,9 @@ use crate::config::{Config, Preflight};
 use crate::output;
 use crate::prompt::select_item;
 use crate::services::ansible_runner::{InventoryHost, run_bootstrap, run_playbook};
-use crate::services::dependency_resolver::resolve_tags_to_playbook_runs;
+use crate::services::dependency_resolver::{
+    find_standalone_playbook, resolve_tags_to_playbook_runs,
+};
 use crate::services::inventory::{Host, get_playbooks, select_or_arg};
 use clap::Subcommand;
 use eyre::{Result, WrapErr};
@@ -28,7 +30,7 @@ pub enum AnsibleCommands {
             short,
             long,
             value_delimiter = ',',
-            help = "Comma-separated tags to run (auto-deploys infra dependencies)"
+            help = "Comma-separated tags to run (auto-deploys infra dependencies; a standalone playbook name runs that playbook)"
         )]
         tags: Option<Vec<String>>,
         #[arg(long, value_delimiter = ',', help = "Skip tasks with these tags")]
@@ -166,16 +168,17 @@ fn run_auto_resolved(
     ask_pass: bool,
     force: bool,
 ) -> Result<()> {
-    let (runs, unknown_tags) = resolve_tags_to_playbook_runs(tags)?;
+    let (runs, unresolved_tags) = resolve_tags_to_playbook_runs(tags)?;
+    let (standalone_playbooks, unknown_tags) = split_standalone_redirects(unresolved_tags)?;
 
     if !unknown_tags.is_empty() {
         output::warn(&format!(
-            "Unknown tags (not in infrastructure.yml or apps.yml): {}",
+            "Unknown tags (no matching role, tag, or standalone playbook): {}",
             unknown_tags.join(", ")
         ));
     }
 
-    if runs.is_empty() {
+    if runs.is_empty() && standalone_playbooks.is_empty() {
         output::info("No auto-resolvable playbooks found, falling back to playbook selection");
         let selected_playbook = select_or_use_playbook(None)?;
         return run_single_playbook(
@@ -192,7 +195,7 @@ fn run_auto_resolved(
 
     output::info(&format!(
         "Resolved {} playbook run(s) for tags: {}",
-        runs.len(),
+        runs.len() + standalone_playbooks.len(),
         tags.join(", ")
     ));
 
@@ -269,8 +272,26 @@ fn run_auto_resolved(
         output::success(&format!("{} completed successfully", playbook_stem));
     }
 
+    for playbook in &standalone_playbooks {
+        run_single_playbook(
+            host, playbook, check, None, skip_tags, user, ask_pass, force,
+        )?;
+    }
+
     output::success("All playbook runs completed successfully");
     Ok(())
+}
+
+fn split_standalone_redirects(tags: Vec<String>) -> Result<(Vec<PathBuf>, Vec<String>)> {
+    let mut playbooks = Vec::new();
+    let mut unknown = Vec::new();
+    for tag in tags {
+        match find_standalone_playbook(&tag)? {
+            Some(path) => playbooks.push(path),
+            None => unknown.push(tag),
+        }
+    }
+    Ok((playbooks, unknown))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -560,6 +581,27 @@ mod tests {
         assert!(validate_ip("192.168.1").is_err());
         assert!(validate_ip("192.168.1.1.1").is_err());
         assert!(validate_ip("192.168.-1.1").is_err());
+    }
+
+    #[test]
+    fn test_split_standalone_redirects_partitions_tags() {
+        let (playbooks, unknown) =
+            split_standalone_redirects(vec!["hermes".to_string(), "nope".to_string()]).unwrap();
+
+        assert_eq!(playbooks.len(), 1);
+        assert_eq!(
+            playbooks[0].file_name().unwrap().to_str().unwrap(),
+            "hermes.yml"
+        );
+        assert_eq!(unknown, vec!["nope"]);
+    }
+
+    #[test]
+    fn test_split_standalone_redirects_keeps_aggregator_stems_unknown() {
+        let (playbooks, unknown) = split_standalone_redirects(vec!["apps".to_string()]).unwrap();
+
+        assert!(playbooks.is_empty());
+        assert_eq!(unknown, vec!["apps"]);
     }
 
     #[test]

--- a/src/services/dependency_resolver.rs
+++ b/src/services/dependency_resolver.rs
@@ -89,6 +89,30 @@ fn build_tag_playbook_map() -> Result<HashMap<String, Vec<PathBuf>>> {
 
 const PLAYBOOK_ORDER: &[&str] = &["hardening.yml", "infrastructure.yml", "apps.yml"];
 
+/// Resolves `name` to a standalone playbook (one outside [`PLAYBOOK_ORDER`]),
+/// excluding `.meta.yml` sidecars.
+pub fn find_standalone_playbook(name: &str) -> Result<Option<PathBuf>> {
+    if name.ends_with(".meta") || name.contains(['/', '\\']) {
+        return Ok(None);
+    }
+
+    let playbooks_dir = AnsibleAssets::prepare()?.playbooks_dir();
+    for ext in ["yml", "yaml"] {
+        let filename = format!("{name}.{ext}");
+        if PLAYBOOK_ORDER.contains(&filename.as_str()) {
+            return Ok(None);
+        }
+        let path = playbooks_dir.join(&filename);
+        if path.is_file() {
+            let canonical = std::fs::canonicalize(&path)
+                .wrap_err_with(|| format!("Failed to canonicalize: {}", path.display()))?;
+            return Ok(Some(canonical));
+        }
+    }
+
+    Ok(None)
+}
+
 pub fn get_app_names() -> Result<Vec<String>> {
     let playbooks_dir = AnsibleAssets::prepare()?.playbooks_dir();
     let apps_path = playbooks_dir.join("apps.yml");
@@ -341,5 +365,40 @@ mod tests {
 
         assert!(runs.is_empty());
         assert_eq!(unknown, vec!["paperles"]);
+    }
+
+    #[test]
+    fn test_find_standalone_playbook_resolves_all_standalones() {
+        for name in [
+            "bootstrap",
+            "calibre",
+            "gokapi",
+            "hermes",
+            "remove-radicale",
+            "vibecoder",
+        ] {
+            let path = find_standalone_playbook(name).unwrap().unwrap();
+            assert_eq!(
+                path.file_name().unwrap().to_str().unwrap(),
+                format!("{name}.yml")
+            );
+        }
+    }
+
+    #[test]
+    fn test_find_standalone_playbook_excludes_aggregators() {
+        for name in ["hardening", "infrastructure", "apps"] {
+            assert!(find_standalone_playbook(name).unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn test_find_standalone_playbook_excludes_meta_sidecars() {
+        assert!(find_standalone_playbook("hermes.meta").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_find_standalone_playbook_unknown_name() {
+        assert!(find_standalone_playbook("nope").unwrap().is_none());
     }
 }


### PR DESCRIPTION
\`auberge ansible run -t hermes\` warned \`Unknown tags\` and fell back to the interactive picker — the 6 standalone playbooks (\`bootstrap\`, \`calibre\`, \`gokapi\`, \`hermes\`, \`remove-radicale\`, \`vibecoder\`) never enter the tag map, which \`build_tag_playbook_map()\` builds from the 3 aggregators only. Now a tag that resolves to nothing is matched against standalone playbook stems and runs that playbook in full, after any aggregator runs.

## Resolution order
1. Tag map (roles + tags from \`hardening.yml\`/\`infrastructure.yml\`/\`apps.yml\`) — unchanged, keeps precedence: \`-t gokapi\` still resolves as the \`apps.yml\` tag, never the standalone
2. Standalone stem match (\`find_standalone_playbook\`) → full playbook run via \`run_single_playbook\`, preserving the \`bootstrap.yml\` provider-firewall confirmation
3. Still unknown → warn + interactive fallback (warning text corrected; it claimed only \`infrastructure.yml\`/\`apps.yml\` were scanned)

## Why stem redirect (issue option 3), not tag-map extension (option 2)
- \`bootstrap.yml\` roles carry generic tags (\`ssh\`, \`network\`, \`security\`, \`firewall\`, \`ufw\`) — scanning it into the map would make \`-t network\` silently run bootstrap
- \`parse_playbook_roles()\` sees no roles in \`remove-radicale.yml\` (tasks only) or \`vibecoder.yml\` (bare role syntax) — option 2 leaves 2 of 6 unreachable
- Redirected runs pass no \`--tags\`: \`remove-radicale.yml\` tasks carry no matching tag, so \`--tags remove-radicale\` would match zero tasks

## Behavior

| Input | Before | After |
|-------|--------|-------|
| \`-t hermes\` | unknown-tag warning → interactive picker | runs \`hermes.yml\` ✅ |
| \`-t hermes,caddy\` | only \`infrastructure.yml\` (caddy) | \`infrastructure.yml\` (caddy), then \`hermes.yml\` ✅ |
| \`-t bootstrap\` | unknown-tag warning | runs \`bootstrap.yml\` incl. firewall confirmation ✅ |
| \`-t gokapi\` | infra + \`apps.yml --tags gokapi\` | unchanged ✅ |
| \`-t hermes.meta\`, \`-t nope\` | unknown-tag warning | unchanged ✅ |

## Test plan
- [x] \`find_standalone_playbook\`: resolves all 6 standalones; rejects aggregator stems, \`.meta\` sidecars, unknown names
- [x] \`split_standalone_redirects\`: partitions redirects vs unknown; aggregator stems stay unknown
- [x] full suite after rebase on master: 344 passed, 0 failed
- [x] clippy clean on changed files; hk hooks (clippy + dprint) passed

> [!NOTE]
> Independent of #364 (\`issue-363\`) — touches different functions in \`ansible.rs\`, merges in either order.

Closes #365