### PR TITLE
chore(examples): make bichon-expunge interactive and guard-railed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+# Google Shell Style Guide, as shfmt reads it: 2-space indent, indented switch
+# cases, binary operators starting the continuation line.
+[*.sh]
+indent_style = space
+indent_size = 2
+switch_case_indent = true
+binary_next_line = true

--- a/.github/scripts/check-stdout-discipline.sh
+++ b/.github/scripts/check-stdout-discipline.sh
@@ -25,13 +25,13 @@ readonly PATTERN='\b(println|print)!'
 readonly ALLOWLIST='src/output\.rs:|src/commands/((backup|config_cmd|dns|headscale|host|select)|bichon/reconcile)\.rs:'
 
 self_test() {
-  echo 'println!()' | grep -qE "${PATTERN}" ||
-    {
+  echo 'println!()' | grep -qE "${PATTERN}" \
+    || {
       echo "self-test FAILED: regex did not match println!"
       exit 2
     }
-  echo 'print!()' | grep -qE "${PATTERN}" ||
-    {
+  echo 'print!()' | grep -qE "${PATTERN}" \
+    || {
       echo "self-test FAILED: regex did not match print!"
       exit 2
     }

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,12 +34,15 @@ jobs:
             [tasks]
             "check-format" = { run = "dprint check --excludes mise.toml" }
             "check-lint" = { run = "ansible-lint", dir = "ansible" }
+            "check-shell" = { run = ["shellcheck $(git ls-files '*.sh')", "shfmt -d --apply-ignore $(git ls-files '*.sh')"] }
             "check" = { depends = "check-*" }
             [tools]
             dprint = "latest"
             pipx = "latest"
             "pipx:ansible-core" = "latest"
             "pipx:ansible-lint" = "latest"
+            shellcheck = "latest"
+            shfmt = "latest"
       - run: mise settings experimental=true
 
       - name: Install Ansible collections with retry

--- a/docs/applications/apps/bichon.md
+++ b/docs/applications/apps/bichon.md
@@ -53,4 +53,22 @@ Default credentials: `admin` / `admin@bichon`. Change after first login.
 
 !> Check journal for errors before expunging — do not rely on archive mtime or message count alone. Unticked folders are not archived. Do not automate expunge on a cron.
 
-Reference script: [`examples/bichon-expunge.sh`](https://github.com/sripwoud/auberge/blob/master/examples/bichon-expunge.sh) (prints the expunge command, does not run it).
+**Reference script**: [`examples/bichon-expunge.sh`](https://github.com/sripwoud/auberge/blob/master/examples/bichon-expunge.sh) turns the ordering above into five gates and, once they all pass, executes the expunge.
+
+```bash
+bash examples/bichon-expunge.sh --host <hostname> --account you@example.com
+```
+
+| Gate | Assertion                                                          |
+| ---- | ------------------------------------------------------------------ |
+| 1    | `auberge backup verify --app bichon` exits 0                       |
+| 2    | last `bichon-archive.service` run succeeded, less than 3h ago      |
+| 3    | archived `.eml` count >= IMAP count, scoped to `--folder`          |
+| 4    | summary: exact himalaya commands, message count, snapshot evidence |
+| 5    | operator types the folder name at a prompt                         |
+
+Defaults: `--folder INBOX`, `--window-days 90`, `--archive-path /var/lib/bichon-archive`. On a TTY, a missing `--host` or `--account` is prompted for. Gate 3 also aborts if anything in the folder already carries the `\Deleted` flag, since the expunge would take it along.
+
+Deletion is `himalaya flag add … deleted` followed by `himalaya folder expunge` — messages are removed in place, not moved to Trash, so mailbox quota is actually reclaimed.
+
+!> The expunge needs an interactive TTY. There is no `--yes`/`--force`; `--no-input` and non-TTY stdin run every gate and then refuse to expunge. Per [ADR-0007](https://github.com/sripwoud/auberge/blob/master/meta/adr/0007-bichon-folder-reconcile-scope-and-silent-vs-loud.md) no unattended expunge path exists, and the script is not shipped in the `auberge` binary.

--- a/examples/bichon-expunge.sh
+++ b/examples/bichon-expunge.sh
@@ -226,6 +226,15 @@ check_prerequisites() {
   note 'auberge, himalaya, jq, ssh ok'
 }
 
+# Guard a value that crossed back from the Host before it reaches (( )).
+# Arithmetic evaluation expands command substitutions, so a non-numeric value
+# there would be more than a wrong answer.
+require_number() {
+  local label="$1" value="$2"
+  [[ "${value}" =~ ^[0-9]+$ ]] \
+    || die 1 "${host} returned a non-numeric ${label}: ${value}"
+}
+
 # Print UTC date offset by -$1 days, formatted with $2.
 # GNU coreutils (Linux) and BSD (macOS) take incompatible flags; dispatch on
 # whichever the operator's `date` binary accepts.
@@ -285,6 +294,8 @@ REMOTE
     || die 1 'bichon-archive.service has never completed a run' \
       "start it: ssh ${host} sudo systemctl start bichon-archive.service"
 
+  require_number 'archive run age' "${age_seconds}"
+
   [[ "${result}" == 'success' ]] \
     || die 1 "the last bichon-archive.service run ended with Result=${result}" \
       "read the failure: ssh ${host} journalctl -u bichon-archive.service -n 50" \
@@ -331,12 +342,16 @@ gate_folder_coverage() {
   # `folder expunge` removes every \Deleted-flagged message in the folder, not
   # only the ones this script flags. A pre-existing flag would therefore be
   # collateral damage, so refuse rather than widen the blast radius.
-  local already_deleted
-  already_deleted=$(himalaya --output json envelope list \
+  local deleted_json already_deleted
+  deleted_json=$(himalaya --output json envelope list \
     --account "${account}" \
     --folder "${folder}" \
     --page-size "${PAGE_SIZE}" \
-    flag deleted 2>/dev/null | jq 'length')
+    flag deleted 2>/dev/null) \
+    || die 1 "himalaya could not list deleted-flagged mail in ${folder}" \
+      'this script must know what the expunge would take along, so it will' \
+      'not continue without that answer'
+  already_deleted=$(printf '%s' "${deleted_json}" | jq 'length')
 
   ((already_deleted == 0)) \
     || die 1 "${already_deleted} message(s) in ${folder} already carry the deleted flag" \
@@ -371,6 +386,7 @@ find "$archive_dir" -regextype posix-extended \
 REMOTE
   )
   note "archive .eml files in window: ${eml_count}"
+  require_number 'archive file count' "${eml_count}"
 
   ((eml_count >= IMAP_COUNT)) \
     || die 1 "coverage gap: archive has ${eml_count} files, IMAP has ${IMAP_COUNT} messages" \

--- a/examples/bichon-expunge.sh
+++ b/examples/bichon-expunge.sh
@@ -1,43 +1,234 @@
 #!/usr/bin/env bash
+#
 # examples/bichon-expunge.sh
 #
-# REFERENCE SCRIPT — NOT A SUPPORTED TOOL
-# ----------------------------------------
-# This is a worked example for operators who want to safely expunge old mail
-# from their Upstream Mailbox after confirming it is present in the Email
-# Archive and the off-host backup.  It intentionally stops short of the actual
-# expunge; the destructive step is left as an explicit operator command.
+# REFERENCE SCRIPT — NOT SHIPPED IN THE auberge BINARY
+# ---------------------------------------------------
+# Expunges mail older than a window from an Upstream Mailbox, but only after
+# proving the messages are in the Email Archive and in the off-host restic
+# backup. Five gates run in order; all must pass:
 #
-# Designed for MXroute but should work with any IMAP provider that supports
-# himalaya.  Adjust IMAP_HOST, FOLDER, and WINDOW_DAYS for your setup.
+#   1. off-host backup    `auberge backup verify --app bichon` exits 0
+#   2. archive freshness  last bichon-archive.service run succeeded, recently
+#   3. folder coverage    archive .eml count >= IMAP count, scoped to --folder
+#   4. summary            exact commands, message count, snapshot evidence
+#   5. typed confirmation operator types the folder name on a TTY
+#
+# Safety contract (ADR-0007) — load-bearing, do not "improve" away:
+#   - stdin must be a TTY; a non-TTY run refuses the expunge unconditionally
+#   - there is no --yes / --force, so no unattended expunge path exists
+#   - the typed folder name is an intent checksum against a mangled --folder
+#
+# Designed for MXroute; works with any IMAP provider himalaya supports.
 #
 # Prerequisites:
-#   - himalaya  (https://github.com/pimalaya/himalaya — Rust, matches project ethos)
-#   - ssh access to the Bichon host
-#   - journalctl access on the Bichon host
+#   - auberge with the `backup verify` subcommand (>= the release carrying it)
+#   - himalaya  (https://github.com/pimalaya/himalaya — Rust, project ethos)
+#   - jq
+#   - key-based ssh access to the Bichon Host, with journal/systemctl read
 #
-# Usage:
-#   BICHON_HOST=yourserver BICHON_ARCHIVE_PATH=/var/lib/bichon-archive \
-#   IMAP_ACCOUNT=you@example.com IMAP_HOST=mail.mxrouting.net \
-#   FOLDER=INBOX WINDOW_DAYS=90 \
-#   bash examples/bichon-expunge.sh
+# Exit codes:
+#   0 — expunged, or (non-interactive) all gates passed and expunge skipped
+#   1 — a gate failed, or the typed confirmation did not match
+#   2 — usage error, missing prerequisite, or unreachable Host
 #
 # shellcheck shell=bash
 
 set -euo pipefail
 
-: "${BICHON_HOST:?Set BICHON_HOST to the SSH hostname of the Bichon server}"
-: "${BICHON_ARCHIVE_PATH:=/var/lib/bichon-archive}"
-: "${IMAP_ACCOUNT:?Set IMAP_ACCOUNT to the email address configured in Bichon}"
-: "${IMAP_HOST:?Set IMAP_HOST to the IMAP server hostname}"
-: "${FOLDER:=INBOX}"
-: "${WINDOW_DAYS:=90}"
+readonly PROGRAM_NAME="${0##*/}"
+readonly DEFAULT_FOLDER='INBOX'
+readonly DEFAULT_WINDOW_DAYS=90
+readonly DEFAULT_ARCHIVE_PATH='/var/lib/bichon-archive'
+# bichon-archive.timer is OnCalendar=hourly with RandomizedDelaySec=10min, so a
+# healthy Host runs it at most ~70min apart. 3h leaves slack for a reboot.
+readonly ARCHIVE_MAX_AGE_HOURS=3
+# himalaya pages envelope listings; one oversized page beats paginating here.
+readonly PAGE_SIZE=9999
+readonly SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=10)
 
-SAFE_ACCOUNT=$(printf '%s' "$IMAP_ACCOUNT" | tr '/' '_')
+host=''
+account=''
+folder="${DEFAULT_FOLDER}"
+window_days="${DEFAULT_WINDOW_DAYS}"
+archive_path="${DEFAULT_ARCHIVE_PATH}"
+no_input=false
+
+# Gate findings, threaded from the gate that computes them to the summary and
+# the expunge.
+BACKUP_EVIDENCE=''
+CUTOFF_DATE=''
+ENVELOPE_JSON=''
+IMAP_COUNT=0
+
+usage() {
+  cat <<EOF
+Expunge archived mail from an Upstream Mailbox, behind five safety gates.
+
+Usage: ${PROGRAM_NAME} [options]
+
+Options:
+  -H, --host HOST            ssh target of the Bichon Host, also passed to
+                             \`auberge backup verify --host\` (prompted if a TTY)
+  -a, --account ADDRESS      himalaya account to expunge from (prompted if a TTY)
+  -f, --folder NAME          folder to expunge (default: ${DEFAULT_FOLDER})
+  -w, --window-days DAYS     expunge mail older than DAYS (default: ${DEFAULT_WINDOW_DAYS})
+      --archive-path PATH    Email Archive root on the Host
+                             (default: ${DEFAULT_ARCHIVE_PATH})
+      --no-input             never prompt; requires --host and --account, and
+                             refuses the expunge (gates still run)
+  -h, --help                 show this help
+
+The expunge requires an interactive TTY. There is deliberately no flag that
+skips the typed confirmation.
+EOF
+}
+
+# die <exit-code> <message> [remediation-line...]
+die() {
+  local code="$1" message="$2"
+  shift 2
+  printf '%s: error: %s\n' "${PROGRAM_NAME}" "${message}" >&2
+  local line
+  for line in "$@"; do
+    printf '  %s\n' "${line}" >&2
+  done
+  exit "${code}"
+}
+
+# Chrome goes to stderr (clig.dev); stdout carries the outcome line only.
+note() {
+  printf '%s\n' "$*" >&2
+}
+
+step() {
+  printf '\n==> %s\n' "$*" >&2
+}
+
+interactive() {
+  [[ "${no_input}" == false ]] && [[ -t 0 ]]
+}
+
+parse_args() {
+  while (($# > 0)); do
+    case "$1" in
+      -H | --host)
+        [[ $# -ge 2 ]] || die 2 "$1 needs a value"
+        host="$2"
+        shift 2
+        ;;
+      -a | --account)
+        [[ $# -ge 2 ]] || die 2 "$1 needs a value"
+        account="$2"
+        shift 2
+        ;;
+      -f | --folder)
+        [[ $# -ge 2 ]] || die 2 "$1 needs a value"
+        folder="$2"
+        shift 2
+        ;;
+      -w | --window-days)
+        [[ $# -ge 2 ]] || die 2 "$1 needs a value"
+        window_days="$2"
+        shift 2
+        ;;
+      --archive-path)
+        [[ $# -ge 2 ]] || die 2 "$1 needs a value"
+        archive_path="$2"
+        shift 2
+        ;;
+      --no-input)
+        no_input=true
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        die 2 "unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+# Read one value from the operator. Prompt on stderr so stdout stays clean.
+prompt_for() {
+  local label="$1" value
+  printf '%s: ' "${label}" >&2
+  IFS= read -r value || die 2 "stdin closed while reading ${label}"
+  printf '%s' "${value}"
+}
+
+resolve_missing_flags() {
+  if [[ -z "${host}" ]]; then
+    interactive || die 2 'missing --host' \
+      'a non-interactive run must pass every value as a flag'
+    host=$(prompt_for 'Bichon Host (ssh target)')
+  fi
+
+  if [[ -z "${account}" ]]; then
+    interactive || die 2 'missing --account' \
+      'a non-interactive run must pass every value as a flag'
+    account=$(prompt_for 'himalaya account (email address)')
+  fi
+}
+
+validate_flags() {
+  # A host starting with '-' would be parsed by ssh as an option, so the
+  # character class is a guard, not cosmetics.
+  [[ "${host}" =~ ^[A-Za-z0-9][A-Za-z0-9._@-]*$ ]] \
+    || die 2 "not a usable ssh target: ${host}" \
+      'expected a hostname, ssh_config alias, or user@host'
+
+  [[ "${account}" == *[![:space:]]* ]] \
+    || die 2 'account must not be empty'
+
+  [[ "${folder}" == *[![:space:]]* ]] \
+    || die 2 'folder must not be empty'
+
+  # A newline in the folder name would desynchronise the typed-confirmation
+  # comparison from what the operator sees on screen.
+  [[ "${folder}" != *$'\n'* ]] \
+    || die 2 'folder must not contain a newline'
+
+  [[ "${window_days}" =~ ^[1-9][0-9]*$ ]] \
+    || die 2 "window-days must be a positive integer, got: ${window_days}"
+
+  [[ "${archive_path}" == /* ]] \
+    || die 2 "archive-path must be absolute, got: ${archive_path}"
+}
+
+check_prerequisites() {
+  step 'Checking prerequisites…'
+
+  local tool
+  for tool in auberge himalaya jq ssh; do
+    command -v "${tool}" >/dev/null 2>&1 \
+      || die 2 "${tool} is not on PATH" \
+        'install it before running this script'
+  done
+
+  # Gate 1 needs `auberge backup verify`. clap exits non-zero on an unknown
+  # subcommand, which is exactly the signal for "your auberge is too old".
+  auberge backup verify --help >/dev/null 2>&1 \
+    || die 2 'this auberge has no "backup verify" subcommand' \
+      'upgrade auberge: mise up auberge' \
+      'gate 1 asserts the archive reached the off-host restic repository;' \
+      'there is no weaker substitute for it'
+
+  ssh "${SSH_OPTS[@]}" "${host}" true 2>/dev/null \
+    || die 2 "cannot ssh to ${host}" \
+      "check: ssh ${host}" \
+      'key-based auth is required (this script runs ssh in BatchMode)'
+
+  note 'auberge, himalaya, jq, ssh ok'
+}
 
 # Print UTC date offset by -$1 days, formatted with $2.
 # GNU coreutils (Linux) and BSD (macOS) take incompatible flags; dispatch on
-# whichever the host's `date` binary accepts.
+# whichever the operator's `date` binary accepts.
 date_offset() {
   if date -u -d "-1 day" '+%Y' >/dev/null 2>&1; then
     date -u -d "-$1 days" "$2"
@@ -46,72 +237,237 @@ date_offset() {
   fi
 }
 
-CUTOFF_DATE=$(date_offset "${WINDOW_DAYS}" '+%Y-%m-%d')
-CUTOFF_YM=$(date_offset "${WINDOW_DAYS}" '+%Y/%m')
+# Gate 1 — the archive is in the off-host restic repository.
+gate_backup_verified() {
+  step 'Gate 1/5 — off-host backup…'
 
-echo "==> Checking archive freshness on ${BICHON_HOST}…"
-ssh "${BICHON_HOST}" "journalctl -u bichon-archive.service --since '-2h' | tail -5"
+  local verify_output
+  if ! verify_output=$(auberge backup verify --host "${host}" --app bichon 2>&1); then
+    printf '%s\n' "${verify_output}" >&2
+    die 1 'the bichon archive is not in a fresh off-host snapshot' \
+      'run: auberge backup sync --host '"${host}" \
+      'expunging now would delete mail that exists in only one place'
+  fi
 
-echo ""
-echo "==> Counting IMAP messages in ${FOLDER} older than ${WINDOW_DAYS} days (before ${CUTOFF_DATE})…"
-# Use --output json: the default table format includes header rows and box
-# drawing, so wc -l is off by a few. jq 'length' counts envelopes precisely.
-IMAP_COUNT=$(himalaya --account "${IMAP_ACCOUNT}" envelope list \
-  --folder "${FOLDER}" \
-  --query "before:${CUTOFF_DATE}" \
-  --page-size 9999 \
-  --output json \
-  2>/dev/null \
-  | jq 'length')
-echo "    IMAP messages in window: ${IMAP_COUNT}"
+  printf '%s\n' "${verify_output}" >&2
+  BACKUP_EVIDENCE="${verify_output}"
+}
 
-echo ""
-echo "==> Counting archived messages for ${FOLDER} on ${BICHON_HOST}…"
-ARCHIVE_DIR="${BICHON_ARCHIVE_PATH}/${SAFE_ACCOUNT}"
-# Archive path encodes message Date as YYYY/MM; folder identity lives in the
-# <id>.meta.json sidecar. The IMAP query is folder-scoped, so the archive
-# count must also be — counting account-wide .eml files would over-count and
-# pass the coverage gate when the target folder is partially archived.
-# Pass remote args via printf %q so $FOLDER / $ARCHIVE_DIR cannot break out of
-# argument quoting and execute on the host. The heredoc body is single-quoted
-# ('REMOTE') to disable local expansion — only positional parameters are used.
-# shellcheck disable=SC2029  # intentional: %q-quote args locally, then expand into ssh cmd
-EML_COUNT=$(ssh "${BICHON_HOST}" \
-  "bash -s -- $(printf '%q ' "${ARCHIVE_DIR}" "${FOLDER}" "${CUTOFF_YM}")" <<'REMOTE'
+# Gate 2 — the hourly archive run succeeded, recently.
+gate_archive_fresh() {
+  step 'Gate 2/5 — archive freshness…'
+
+  # Age is computed on the Host: its `date` is GNU, and systemd's timestamp
+  # format is only reliably parseable there.
+  local status
+  status=$(
+    ssh "${SSH_OPTS[@]}" "${host}" 'bash -s' <<'REMOTE'
+set -euo pipefail
+result=$(systemctl show bichon-archive.service --property=Result --value)
+exit_ts=$(systemctl show bichon-archive.service --property=ExecMainExitTimestamp --value)
+printf 'result=%s\n' "$result"
+if [ -n "$exit_ts" ]; then
+  printf 'age_seconds=%s\n' "$(($(date +%s) - $(date -d "$exit_ts" +%s)))"
+fi
+REMOTE
+  )
+
+  local result age_seconds
+  result=$(printf '%s\n' "${status}" | sed -n 's/^result=//p')
+  age_seconds=$(printf '%s\n' "${status}" | sed -n 's/^age_seconds=//p')
+
+  # shellcheck disable=SC2029  # intentional: ARCHIVE_MAX_AGE_HOURS is a local constant
+  ssh "${SSH_OPTS[@]}" "${host}" \
+    "journalctl -u bichon-archive.service --since=-${ARCHIVE_MAX_AGE_HOURS}h --no-pager | tail -5" >&2 \
+    || true
+
+  [[ -n "${age_seconds}" ]] \
+    || die 1 'bichon-archive.service has never completed a run' \
+      "start it: ssh ${host} sudo systemctl start bichon-archive.service"
+
+  [[ "${result}" == 'success' ]] \
+    || die 1 "the last bichon-archive.service run ended with Result=${result}" \
+      "read the failure: ssh ${host} journalctl -u bichon-archive.service -n 50" \
+      'a failed run means the archive is incomplete for an unknown set of mail'
+
+  local max_age_seconds=$((ARCHIVE_MAX_AGE_HOURS * 3600))
+  ((age_seconds <= max_age_seconds)) \
+    || die 1 "the last archive run finished $((age_seconds / 3600))h ago (limit ${ARCHIVE_MAX_AGE_HOURS}h)" \
+      "check the timer: ssh ${host} systemctl list-timers bichon-archive.timer"
+
+  note "last run succeeded $((age_seconds / 60))m ago"
+}
+
+# Gate 3 — every in-window IMAP message has an archived counterpart.
+# Sets IMAP_COUNT and ENVELOPE_JSON; the expunge reuses the same envelope set,
+# so the messages counted here are exactly the messages deleted later.
+gate_folder_coverage() {
+  step "Gate 3/5 — coverage for ${folder} older than ${window_days} days…"
+
+  local cutoff_date cutoff_ym
+  cutoff_date=$(date_offset "${window_days}" '+%Y-%m-%d')
+  cutoff_ym=$(date_offset "${window_days}" '+%Y/%m')
+  CUTOFF_DATE="${cutoff_date}"
+
+  # --output json: the default table format adds headers and box drawing, so
+  # `wc -l` is off by a few. jq counts envelopes precisely. The filter query is
+  # a trailing positional in himalaya, so it must come after every flag.
+  ENVELOPE_JSON=$(himalaya --output json envelope list \
+    --account "${account}" \
+    --folder "${folder}" \
+    --page-size "${PAGE_SIZE}" \
+    before "${cutoff_date}" 2>/dev/null) \
+    || die 1 "himalaya could not list ${folder} for ${account}" \
+      "check the account exists: himalaya account list" \
+      "check the folder exists: himalaya folder list --account ${account}"
+
+  IMAP_COUNT=$(printf '%s' "${ENVELOPE_JSON}" | jq 'length')
+  note "IMAP messages in window: ${IMAP_COUNT}"
+
+  ((IMAP_COUNT > 0)) \
+    || die 1 "no IMAP messages in ${folder} older than ${window_days} days" \
+      'nothing to expunge — check --folder and --account'
+
+  # `folder expunge` removes every \Deleted-flagged message in the folder, not
+  # only the ones this script flags. A pre-existing flag would therefore be
+  # collateral damage, so refuse rather than widen the blast radius.
+  local already_deleted
+  already_deleted=$(himalaya --output json envelope list \
+    --account "${account}" \
+    --folder "${folder}" \
+    --page-size "${PAGE_SIZE}" \
+    flag deleted 2>/dev/null | jq 'length')
+
+  ((already_deleted == 0)) \
+    || die 1 "${already_deleted} message(s) in ${folder} already carry the deleted flag" \
+      "inspect them: himalaya envelope list --account ${account} --folder ${folder} flag deleted" \
+      'clear or expunge them separately — this script only expunges what it flags'
+
+  # Archive paths encode the message Date as YYYY/MM; folder identity lives in
+  # the <id>.meta.json sidecar. The IMAP query is folder-scoped, so the archive
+  # count must be too — counting account-wide .eml files would over-count and
+  # pass this gate while the target folder is only partially archived.
+  local safe_account archive_dir eml_count
+  safe_account=$(printf '%s' "${account}" | tr '/' '_')
+  archive_dir="${archive_path}/${safe_account}"
+
+  # Remote args go through printf %q so ${folder} / ${archive_dir} cannot break
+  # out of argument quoting and execute on the Host. The heredoc body is
+  # single-quoted ('REMOTE') to disable local expansion — only positional
+  # parameters are used.
+  # shellcheck disable=SC2029  # intentional: %q-quote args locally, then expand into ssh cmd
+  eml_count=$(
+    ssh "${SSH_OPTS[@]}" "${host}" \
+      "bash -s -- $(printf '%q ' "${archive_dir}" "${folder}" "${cutoff_ym}")" <<'REMOTE'
 set -euo pipefail
 archive_dir=$1; folder=$2; cutoff_ym=$3
 find "$archive_dir" -regextype posix-extended \
   -regex '.*/[0-9]{4}/[0-9]{2}/[^/]+\.meta\.json' 2>/dev/null \
-| while IFS= read -r meta; do
+  | while IFS= read -r meta; do
     ym=$(printf '%s' "$meta" | awk -F/ '{ print $(NF-2)"/"$(NF-1) }')
     [ "$ym" \> "$cutoff_ym" ] && continue
     jq -e --arg f "$folder" '.folder == $f' "$meta" >/dev/null 2>&1 && printf '.\n'
   done | wc -l
 REMOTE
-)
-echo "    Archive .eml files in window: ${EML_COUNT}"
+  )
+  note "archive .eml files in window: ${eml_count}"
 
-echo ""
-if [ "${IMAP_COUNT}" -eq 0 ]; then
-  echo "ERROR: No IMAP messages found — check FOLDER and IMAP_ACCOUNT." >&2
-  exit 1
-fi
+  ((eml_count >= IMAP_COUNT)) \
+    || die 1 "coverage gap: archive has ${eml_count} files, IMAP has ${IMAP_COUNT} messages" \
+      "read the journal: ssh ${host} journalctl -u bichon-archive.service" \
+      "check ${folder} is a Synced Folder: auberge bichon reconcile-folders --host ${host}" \
+      'do not expunge until the counts reconcile'
 
-if [ "${EML_COUNT}" -lt "${IMAP_COUNT}" ]; then
-  echo "COVERAGE GAP: archive has ${EML_COUNT} files but IMAP has ${IMAP_COUNT} messages." >&2
-  echo "Do NOT expunge until the gap is resolved.  Check:" >&2
-  echo "  ssh ${BICHON_HOST} journalctl -u bichon-archive.service" >&2
-  echo "  Bichon UI → Accounts → ${IMAP_ACCOUNT} → sync_folders (verify ${FOLDER} is ticked)" >&2
-  exit 1
-fi
+  note "coverage ok (${eml_count} >= ${IMAP_COUNT})"
+}
 
-echo "Coverage OK (${EML_COUNT} archive files >= ${IMAP_COUNT} IMAP messages)."
-echo ""
-echo "==> Pre-conditions satisfied.  The expunge step is intentionally NOT automated."
-echo "    To expunge messages older than ${WINDOW_DAYS} days from ${FOLDER}, run:"
-echo ""
-echo "    himalaya --account ${IMAP_ACCOUNT} message expunge \\"
-echo "      --folder '${FOLDER}' --query 'before:${CUTOFF_DATE}'"
-echo ""
-echo "    Confirm the archive is in an off-host backup before proceeding:"
-echo "    auberge backup create --apps bichon   # on your operator laptop"
+# Gate 4 — show the operator exactly what is about to happen.
+print_summary() {
+  step 'Gate 4/5 — summary'
+
+  cat >&2 <<EOF
+  account         ${account}
+  folder          ${folder}
+  window          older than ${window_days} days (before ${CUTOFF_DATE})
+  messages        ${IMAP_COUNT}
+  Host            ${host}
+  archive root    ${archive_path}
+
+off-host backup evidence:
+$(printf '%s\n' "${BACKUP_EVIDENCE}" | sed 's/^/  /')
+
+commands to be run against ${account}:
+  himalaya flag add --account ${account} --folder ${folder} <${IMAP_COUNT} uids> deleted
+  himalaya folder expunge --account ${account} ${folder}
+
+The uids are the ${IMAP_COUNT} envelopes listed in gate 3 — no second listing
+happens, so nothing that arrived since then can be caught up in the expunge.
+EOF
+}
+
+# Gate 5 — typed confirmation. TTY-only by construction.
+confirm_or_abort() {
+  step 'Gate 5/5 — confirmation'
+
+  printf 'This permanently deletes %s message(s) from %s.\n' "${IMAP_COUNT}" "${account}" >&2
+  printf 'Type the folder name (%s) to proceed, anything else to abort: ' "${folder}" >&2
+
+  local typed
+  IFS= read -r typed || die 1 'stdin closed before confirmation — nothing expunged'
+
+  [[ "${typed}" == "${folder}" ]] \
+    || die 1 'confirmation did not match the folder name — nothing expunged'
+}
+
+expunge() {
+  local ids=()
+  mapfile -t ids < <(printf '%s' "${ENVELOPE_JSON}" | jq -r '.[].id')
+
+  ((${#ids[@]} == IMAP_COUNT)) \
+    || die 1 "envelope ids (${#ids[@]}) do not match the counted messages (${IMAP_COUNT})" \
+      'refusing to act on a listing that changed underfoot'
+
+  # himalaya reads any non-numeric positional as a flag name, so a stray value
+  # here would silently become a flag instead of a uid.
+  local id
+  for id in "${ids[@]}"; do
+    [[ "${id}" =~ ^[0-9]+$ ]] \
+      || die 1 "himalaya returned a non-numeric envelope id: ${id}"
+  done
+
+  step "Flagging ${#ids[@]} message(s) as deleted…"
+  himalaya flag add \
+    --account "${account}" \
+    --folder "${folder}" \
+    "${ids[@]}" deleted >&2
+
+  step "Expunging ${folder}…"
+  himalaya folder expunge --account "${account}" "${folder}" >&2
+}
+
+main() {
+  parse_args "$@"
+  resolve_missing_flags
+  validate_flags
+
+  check_prerequisites
+  gate_backup_verified
+  gate_archive_fresh
+  gate_folder_coverage
+  print_summary
+
+  if ! interactive; then
+    note ''
+    note 'All gates passed. The expunge needs an interactive TTY and a typed'
+    note 'confirmation; there is no unattended path (ADR-0007). Re-run this'
+    note 'script from a terminal to expunge.'
+    printf 'verified: %s message(s) eligible in %s\n' "${IMAP_COUNT}" "${folder}"
+    return 0
+  fi
+
+  confirm_or_abort
+  expunge
+  printf 'expunged: %s message(s) from %s\n' "${IMAP_COUNT}" "${folder}"
+}
+
+main "$@"

--- a/hk.pkl
+++ b/hk.pkl
@@ -12,7 +12,9 @@ local linters  = new Mapping<String, Step> {
     fix = "dprint fmt"
     stage = "*"
   }
-  
+  ["shellcheck"] = Builtins.shellcheck
+  // shfmt reads .editorconfig for the Google Shell Style Guide settings.
+  ["shfmt"] = Builtins.shfmt
 }
 
 hooks {

--- a/mise.toml
+++ b/mise.toml
@@ -27,6 +27,13 @@ quiet = true
 run = "cargo clippy"
 quiet = true
 
+[tasks.lint-shell]
+run = [
+  "shellcheck $(git ls-files '*.sh')",
+  "shfmt -d --apply-ignore $(git ls-files '*.sh')",
+]
+quiet = true
+
 [tasks.lint]
 alias = "l"
 depends = "lint-*"
@@ -49,6 +56,8 @@ ansible = "latest"
 "pipx:ansible-dev-tools" = "latest"
 "pipx:ansible-lint" = "latest"
 rust = "latest"
+shellcheck = "latest"
+shfmt = "latest"
 "cargo:cargo-nextest" = "latest"
 "npm:docsify-cli" = "latest"
 


### PR DESCRIPTION
Closes #375.

`examples/bichon-expunge.sh` ran the safe checks then printed a command for the operator to retype — putting the least-guarded step of the archived-then-expunge workflow in the place most likely to be run against the wrong folder. It now performs the expunge itself, from a terminal only, after the operator types the folder name back.

```
$ bash examples/bichon-expunge.sh --host myserver --account you@example.com
==> Gate 3/5 — coverage for INBOX older than 90 days…
    IMAP messages in window: 1284
    archive .eml files in window: 1310
==> Gate 5/5 — confirmation
Type the folder name (INBOX) to proceed, anything else to abort: _
```

Defaults `--folder INBOX`, `--window-days 90`, `--archive-path /var/lib/bichon-archive`; `--host`/`--account` are prompted for on a TTY.

### Gates

| # | Assertion | On failure |
|---|-----------|------------|
| 1 | `auberge backup verify --app bichon` exits 0 | prints auberge's own output, then `auberge backup sync` |
| 2 | last `bichon-archive.service` run `Result=success`, < 3h old | journal tail + the `systemctl` command to run |
| 3 | archived `.eml` count >= IMAP count, scoped to `--folder` | journal + `auberge bichon reconcile-folders` |
| 4 | summary: exact commands, count, snapshot evidence | — |
| 5 | operator types the folder name | abort, nothing expunged |

Gate 3 keeps the folder-scoped `meta.json` counting and the `printf %q` ssh quoting from the previous version. It gained one check the issue didn't ask for: `folder expunge` removes **every** `\Deleted`-flagged message in the folder, so a pre-existing flag would be collateral damage — the gate refuses instead of widening the blast radius.

### Safety contract

Per [ADR-0007](https://github.com/sripwoud/auberge/blob/master/meta/adr/0007-bichon-folder-reconcile-scope-and-silent-vs-loud.md), unchanged and load-bearing:

- `expunge()` is reachable from exactly one place, behind `if ! interactive; then … return 0; fi` where `interactive()` requires `[[ -t 0 ]]`
- no `--yes`, no `--force` — no unattended path exists
- `--no-input` (TTY or not) runs every gate, prints the commands, exits 0 with `verified: N message(s) eligible`, and expunges nothing
- the typed folder name is an intent checksum against a mangled `--folder`

Verified with stubbed `auberge`/`himalaya`/`ssh` and a pty from `script(1)`. Every row expunges nothing except the control:

| Scenario | Destructive calls |
|----------|-------------------|
| control: gates pass, `INBOX` typed on a pty | 2 (`flag add`, `folder expunge`) |
| `echo INBOX \| script`, `yes INBOX \| script`, heredoc, `</dev/null`, `setsid` | 0 |
| `--no-input` on a real TTY with `INBOX` available on stdin | 0 |
| wrong name typed / empty confirmation | 0 |
| each of gates 1, 2 (failed unit / stale / never ran), 3 (gap / empty window / listing failure / pre-flagged mail) | 0 |
| non-numeric uid, non-numeric count or age from the Host | 0 |

> [!IMPORTANT]
> Depends on #374. Until `auberge backup verify` merges, gate 1's prerequisite check fires: `auberge backup verify --help` exits non-zero on an unknown subcommand, and the script dies with `this auberge has no "backup verify" subcommand` plus `mise up auberge`. No fallback path — gate 1 has no weaker substitute.

### Two corrections to the spec

**The himalaya incantation the old script printed does not exist.** Checked against [himalaya v1.2.0 source](https://github.com/pimalaya/himalaya/tree/v1.2.0/src): there is no `message expunge`; `envelope list` takes its query as a *trailing positional* (`before 2026-04-30`), not `--query before:…`; and `--account` is declared per-subcommand, so `himalaya --account X envelope list` fails outright. Harmless while the line was only printed; fatal now that it runs.

Deletion is therefore `flag add … deleted` (in-place `\Deleted` via `UID STORE` — `Envelope.id` is the IMAP UID, not a sequence number, so the id set cannot shift underfoot) then `folder expunge`. `message delete` would have *moved* mail to Trash and reclaimed no quota.

**`--imap-host` is dropped.** The issue lists it, inherited from `IMAP_HOST` in the old script — where it was `:?`-required and then never read. himalaya resolves the server from its own account config, so the flag could not verify anything; a required flag that changes no behavior misrepresents what the script checks. `himalaya folder list --account …` in gate 3's error path is the real "is this account reachable" signal.

### Shell linting

Shell was the only language in the repo without a linter, and this script now executes a destructive IMAP operation.

- `hk.pkl`: `Builtins.shellcheck` + `Builtins.shfmt`
- `.editorconfig`: Google Shell Style Guide settings (2-space, `switch_case_indent`, `binary_next_line`) — shfmt reads them from there, so hk, CI, and editors agree without duplicated flags
- `mise.toml`: `lint-shell` task, picked up by `lint`'s `depends = "lint-*"`
- `master.yml`: `check-shell`, picked up by `check`'s `depends = "check-*"` (the workflow's inline `mise_toml` replaces the repo's, so it needs its own entry)

`.github/scripts/check-stdout-discipline.sh` is reformatted — that config applied, no logic change.

### Test plan

- [x] `shellcheck` clean, `shfmt` clean, `dprint check` clean
- [x] `hk run pre-commit --all` green across all five steps (ansible, clippy, dprint, shellcheck, shfmt)
- [x] `mise r lint-shell` green
- [x] 20 stubbed scenarios above; the only destructive calls are the control's
- [ ] one real run against the Bichon Host after #374 merges
