### PR TITLE
fix(backup): make restic prune actually forget old snapshots

### DIFF
--- a/docs/cli-reference/backup/prune.md
+++ b/docs/cli-reference/backup/prune.md
@@ -18,6 +18,8 @@ auberge backup prune [OPTIONS]
 - 4 weekly snapshots
 - 12 monthly snapshots
 
+Retention applies per host: each snapshot is tagged with its host name at push, and `forget` groups by tag (`--group-by tags`). Hosts sharing one repository never evict each other's snapshots.
+
 ## Prerequisites
 
 Same as [backup push](cli-reference/backup/push.md) — requires `restic_repository` and `restic_password` config values.

--- a/docs/cli-reference/backup/push.md
+++ b/docs/cli-reference/backup/push.md
@@ -8,6 +8,8 @@ auberge backup push [OPTIONS]
 
 The repository is initialized automatically on first push.
 
+?> `push` is upload-only — it never applies the retention policy. [backup sync](cli-reference/backup/sync.md) is the retention-enforcing entrypoint (it runs prune after push); standalone pushes accumulate snapshots until the next `sync` or manual [backup prune](cli-reference/backup/prune.md).
+
 ## Options
 
 | Option               | Description               | Default                         |

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1116,7 +1116,18 @@ pub fn run_backup_push(host_filter: Option<String>, backup_id: Option<String>) -
     let backup_dir =
         resolve_backup_dir(&backup_root, host_filter.as_deref(), backup_id.as_deref())?;
 
-    restic_push(&restic_repo, &restic_password, &backup_dir)
+    let host = backup_dir
+        .parent()
+        .and_then(Path::file_name)
+        .map(|h| h.to_string_lossy().into_owned())
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "Cannot determine host from backup dir: {}",
+                backup_dir.display()
+            )
+        })?;
+
+    restic_push(&restic_repo, &restic_password, &backup_dir, &host)
 }
 
 pub fn run_backup_prune(dry_run: bool) -> Result<()> {

--- a/src/services/backup/executor.rs
+++ b/src/services/backup/executor.rs
@@ -63,7 +63,7 @@ impl<'a, S: SshSession + ?Sized> RecipeExecutor<'a, S> {
             if let Some(db) = &recipe.db {
                 progress.task_started(&format!("pg_dump {}", db.name));
                 let cmd = format!(
-                    "sudo -u postgres pg_dump -Fc {} > {}",
+                    "sudo -u postgres pg_dump -Fc -Z0 {} > {}",
                     db.name, db.dump_path
                 );
                 let dump = self.session.run(&cmd)?;
@@ -406,7 +406,7 @@ mod tests {
         );
         match &calls[1] {
             SshOp::Run(cmd) => {
-                assert!(cmd.contains("pg_dump"));
+                assert!(cmd.contains("pg_dump -Fc -Z0"));
                 assert!(cmd.contains("paperless"));
                 assert!(cmd.contains("/tmp/paperless_db.dump"));
             }

--- a/src/services/backup/session.rs
+++ b/src/services/backup/session.rs
@@ -137,7 +137,41 @@ fn make_recipe_progress(app: &str) -> Box<dyn Progress> {
     Box::new(TerminalProgress::hidden(&format!("Backing up {}", app)))
 }
 
-pub fn restic_push(restic_repo: &str, restic_password: &str, backup_dir: &Path) -> Result<()> {
+fn backup_args(backup_dir: &Path, host: &str) -> Vec<std::ffi::OsString> {
+    vec![
+        "backup".into(),
+        "--json".into(),
+        "--tag".into(),
+        host.into(),
+        backup_dir.into(),
+    ]
+}
+
+fn forget_args(dry_run: bool) -> Vec<&'static str> {
+    let mut args = vec![
+        "forget",
+        "--group-by",
+        "tags",
+        "--keep-daily",
+        "7",
+        "--keep-weekly",
+        "4",
+        "--keep-monthly",
+        "12",
+        "--prune",
+    ];
+    if dry_run {
+        args.push("--dry-run");
+    }
+    args
+}
+
+pub fn restic_push(
+    restic_repo: &str,
+    restic_password: &str,
+    backup_dir: &Path,
+    host: &str,
+) -> Result<()> {
     output::info(&format!("Pushing {} to restic", backup_dir.display()));
 
     let mut progress = TerminalProgress::new("Checking restic repository");
@@ -197,9 +231,7 @@ pub fn restic_push(restic_repo: &str, restic_password: &str, backup_dir: &Path) 
     let result = output::stream_command_stdout(
         "restic",
         Command::new("restic")
-            .arg("backup")
-            .arg("--json")
-            .arg(backup_dir)
+            .args(backup_args(backup_dir, host))
             .env("RESTIC_REPOSITORY", restic_repo)
             .env("RESTIC_PASSWORD", restic_password)
             .env_remove("RESTIC_PASSWORD_COMMAND"),
@@ -243,21 +275,10 @@ pub fn restic_prune(restic_repo: &str, restic_password: &str, dry_run: bool) -> 
     let mut progress = TerminalProgress::new("Pruning restic snapshots");
 
     let mut cmd = Command::new("restic");
-    cmd.arg("forget")
-        .arg("--keep-daily")
-        .arg("7")
-        .arg("--keep-weekly")
-        .arg("4")
-        .arg("--keep-monthly")
-        .arg("12")
-        .arg("--prune")
+    cmd.args(forget_args(dry_run))
         .env("RESTIC_REPOSITORY", restic_repo)
         .env("RESTIC_PASSWORD", restic_password)
         .env_remove("RESTIC_PASSWORD_COMMAND");
-
-    if dry_run {
-        cmd.arg("--dry-run");
-    }
 
     let prune_output = cmd.output().wrap_err("Failed to run restic forget")?;
 
@@ -359,6 +380,36 @@ mod tests {
             timestamp: "2026-04-28_03-00-00".to_string(),
             parameters: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn backup_args_tags_snapshot_with_host() {
+        let args = backup_args(
+            Path::new("/backups/myserver/2026-04-28_03-00-00"),
+            "myserver",
+        );
+
+        let tag_pos = args.iter().position(|a| a == "--tag").unwrap();
+        assert_eq!(args[tag_pos + 1], "myserver");
+        assert_eq!(
+            args.last().unwrap(),
+            &std::ffi::OsString::from("/backups/myserver/2026-04-28_03-00-00")
+        );
+    }
+
+    #[test]
+    fn forget_args_group_by_tags_so_retention_spans_snapshots() {
+        let args = forget_args(false);
+
+        assert!(args.windows(2).any(|w| w == ["--group-by", "tags"]));
+        assert!(args.windows(2).any(|w| w == ["--keep-daily", "7"]));
+        assert!(args.contains(&"--prune"));
+        assert!(!args.contains(&"--dry-run"));
+    }
+
+    #[test]
+    fn forget_args_dry_run_appends_flag() {
+        assert!(forget_args(true).contains(&"--dry-run"));
     }
 
     #[test]


### PR DESCRIPTION
Offsite repo (filen) grew unboundedly: every snapshot ever pushed was kept forever and `--prune` reclaimed zero data. Retention now applies per host, and Postgres dumps dedup across snapshots again. Closes #371.

## Root causes → fixes

| # | Cause | Fix |
|---|---|---|
| 1 | Unique `<host>/<timestamp>` path per push + restic's default `host,paths` grouping → every snapshot a singleton retention group, `--keep-daily 7` retained all | Tag snapshots with host at push (`restic backup --tag <host>`), `forget --group-by tags` — `src/services/backup/session.rs` |
| 2 | `pg_dump -Fc` compression reshuffles downstream bytes after one changed row → near-zero chunk reuse, full `db.dump` stored per snapshot | `-Fc -Z0`: raw tuples produce identical byte runs; restic zstd-compresses the unique chunks — `src/services/backup/executor.rs` |
| 3 | Standalone `push` never prunes | Doc-only per grilling decision (2026-07-26): `push` stays upload-only, `sync` is the retention-enforcing entrypoint — `docs/cli-reference/backup/{push,prune}.md` |

Tags instead of `--group-by host`: restic's `host` field is the machine running restic (constant across pushes), which would pool all auberge hosts sharing one repo into a single retention group and let them evict each other's snapshots.

> [!IMPORTANT]
> Pre-existing snapshots are untagged and form their own retention group — up to 23 (7d+4w+12m) linger forever without a one-time cleanup after release:
> ```bash
> restic tag --set <host>          # single-host repo: tags all snapshots
> auberge backup prune --dry-run   # verify removals are listed
> auberge backup prune
> ```

## Test plan

- [x] 347 unit tests pass; 3 new (`backup_args` host tag, `forget_args` grouping + retention, `--dry-run` flag)
- [x] `pg_dump -Fc -Z0` asserted in executor command-order test
- [ ] Post-release on the filen repo: `restic forget --dry-run` lists removals; `restic stats --mode raw-data` shrinks after prune

https://claude.ai/code/session_01FWHk6i1t8Ecfb7STntj8mg