### PR TITLE
chore: release v0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.6](https://github.com/sripwoud/auberge/compare/v0.14.5...v0.14.6) - 2026-07-27
+
+### Fixed
+
+- *(backup)* make restic prune actually forget old snapshots ([#372](https://github.com/sripwoud/auberge/pull/372))
+
 ## [0.14.5](https://github.com/sripwoud/auberge/compare/v0.14.4...v0.14.5) - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auberge"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.5 -> 0.14.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.6](https://github.com/sripwoud/auberge/compare/v0.14.5...v0.14.6) - 2026-07-27

### Fixed

- *(backup)* make restic prune actually forget old snapshots ([#372](https://github.com/sripwoud/auberge/pull/372))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).