### PR TITLE
feat(backup): add verify command for offsite snapshot freshness

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,10 @@ _Avoid_: Backup runner, recipe runner
 The Rust module that orchestrates multiple Recipe Executor invocations across a Host's Apps, plus restic push and prune. Owns cross-recipe concerns; per-recipe semantics live in the Recipe Executor.
 _Avoid_: Backup job, backup workflow
 
+**Backup Verdict**:
+The verdict `auberge backup verify` reaches about the newest offsite restic snapshot for a Host, as a fail-fast checklist — repository reachable → a snapshot exists → it contains an App → it is younger than a threshold — carried by the exit code (0 verified, 1 a check failed, 2 operational error). A pure function of `restic snapshots --json` plus one containment probe, so the whole decision is unit-tested without invoking restic. Asserts the "backup is current" half of ADR-0007's boundary; it says nothing about the **Upstream Mailbox**, which would be coverage-check and stays out of scope.
+_Avoid_: Health check, audit, validation, integrity check (restic's own `check` verifies repository integrity — a different question).
+
 **Email Archive**:
 A Bichon-independent on-disk mirror of email messages, produced by an hourly systemd timer on the bichon Host that walks Bichon's REST API and writes one `.eml` per message under `/var/lib/bichon-archive/`, with a `.meta.json` sidecar capturing folder + tags. Distinct from a **Backup Recipe**: an Archive is consumable without Bichon (any MBOX/EML-aware client can read it), and is the _source_ the bichon Backup Recipe rsyncs — Bichon's encrypted internal store (`/opt/bichon/data`) is deliberately not backed up. See ADR-0006.
 _Avoid_: backup (collides with Backup Recipe), dump, export.
@@ -95,6 +99,7 @@ _Avoid_: Logger, reporter
 - A **Playbook Meta** declares zero or one **Backup Recipe**.
 - A **Preflight** binds one **Playbook Meta** to a validated **Config**.
 - The **Recipe Executor** consumes one **Backup Recipe**; the **Backup Session** consumes many.
+- A **Backup Verdict** reads only what a **Backup Session** already pushed, attributing a snapshot to a **Host** by the restic tag push writes (the same tag prune groups retention by).
 - All runners report through **Progress**; none touch terminal output directly.
 - An **App** is either a **Public App** or a **Tailnet-only App**, determined by the `tailnet_only` flag in its **Playbook Meta**. **DNS Publication** is dispatched accordingly.
 - The **Busy Feed** is derived from **Baikal**'s calendar data — plus, optionally, a read-only external CalDAV calendar fetched Host-side — and served on Baikal's **Public App** site (Google's servers must reach it); auberge produces and serves it but ships no consumer.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -27,6 +27,7 @@
     - [push](cli-reference/backup/push.md)
     - [prune](cli-reference/backup/prune.md)
     - [sync](cli-reference/backup/sync.md)
+    - [verify](cli-reference/backup/verify.md)
     - [export-opml](cli-reference/backup/export-opml.md)
     - [import-opml](cli-reference/backup/import-opml.md)
   - DNS

--- a/docs/applications/apps/bichon.md
+++ b/docs/applications/apps/bichon.md
@@ -48,7 +48,11 @@ Default credentials: `admin` / `admin@bichon`. Change after first login.
 
 1. Folders ticked in Bichon UI, `bichon.service` syncing.
 2. `bichon-archive.timer` ran successfully — check `journalctl -u bichon-archive.service`.
-3. `auberge backup sync` completed — archive is off-host.
+3. Archive is off-host — `auberge backup sync`, then confirm it landed:
+   ```bash
+   auberge backup verify --app bichon
+   ```
+   Exit `0` means the newest offsite snapshot contains the archive and is younger than 24h. Anything else: stop, do not expunge. See [backup verify](cli-reference/backup/verify.md).
 4. Operator expunges manually (e.g. `himalaya`).
 
 !> Check journal for errors before expunging — do not rely on archive mtime or message count alone. Unticked folders are not archived. Do not automate expunge on a cron.

--- a/docs/backup-restore/overview.md
+++ b/docs/backup-restore/overview.md
@@ -41,17 +41,16 @@ Backups are stored locally in `~/.local/share/auberge/backups/` with the followi
 ```
 backups/
 └── {hostname}/
-    ├── baikal/
-    │   ├── 2026-01-23_14-30-00/
-    │   ├── 2026-01-23_18-45-12/
-    │   └── latest -> 2026-01-23_18-45-12
-    ├── freshrss/
-    ├── gokapi/
-    ├── navidrome/
-    └── calibre/
+    ├── 2026-01-23_14-30-00/
+    │   ├── baikal/
+    │   ├── freshrss/
+    │   └── navidrome/
+    └── 2026-01-23_18-45-12/
+        ├── baikal/
+        └── freshrss/
 ```
 
-Each app has a `latest` symlink pointing to the most recent backup for easy access.
+One directory per run, holding one directory per app backed up in that run. `auberge backup push` uploads a whole timestamped run, and `backup verify` reads the same `{hostname}/{timestamp}` layout back out of the repository.
 
 ## Technical Details
 
@@ -62,7 +61,6 @@ Each app has a `latest` symlink pointing to the most recent backup for easy acce
 3. Data is synced from remote using `rsync` with SSH
 4. Database dumps are downloaded via `scp` and cleaned up on remote
 5. Services are restarted via `systemctl start {service}`
-6. `latest` symlink is updated to point to new backup
 
 ### Restore Process
 
@@ -83,6 +81,7 @@ Local backups can be pushed to an offsite restic repository for disaster recover
 1. Create a local backup with `auberge backup create`
 2. Push it offsite with `auberge backup push`
 3. Apply retention policies with `auberge backup prune` (7 daily, 4 weekly, 12 monthly)
+4. Confirm it landed with `auberge backup verify` — the only step that reads the repository back. See [backup verify](cli-reference/backup/verify.md)
 
 For automated daily backups, use `auberge backup sync` which runs the full pipeline (create → push → prune → cleanup) in one command and removes local staging after a successful push. Prune failures are non-fatal. See [backup sync](cli-reference/backup/sync.md).
 

--- a/docs/cli-reference/auberge.md
+++ b/docs/cli-reference/auberge.md
@@ -18,19 +18,19 @@ auberge [GLOBAL OPTIONS] <COMMAND>
 
 ## Commands
 
-| Command                                             | Alias | Purpose                             |
-| --------------------------------------------------- | ----- | ----------------------------------- |
-| [deploy](cli-reference/deploy.md)                   | `dp`  | Deploy apps with auto-hardening     |
-| [ansible](cli-reference/ansible/run.md)             | `a`   | Run Ansible playbooks               |
-| [backup](cli-reference/backup/create.md)            | `b`   | Backup / restore / push / prune     |
-| [dns](cli-reference/dns/list.md)                    | `d`   | Cloudflare DNS management           |
-| [host](cli-reference/host/add.md)                   | `h`   | Manage `hosts.toml`                 |
-| [ssh](cli-reference/ssh/keygen.md)                  | `ss`  | SSH key generation and deployment   |
-| [sync](cli-reference/sync/music.md)                 | `sy`  | rsync media to the VPS              |
-| [headscale](cli-reference/headscale/add-user.md)    | `hs`  | Headscale users and nodes           |
-| [bichon](cli-reference/bichon/reconcile-folders.md) | —     | Bichon folder reconciliation        |
-| [config](cli-reference/config/overview.md)          | `c`   | Manage `config.toml`                |
-| [select](cli-reference/select/host.md)              | `se`  | Interactive host / playbook pickers |
+| Command                                             | Alias | Purpose                                  |
+| --------------------------------------------------- | ----- | ---------------------------------------- |
+| [deploy](cli-reference/deploy.md)                   | `dp`  | Deploy apps with auto-hardening          |
+| [ansible](cli-reference/ansible/run.md)             | `a`   | Run Ansible playbooks                    |
+| [backup](cli-reference/backup/create.md)            | `b`   | Backup / restore / push / prune / verify |
+| [dns](cli-reference/dns/list.md)                    | `d`   | Cloudflare DNS management                |
+| [host](cli-reference/host/add.md)                   | `h`   | Manage `hosts.toml`                      |
+| [ssh](cli-reference/ssh/keygen.md)                  | `ss`  | SSH key generation and deployment        |
+| [sync](cli-reference/sync/music.md)                 | `sy`  | rsync media to the VPS                   |
+| [headscale](cli-reference/headscale/add-user.md)    | `hs`  | Headscale users and nodes                |
+| [bichon](cli-reference/bichon/reconcile-folders.md) | —     | Bichon folder reconciliation             |
+| [config](cli-reference/config/overview.md)          | `c`   | Manage `config.toml`                     |
+| [select](cli-reference/select/host.md)              | `se`  | Interactive host / playbook pickers      |
 
 ## Files
 

--- a/docs/cli-reference/backup/sync.md
+++ b/docs/cli-reference/backup/sync.md
@@ -26,6 +26,8 @@ auberge backup sync [OPTIONS]
 
 The local staging copy is ephemeral — restic handles long-term retention with content-addressable, deduplicated storage.
 
+?> Sync reports what it did; it does not read the repository back. [backup verify](cli-reference/backup/verify.md) asserts the snapshot actually landed and is fresh — run it before anything destructive depends on the backup existing.
+
 ## Prerequisites
 
 Same as [backup push](cli-reference/backup/push.md) — requires `restic_repository` and `restic_password` config values, plus `restic` and `rclone` installed.

--- a/docs/cli-reference/backup/verify.md
+++ b/docs/cli-reference/backup/verify.md
@@ -1,0 +1,118 @@
+# auberge backup verify
+
+Assert that the latest offsite restic snapshot is fresh and holds an app's backup. Read-only — it never writes to the repository. Alias: `auberge b v`.
+
+```bash
+auberge backup verify [OPTIONS]
+```
+
+## Options
+
+| Option                | Description                                    | Default                                       |
+| --------------------- | ---------------------------------------------- | --------------------------------------------- |
+| `-H, --host HOST`     | Host whose snapshots to check                  | The sole configured host; required if several |
+| `-a, --app APP`       | Also assert this app is in the latest snapshot | No app check                                  |
+| `--max-age DURATION`  | Freshness threshold, `<number><s\|m\|h\|d>`    | `24h`                                         |
+| `-o, --output FORMAT` | `human` or `json`                              | `human`                                       |
+
+Verify never prompts, so it is safe in scripts and timers.
+
+## Checks
+
+Fail-fast, in order:
+
+1. The restic repository answers `restic snapshots --json`.
+2. At least one snapshot exists for the host.
+3. The latest snapshot contains the app's directory — only with `--app`.
+4. The latest snapshot is younger than `--max-age`.
+
+```bash
+$ auberge backup verify --app bichon
+✓ repository reachable
+✓ latest snapshot for myserver: a1b2c3d4 (2026-07-29T03:00Z, 6h ago)
+✓ contains bichon (…/myserver/2026-07-29_03-00-00/bichon)
+✓ younger than 24h
+verified
+```
+
+The checklist is data on stdout; remediation for a failed check goes to stderr.
+
+## Exit codes
+
+| Code | Meaning                                                                                               |
+| ---- | ----------------------------------------------------------------------------------------------------- |
+| `0`  | Verified — every check passed                                                                         |
+| `1`  | A check failed — no snapshot for the host, app missing, or snapshot older than `--max-age`            |
+| `2`  | Operational error — restic not installed, repository unreachable, config keys or `--max-age` unusable |
+
+Gate a destructive step on it:
+
+```bash
+auberge backup verify --app bichon || exit 1
+```
+
+## Examples
+
+```bash
+auberge backup verify
+auberge backup verify --app bichon
+auberge backup verify --host myserver --max-age 36h
+auberge backup verify --app bichon --output json
+```
+
+## Prerequisites
+
+Same as [backup push](cli-reference/backup/push.md) — requires `restic_repository` and `restic_password` config values.
+
+<details>
+<summary>JSON output schema</summary>
+
+```json
+{
+  "verified": false,
+  "status": "check_failed",
+  "host": "myserver",
+  "app": "bichon",
+  "max_age": "24h",
+  "snapshot": {
+    "id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    "short_id": "a1b2c3d4",
+    "time": "2026-07-29T03:00:00Z",
+    "age_seconds": 21600
+  },
+  "checks": [
+    {
+      "name": "repository_reachable",
+      "passed": true,
+      "message": "repository reachable",
+      "remediation": null
+    },
+    {
+      "name": "contains_app",
+      "passed": false,
+      "message": "contains bichon",
+      "remediation": "run: auberge backup sync --host myserver --apps bichon"
+    }
+  ]
+}
+```
+
+| Field                  | Type           | Description                                                             |
+| ---------------------- | -------------- | ----------------------------------------------------------------------- |
+| `verified`             | boolean        | `true` only when every check passed                                     |
+| `status`               | string         | `verified`, `check_failed`, or `operational_error`                      |
+| `host`                 | string         | Host the snapshots were filtered by                                     |
+| `app`                  | string \| null | App asserted with `--app`; `null` when omitted                          |
+| `max_age`              | string         | Threshold as passed on the command line                                 |
+| `snapshot`             | object \| null | Resolved snapshot; `null` when none was found                           |
+| `snapshot.short_id`    | string         | First 8 characters of `snapshot.id`, as restic displays it              |
+| `snapshot.age_seconds` | number         | Snapshot age at the time of the check                                   |
+| `checks`               | array          | Checks that ran, in order — fail-fast, so it stops at the first failure |
+| `checks[].name`        | string         | `repository_reachable`, `snapshot_exists`, `contains_app`, or `fresh`   |
+| `checks[].remediation` | string \| null | Command to fix a failed check; `null` when it passed                    |
+
+JSON goes to stdout; human-format chrome goes to stderr.
+
+</details>
+
+?> A snapshot belongs to a host if [backup push](cli-reference/backup/push.md) tagged it with the host name — the same tag [backup prune](cli-reference/backup/prune.md) groups retention by, so both commands agree on which snapshots are a host's. Snapshots pushed before tagging landed carry no tags and are matched by their `…/backups/<host>/<timestamp>` path instead, so an existing repository verifies without a re-push.

--- a/meta/adr/0007-auberge-folder-reconcile-scope.md
+++ b/meta/adr/0007-auberge-folder-reconcile-scope.md
@@ -10,7 +10,7 @@ Auberge ships `auberge bichon reconcile-folders --host <h>` — an idempotent CL
 
 Folder identity is matched primarily by RFC 6154 SPECIAL-USE attributes (`AttributeEnum::{Junk, Trash}` on Bichon's `MailBox` struct — language-portable, hierarchy-portable across `[Gmail]/`, `INBOX.`, etc.), with case-insensitive name matching as fallback for legacy IMAP servers that don't advertise SPECIAL-USE. The default exclusion set is `{Junk/Spam, Trash}`. An operator-supplied per-account additive override (`extra_excluded_folders`) is supported in `config.toml`; subtracting from the default exclusions (e.g. archiving Trash anyway) requires a separate explicit flag and is deliberately a foot-gun.
 
-Auberge **does not** ship tooling for archive verification (coverage-check) or **Upstream Mailbox** expunge. The Email Archive is exposed as a primitive for operators to compose with external tools (`himalaya`, `imap-tools`, Bichon's UI). The `bichon.md` documentation captures the recommended archived-then-expunge workflow, including ordering invariants and a reference shell script at `examples/bichon-expunge.sh`.
+Auberge **does not** ship tooling for archive verification (coverage-check) or **Upstream Mailbox** expunge. (Amended 2026-07-29: verifying auberge's _own_ offsite snapshots is in scope — see below.) The Email Archive is exposed as a primitive for operators to compose with external tools (`himalaya`, `imap-tools`, Bichon's UI). The `bichon.md` documentation captures the recommended archived-then-expunge workflow, including ordering invariants and a reference shell script at `examples/bichon-expunge.sh`.
 
 ## Why
 
@@ -53,6 +53,35 @@ The deciding principle is **asymmetric automation along the silent-vs-loud failu
 - Operator must remember to invoke `reconcile-folders` after creating an account in Bichon's UI. Mitigated by `bichon.md` docs and (likely) a sentence in the `auberge ansible run --tags bichon` post-task output ("Reminder: run `auberge bichon reconcile-folders --apply` if you've added accounts since the last reconcile.").
 - Folder _drift_ (operator creates a new IMAP folder, never re-runs reconcile, new folder isn't in `sync_folders`) is silent until next reconcile. Acceptable: drift in this direction means the new folder isn't archived (loud-ish — the operator notices missing mail in search) rather than the wrong folder _is_ archived (silent, append-only). Direction of failure matters.
 - Expunge tooling lives outside auberge — operators who want one-command expunge must either build a wrapper script or accept the two-tool workflow (reconcile + himalaya). Documented as the recommended pattern.
+
+## Amendment (2026-07-29): offsite snapshot verification moves into the binary
+
+`auberge backup verify [-H <host>] [-a <app>] [--max-age <duration>]` ships as a read-only
+command: it asserts that the newest restic snapshot for a Host exists, contains an App's backup,
+and is younger than a freshness threshold. Exit `0` verified, `1` a check failed, `2` operational
+error, so it composes as a gate in a script.
+
+This does **not** reopen alternative (γ). Coverage-check compares the **Email Archive** against the
+**Upstream Mailbox** — two-sided, needs IMAP credentials auberge deliberately doesn't hold, and its
+failure mode is loud. That stays out. `backup verify` is one-sided and reads only state auberge
+itself produced: its own snapshots, in its own repository, under its own
+`…/backups/<host>/<timestamp>` layout. The sibling ADR-0007 draws the boundary at "archive is
+current and **backup is current**"; verify makes the second clause executable instead of leaving it
+as prose an operator re-derives with `restic snapshots --json | jq` each time.
+
+What changed since (γ) was rejected is the argument, not the convenience. (γ) was refused because
+"auberge has unique knowledge" collapsed — every path was filesystem-readable. That still holds for
+the archive. It does not hold for the restic repository: the repository URL and password live in
+`config.toml` (both supporting `!command` indirection), the host↔snapshot mapping is auberge's own
+path convention, and `RESTIC_PASSWORD_COMMAND` must be unset or restic silently resolves the wrong
+password. An external script must reimplement all four to be correct, and a verifier that is
+_subtly_ wrong is not loud — it prints a green check against the wrong snapshot. That inverts the
+silent-vs-loud test that decided this ADR.
+
+Scope is held down by construction: no repository writes, no IMAP, no expunge, no new config keys,
+no new dependencies. A snapshot is attributed to a Host by the tag `backup push` writes (#371) —
+the same tag `backup prune` groups retention by — with the `…/backups/<host>/<timestamp>` path
+covering snapshots pushed before tagging landed.
 
 ## References
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,15 +1,17 @@
 use crate::config::Config;
-use crate::hosts::{Host, select_or_arg as hosts_select_or_arg};
+use crate::hosts::{Host, HostManager, select_or_arg as hosts_select_or_arg};
 use crate::output;
 use crate::prompt::confirm;
 use crate::services::backup::executor::RecipeExecutor;
 use crate::services::backup::recipe::{
     assets_playbooks_dir, discover_backuppable_apps, load_app_recipe,
 };
+use crate::services::backup::restic;
 use crate::services::backup::session::{
     BackupSession, CreateOutcome, SessionOpts, restic_prune, restic_push,
 };
 use crate::services::backup::ssh::LiveSshSession;
+use crate::services::backup::verify::{self, MaxAge, Status, Verdict, VerifyRequest};
 use crate::ssh_session::SshSession;
 use chrono::Utc;
 use clap::Subcommand;
@@ -173,6 +175,34 @@ pub enum BackupCommands {
     Prune {
         #[arg(short = 'n', long, help = "Show what would be pruned without removing")]
         dry_run: bool,
+    },
+    #[command(
+        alias = "v",
+        about = "Check the latest offsite snapshot is fresh and holds an app's backup"
+    )]
+    Verify {
+        #[arg(
+            short = 'H',
+            long,
+            help = "Host whose snapshots to check (default: the sole configured host)"
+        )]
+        host: Option<String>,
+        #[arg(short, long, help = "Also assert this app is in the latest snapshot")]
+        app: Option<String>,
+        #[arg(
+            long,
+            default_value = "24h",
+            help = "Freshness threshold as <number><s|m|h|d>"
+        )]
+        max_age: String,
+        #[arg(
+            short = 'o',
+            long,
+            value_enum,
+            default_value = "human",
+            help = "Output format"
+        )]
+        output: OutputFormat,
     },
     #[command(alias = "io", about = "Import OPML file to FreshRSS")]
     ImportOpml {
@@ -1135,6 +1165,141 @@ pub fn run_backup_prune(dry_run: bool) -> Result<()> {
     restic_prune(&restic_repo, &restic_password, dry_run)
 }
 
+pub struct VerifyOptions {
+    pub host: Option<String>,
+    pub app: Option<String>,
+    pub max_age: String,
+    pub format: OutputFormat,
+}
+
+/// Returns the process exit code: 0 verified, 1 a check failed, 2 operational
+/// error. Verify is a gate for destructive downstream work, so the caller must
+/// be able to branch on which of the three happened.
+pub fn run_backup_verify(opts: VerifyOptions) -> i32 {
+    verify_exit_code(verify_and_report(opts))
+}
+
+fn verify_exit_code(result: Result<Status>) -> i32 {
+    match result {
+        Ok(status) => status.exit_code(),
+        Err(e) => {
+            eprintln!("✗ {e:#}");
+            Status::OperationalError.exit_code()
+        }
+    }
+}
+
+fn verify_and_report(opts: VerifyOptions) -> Result<Status> {
+    let max_age = MaxAge::parse(&opts.max_age)?;
+    let (restic_repo, restic_password) = load_restic_config()?;
+    let host = resolve_snapshot_host(opts.host)?;
+
+    let request = VerifyRequest {
+        host: &host,
+        app: opts.app.as_deref(),
+        max_age: &max_age,
+        now: Utc::now(),
+    };
+
+    let verdict = match restic::snapshots_json(&restic_repo, &restic_password) {
+        Ok(snapshots_json) => verify::verdict(&request, &snapshots_json, |snapshot, path| {
+            restic::snapshot_contains_path(&restic_repo, &restic_password, &snapshot.id, path)
+        }),
+        Err(e) => Verdict::unreachable(&format!("{e:#}")),
+    };
+
+    match opts.format {
+        OutputFormat::Human => print_verify_checklist(&verdict),
+        OutputFormat::Json => print_verify_json(&request, &verdict)?,
+    }
+
+    for remediation in verdict
+        .checks
+        .iter()
+        .filter_map(|check| check.remediation.as_deref())
+    {
+        eprintln!("{}", remediation);
+    }
+
+    Ok(verdict.status)
+}
+
+fn resolve_snapshot_host(host_arg: Option<String>) -> Result<String> {
+    match host_arg {
+        Some(name) => Ok(name),
+        None => sole_configured_host(&HostManager::load_hosts()?),
+    }
+}
+
+/// Verify is a scripted gate, so it never prompts: a single configured Host is
+/// implied, anything else makes `--host` mandatory.
+fn sole_configured_host(hosts: &[Host]) -> Result<String> {
+    match hosts {
+        [only] => Ok(only.name.clone()),
+        [] => eyre::bail!(
+            "No hosts configured. Pass --host <name> or add one with `auberge host add`"
+        ),
+        many => {
+            let names: Vec<&str> = many.iter().map(|h| h.name.as_str()).collect();
+            eyre::bail!(
+                "{} hosts configured; pass --host <{}>",
+                many.len(),
+                names.join("|")
+            )
+        }
+    }
+}
+
+fn print_verify_checklist(verdict: &Verdict) {
+    for check in &verdict.checks {
+        println!("{} {}", if check.passed { "✓" } else { "✗" }, check.message);
+    }
+    println!(
+        "{}",
+        match verdict.is_verified() {
+            true => "verified",
+            false => "not verified",
+        }
+    );
+}
+
+fn print_verify_json(request: &VerifyRequest<'_>, verdict: &Verdict) -> Result<()> {
+    let checks: Vec<_> = verdict
+        .checks
+        .iter()
+        .map(|check| {
+            serde_json::json!({
+                "name": check.name,
+                "passed": check.passed,
+                "message": check.message,
+                "remediation": check.remediation,
+            })
+        })
+        .collect();
+
+    let snapshot = verdict.snapshot.as_ref().map(|snapshot| {
+        serde_json::json!({
+            "id": snapshot.id,
+            "short_id": snapshot.short_id,
+            "time": snapshot.time.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "age_seconds": snapshot.age_seconds,
+        })
+    });
+
+    let json = serde_json::to_string_pretty(&serde_json::json!({
+        "verified": verdict.is_verified(),
+        "status": verdict.status.as_str(),
+        "host": request.host,
+        "app": request.app,
+        "max_age": request.max_age.label(),
+        "snapshot": snapshot,
+        "checks": checks,
+    }))?;
+
+    println!("{}", json);
+    Ok(())
+}
+
 fn resolve_backup_dir(
     backup_root: &Path,
     host_filter: Option<&str>,
@@ -1447,6 +1612,56 @@ mod tests {
     #[test]
     fn test_prune_variant_exists() {
         let _prune = BackupCommands::Prune { dry_run: true };
+    }
+
+    #[test]
+    fn test_verify_variant_exists() {
+        let _verify = BackupCommands::Verify {
+            host: None,
+            app: Some("bichon".to_string()),
+            max_age: "24h".to_string(),
+            output: OutputFormat::Human,
+        };
+    }
+
+    #[test]
+    fn sole_configured_host_is_implied() {
+        let hosts = vec![test_host()];
+        assert_eq!(sole_configured_host(&hosts).unwrap(), "test");
+    }
+
+    #[test]
+    fn sole_configured_host_errors_without_hosts() {
+        let err = sole_configured_host(&[]).unwrap_err().to_string();
+        assert!(err.contains("No hosts configured"), "{err}");
+    }
+
+    #[test]
+    fn sole_configured_host_errors_with_several_hosts() {
+        let second = Host {
+            name: "other".to_string(),
+            ..test_host()
+        };
+        let err = sole_configured_host(&[test_host(), second])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("2 hosts configured"), "{err}");
+        assert!(err.contains("--host <test|other>"), "{err}");
+    }
+
+    #[test]
+    fn verify_exit_code_maps_each_status() {
+        assert_eq!(verify_exit_code(Ok(Status::Verified)), 0);
+        assert_eq!(verify_exit_code(Ok(Status::CheckFailed)), 1);
+        assert_eq!(verify_exit_code(Ok(Status::OperationalError)), 2);
+    }
+
+    #[test]
+    fn verify_exit_code_treats_setup_errors_as_operational() {
+        assert_eq!(
+            verify_exit_code(Err(eyre::eyre!("restic_password missing"))),
+            2
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@ mod ssh_session;
 use clap::{Parser, Subcommand};
 use commands::ansible::{AnsibleCommands, run_ansible_bootstrap, run_ansible_run};
 use commands::backup::{
-    BackupCommands, RestoreOptions, run_backup_create, run_backup_list, run_backup_prune,
-    run_backup_push, run_backup_restore, run_backup_sync, run_export_opml, run_import_opml,
+    BackupCommands, RestoreOptions, VerifyOptions, run_backup_create, run_backup_list,
+    run_backup_prune, run_backup_push, run_backup_restore, run_backup_sync, run_backup_verify,
+    run_export_opml, run_import_opml,
 };
 use commands::bichon::{BichonCommands, run_bichon_command};
 use commands::config_cmd::{
@@ -231,6 +232,17 @@ async fn main() -> Result<()> {
                 signal::with_ctrlc(|| run_backup_push(host, backup_id))
             }
             BackupCommands::Prune { dry_run } => signal::with_ctrlc(|| run_backup_prune(dry_run)),
+            BackupCommands::Verify {
+                host,
+                app,
+                max_age,
+                output,
+            } => std::process::exit(run_backup_verify(VerifyOptions {
+                host,
+                app,
+                max_age,
+                format: output,
+            })),
             BackupCommands::ExportOpml {
                 host,
                 output,

--- a/src/services/backup.rs
+++ b/src/services/backup.rs
@@ -3,3 +3,4 @@ pub mod recipe;
 pub mod restic;
 pub mod session;
 pub mod ssh;
+pub mod verify;

--- a/src/services/backup/restic.rs
+++ b/src/services/backup/restic.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::process::Command;
 
 #[derive(Debug, Deserialize)]
 pub struct ResticStatus {
@@ -27,6 +28,19 @@ pub enum ResticMessage {
 
 pub fn parse_restic_message(line: &str) -> Option<ResticMessage> {
     serde_json::from_str(line).ok()
+}
+
+/// A `restic` invocation carrying the repository credentials.
+///
+/// `RESTIC_PASSWORD_COMMAND` is removed because restic prefers it over
+/// `RESTIC_PASSWORD`: an operator with it exported would have every auberge
+/// restic call resolve the wrong password.
+pub fn command(repo: &str, password: &str) -> Command {
+    let mut cmd = Command::new("restic");
+    cmd.env("RESTIC_REPOSITORY", repo)
+        .env("RESTIC_PASSWORD", password)
+        .env_remove("RESTIC_PASSWORD_COMMAND");
+    cmd
 }
 
 #[cfg(test)]
@@ -84,6 +98,27 @@ mod tests {
             }
             _ => panic!("expected Status"),
         }
+    }
+
+    #[test]
+    fn command_sets_repo_and_password_and_drops_password_command() {
+        let cmd = command("rclone:filen:auberge-backup", "s3cret");
+        let envs: Vec<(String, Option<String>)> = cmd
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+
+        assert!(envs.contains(&(
+            "RESTIC_REPOSITORY".to_string(),
+            Some("rclone:filen:auberge-backup".to_string())
+        )));
+        assert!(envs.contains(&("RESTIC_PASSWORD".to_string(), Some("s3cret".to_string()))));
+        assert!(envs.contains(&("RESTIC_PASSWORD_COMMAND".to_string(), None)));
     }
 
     #[test]

--- a/src/services/backup/restic.rs
+++ b/src/services/backup/restic.rs
@@ -1,5 +1,7 @@
+use eyre::{Context, Result};
 use serde::Deserialize;
-use std::process::Command;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
 
 #[derive(Debug, Deserialize)]
 pub struct ResticStatus {
@@ -20,10 +22,16 @@ pub struct ResticSummary {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "message_type", rename_all = "lowercase")]
+pub struct ResticExitError {
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "message_type", rename_all = "snake_case")]
 pub enum ResticMessage {
     Status(ResticStatus),
     Summary(ResticSummary),
+    ExitError(ResticExitError),
 }
 
 pub fn parse_restic_message(line: &str) -> Option<ResticMessage> {
@@ -41,6 +49,92 @@ pub fn command(repo: &str, password: &str) -> Command {
         .env("RESTIC_PASSWORD", password)
         .env_remove("RESTIC_PASSWORD_COMMAND");
     cmd
+}
+
+/// Human-readable reason from a failed `restic --json` invocation.
+///
+/// With `--json` restic reports failures as an `exit_error` message on stderr;
+/// older versions print plain text, which is passed through unchanged.
+pub fn error_message(stderr: &str) -> String {
+    stderr
+        .lines()
+        .find_map(|line| match parse_restic_message(line) {
+            Some(ResticMessage::ExitError(err)) => Some(err.message),
+            _ => None,
+        })
+        .unwrap_or_else(|| stderr.trim().to_string())
+}
+
+/// Raw `restic snapshots --json` output for the repository.
+pub fn snapshots_json(repo: &str, password: &str) -> Result<String> {
+    let output = command(repo, password)
+        .arg("snapshots")
+        .arg("--json")
+        .output()
+        .wrap_err("Failed to run restic. Install restic: https://restic.net")?;
+
+    if !output.status.success() {
+        let reason = error_message(&String::from_utf8_lossy(&output.stderr));
+        eyre::bail!(match reason.is_empty() {
+            true => format!("restic snapshots failed ({})", output.status),
+            false => reason,
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Whether `path` is present inside a snapshot.
+///
+/// `restic ls <id> <dir>` walks only that subtree and exits 0 whether or not
+/// the dir exists, so presence is read off the output. Streaming stops at the
+/// first hit — an app's subtree can hold hundreds of thousands of files.
+/// restic's own diagnostics stay on the inherited stderr.
+pub fn snapshot_contains_path(
+    repo: &str,
+    password: &str,
+    snapshot_id: &str,
+    path: &str,
+) -> Result<bool> {
+    let mut child = command(repo, password)
+        .arg("ls")
+        .arg(snapshot_id)
+        .arg(path)
+        .stdout(Stdio::piped())
+        .spawn()
+        .wrap_err("Failed to run restic. Install restic: https://restic.net")?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| eyre::eyre!("Failed to capture restic ls output"))?;
+
+    let found = BufReader::new(stdout)
+        .lines()
+        .map_while(Result::ok)
+        .any(|line| is_path_under(&line, path));
+
+    if found {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Ok(true);
+    }
+
+    let status = child.wait().wrap_err("Failed to wait on restic ls")?;
+    if !status.success() {
+        eyre::bail!("restic ls failed ({status})");
+    }
+
+    Ok(false)
+}
+
+/// Whether a `restic ls` line is `path` itself or a descendant of it. The
+/// header line (`snapshot <id> of […]`) and sibling prefixes never match.
+fn is_path_under(line: &str, path: &str) -> bool {
+    line == path
+        || line
+            .strip_prefix(path)
+            .is_some_and(|rest| rest.starts_with('/'))
 }
 
 #[cfg(test)]
@@ -101,6 +195,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_restic_exit_error_line() {
+        let line = r#"{"message_type":"exit_error","code":12,"message":"Fatal: wrong password or no key found"}"#;
+        match parse_restic_message(line).unwrap() {
+            ResticMessage::ExitError(err) => {
+                assert_eq!(err.message, "Fatal: wrong password or no key found");
+            }
+            _ => panic!("expected ExitError"),
+        }
+    }
+
+    #[test]
     fn command_sets_repo_and_password_and_drops_password_command() {
         let cmd = command("rclone:filen:auberge-backup", "s3cret");
         let envs: Vec<(String, Option<String>)> = cmd
@@ -119,6 +224,65 @@ mod tests {
         )));
         assert!(envs.contains(&("RESTIC_PASSWORD".to_string(), Some("s3cret".to_string()))));
         assert!(envs.contains(&("RESTIC_PASSWORD_COMMAND".to_string(), None)));
+    }
+
+    #[test]
+    fn error_message_extracts_exit_error_message() {
+        let stderr = r#"{"message_type":"exit_error","code":10,"message":"Fatal: repository does not exist"}"#;
+        assert_eq!(error_message(stderr), "Fatal: repository does not exist");
+    }
+
+    #[test]
+    fn error_message_passes_through_plain_text() {
+        assert_eq!(
+            error_message("  Fatal: unable to open config file\n"),
+            "Fatal: unable to open config file"
+        );
+    }
+
+    #[test]
+    fn error_message_of_empty_stderr_is_empty() {
+        assert_eq!(error_message(""), "");
+    }
+
+    #[test]
+    fn is_path_under_matches_the_path_itself() {
+        assert!(is_path_under(
+            "/backups/myserver/ts/bichon",
+            "/backups/myserver/ts/bichon"
+        ));
+    }
+
+    #[test]
+    fn is_path_under_matches_descendants() {
+        assert!(is_path_under(
+            "/backups/myserver/ts/bichon/2026/a.eml",
+            "/backups/myserver/ts/bichon"
+        ));
+    }
+
+    #[test]
+    fn is_path_under_rejects_ls_header_line() {
+        assert!(!is_path_under(
+            "snapshot ef9c32e9 of [/backups/myserver/ts] at 2026-07-29 by user:",
+            "/backups/myserver/ts/bichon"
+        ));
+    }
+
+    #[test]
+    fn is_path_under_rejects_sibling_sharing_a_prefix() {
+        assert!(!is_path_under(
+            "/backups/myserver/ts/bichon-archive",
+            "/backups/myserver/ts/bichon"
+        ));
+    }
+
+    #[test]
+    fn is_path_under_rejects_ancestor_lines() {
+        assert!(!is_path_under(
+            "/backups/myserver/ts",
+            "/backups/myserver/ts/bichon"
+        ));
     }
 
     #[test]

--- a/src/services/backup/session.rs
+++ b/src/services/backup/session.rs
@@ -237,7 +237,8 @@ pub fn restic_push(
             Some(ResticMessage::Summary(s)) => {
                 snapshot_id = Some(s.snapshot_id);
             }
-            None => {}
+            // restic reports failures on stderr, surfaced via `result.status` below.
+            Some(ResticMessage::ExitError(_)) | None => {}
         },
     )
     .wrap_err("Failed to run restic backup")?;

--- a/src/services/backup/session.rs
+++ b/src/services/backup/session.rs
@@ -1,14 +1,13 @@
 use crate::output;
 use crate::playbook_meta::BackupRecipe;
 use crate::services::backup::executor::RecipeExecutor;
-use crate::services::backup::restic::{ResticMessage, parse_restic_message};
+use crate::services::backup::restic::{self, ResticMessage, parse_restic_message};
 use crate::services::backup::ssh::SshSession;
 use crate::services::progress::{Progress, TerminalProgress};
 use eyre::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 #[derive(Debug, Clone)]
 pub struct SessionOpts {
@@ -175,12 +174,9 @@ pub fn restic_push(
     output::info(&format!("Pushing {} to restic", backup_dir.display()));
 
     let mut progress = TerminalProgress::new("Checking restic repository");
-    let snapshots_check = Command::new("restic")
+    let snapshots_check = restic::command(restic_repo, restic_password)
         .arg("snapshots")
         .arg("--json")
-        .env("RESTIC_REPOSITORY", restic_repo)
-        .env("RESTIC_PASSWORD", restic_password)
-        .env_remove("RESTIC_PASSWORD_COMMAND")
         .output();
 
     let needs_init = match snapshots_check {
@@ -204,11 +200,8 @@ pub fn restic_push(
 
     if needs_init {
         progress.task_started("Initializing restic repository");
-        let init_output = Command::new("restic")
+        let init_output = restic::command(restic_repo, restic_password)
             .arg("init")
-            .env("RESTIC_REPOSITORY", restic_repo)
-            .env("RESTIC_PASSWORD", restic_password)
-            .env_remove("RESTIC_PASSWORD_COMMAND")
             .output()
             .wrap_err("Failed to initialize restic repository")?;
         let stderr_text = String::from_utf8_lossy(&init_output.stderr);
@@ -230,11 +223,7 @@ pub fn restic_push(
 
     let result = output::stream_command_stdout(
         "restic",
-        Command::new("restic")
-            .args(backup_args(backup_dir, host))
-            .env("RESTIC_REPOSITORY", restic_repo)
-            .env("RESTIC_PASSWORD", restic_password)
-            .env_remove("RESTIC_PASSWORD_COMMAND"),
+        restic::command(restic_repo, restic_password).args(backup_args(backup_dir, host)),
         |line| match parse_restic_message(line) {
             Some(ResticMessage::Status(s)) => {
                 if let (Some(total), Some(done)) = (s.total_bytes, s.bytes_done) {
@@ -274,11 +263,8 @@ pub fn restic_push(
 pub fn restic_prune(restic_repo: &str, restic_password: &str, dry_run: bool) -> Result<()> {
     let mut progress = TerminalProgress::new("Pruning restic snapshots");
 
-    let mut cmd = Command::new("restic");
-    cmd.args(forget_args(dry_run))
-        .env("RESTIC_REPOSITORY", restic_repo)
-        .env("RESTIC_PASSWORD", restic_password)
-        .env_remove("RESTIC_PASSWORD_COMMAND");
+    let mut cmd = restic::command(restic_repo, restic_password);
+    cmd.args(forget_args(dry_run));
 
     let prune_output = cmd.output().wrap_err("Failed to run restic forget")?;
 

--- a/src/services/backup/verify.rs
+++ b/src/services/backup/verify.rs
@@ -1,0 +1,916 @@
+use chrono::{DateTime, TimeDelta, Utc};
+use eyre::{Result, eyre};
+use serde::Deserialize;
+use std::fmt;
+
+pub const CHECK_REACHABLE: &str = "repository_reachable";
+pub const CHECK_SNAPSHOT: &str = "snapshot_exists";
+pub const CHECK_CONTAINS_APP: &str = "contains_app";
+pub const CHECK_FRESH: &str = "fresh";
+
+/// Freshness threshold for the latest snapshot, e.g. `24h`.
+///
+/// Keeps the operator's literal spelling so the checklist echoes what they
+/// asked for (`younger than 90m`, not a re-rendered `1h`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaxAge {
+    duration: TimeDelta,
+    label: String,
+}
+
+impl MaxAge {
+    pub fn parse(input: &str) -> Result<Self> {
+        let label = input.trim();
+        let invalid =
+            || eyre!("Invalid --max-age '{input}': expected <number><s|m|h|d>, for example 24h");
+
+        let mut chars = label.chars();
+        let unit = chars.next_back().ok_or_else(invalid)?;
+        let value: i64 = chars.as_str().parse().map_err(|_| invalid())?;
+        if value < 0 {
+            return Err(invalid());
+        }
+
+        let duration = match unit {
+            's' => TimeDelta::try_seconds(value),
+            'm' => TimeDelta::try_minutes(value),
+            'h' => TimeDelta::try_hours(value),
+            'd' => TimeDelta::try_days(value),
+            _ => return Err(invalid()),
+        }
+        .ok_or_else(invalid)?;
+
+        Ok(Self {
+            duration,
+            label: label.to_string(),
+        })
+    }
+
+    pub fn duration(&self) -> TimeDelta {
+        self.duration
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+}
+
+impl fmt::Display for MaxAge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.label)
+    }
+}
+
+/// One entry of `restic snapshots --json`.
+///
+/// `tags` is absent from the JSON for snapshots pushed before `backup push`
+/// started tagging, hence the default.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Snapshot {
+    pub id: String,
+    pub time: DateTime<Utc>,
+    pub paths: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+impl Snapshot {
+    /// restic's `short_id`: the first 8 characters of the snapshot id.
+    pub fn short_id(&self) -> &str {
+        self.id.get(..8).unwrap_or(&self.id)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Verified,
+    CheckFailed,
+    OperationalError,
+}
+
+impl Status {
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::Verified => 0,
+            Self::CheckFailed => 1,
+            Self::OperationalError => 2,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::CheckFailed => "check_failed",
+            Self::OperationalError => "operational_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Check {
+    pub name: &'static str,
+    pub message: String,
+    pub passed: bool,
+    pub remediation: Option<String>,
+}
+
+impl Check {
+    fn passed(name: &'static str, message: String) -> Self {
+        Self {
+            name,
+            message,
+            passed: true,
+            remediation: None,
+        }
+    }
+
+    fn failed(name: &'static str, message: String, remediation: String) -> Self {
+        Self {
+            name,
+            message,
+            passed: false,
+            remediation: Some(remediation),
+        }
+    }
+}
+
+/// The snapshot a verdict was reached about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotSummary {
+    pub id: String,
+    pub short_id: String,
+    pub time: DateTime<Utc>,
+    pub age_seconds: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Verdict {
+    pub status: Status,
+    pub checks: Vec<Check>,
+    pub snapshot: Option<SnapshotSummary>,
+}
+
+impl Verdict {
+    fn new(status: Status, checks: Vec<Check>, snapshot: Option<SnapshotSummary>) -> Self {
+        Self {
+            status,
+            checks,
+            snapshot,
+        }
+    }
+
+    pub fn is_verified(&self) -> bool {
+        self.status == Status::Verified
+    }
+
+    /// The snapshot list could not be read, so no later check ran.
+    pub fn unreachable(reason: &str) -> Self {
+        Self::new(
+            Status::OperationalError,
+            vec![Check::failed(
+                CHECK_REACHABLE,
+                format!("repository reachable: {}", one_line(reason)),
+                "check restic is installed and restic_repository / restic_password are right (auberge config list)"
+                    .to_string(),
+            )],
+            None,
+        )
+    }
+}
+
+pub struct VerifyRequest<'a> {
+    pub host: &'a str,
+    pub app: Option<&'a str>,
+    pub max_age: &'a MaxAge,
+    pub now: DateTime<Utc>,
+}
+
+/// Fail-fast checklist: snapshot list readable, a snapshot exists for the host,
+/// it contains the app (only with `app`), and it is younger than `max_age`.
+///
+/// `contains_app` receives the resolved snapshot and the app path to look for;
+/// it is the only step that needs a second restic call.
+pub fn verdict(
+    request: &VerifyRequest<'_>,
+    snapshots_json: &str,
+    contains_app: impl FnOnce(&Snapshot, &str) -> Result<bool>,
+) -> Verdict {
+    let snapshots: Vec<Snapshot> = match serde_json::from_str(snapshots_json) {
+        Ok(snapshots) => snapshots,
+        Err(e) => return Verdict::unreachable(&format!("unreadable snapshot list ({e})")),
+    };
+
+    let mut checks = vec![Check::passed(
+        CHECK_REACHABLE,
+        "repository reachable".to_string(),
+    )];
+
+    let Some(host_snapshot) = latest_for_host(&snapshots, request.host) else {
+        checks.push(Check::failed(
+            CHECK_SNAPSHOT,
+            format!("latest snapshot for {}", request.host),
+            missing_snapshot_remediation(&snapshots, request.host),
+        ));
+        return Verdict::new(Status::CheckFailed, checks, None);
+    };
+
+    let snapshot = host_snapshot.snapshot;
+    let age = request.now - snapshot.time;
+    let summary = Some(SnapshotSummary {
+        id: snapshot.id.clone(),
+        short_id: snapshot.short_id().to_string(),
+        time: snapshot.time,
+        age_seconds: age.num_seconds(),
+    });
+
+    checks.push(Check::passed(
+        CHECK_SNAPSHOT,
+        format!(
+            "latest snapshot for {}: {} ({}, {} ago)",
+            request.host,
+            snapshot.short_id(),
+            snapshot.time.format("%Y-%m-%dT%H:%MZ"),
+            format_age(age),
+        ),
+    ));
+
+    if let Some(app) = request.app {
+        let app_path = format!("{}/{}", host_snapshot.root.trim_end_matches('/'), app);
+        match contains_app(snapshot, &app_path) {
+            Err(e) => {
+                checks.push(Check::failed(
+                    CHECK_CONTAINS_APP,
+                    format!("contains {app}: {}", one_line(&format!("{e:#}"))),
+                    "check the restic repository is readable".to_string(),
+                ));
+                return Verdict::new(Status::OperationalError, checks, summary);
+            }
+            Ok(false) => {
+                checks.push(Check::failed(
+                    CHECK_CONTAINS_APP,
+                    format!("contains {app}"),
+                    format!(
+                        "run: auberge backup sync --host {} --apps {app}",
+                        request.host
+                    ),
+                ));
+                return Verdict::new(Status::CheckFailed, checks, summary);
+            }
+            Ok(true) => checks.push(Check::passed(
+                CHECK_CONTAINS_APP,
+                format!("contains {app} ({})", abbreviate(&app_path)),
+            )),
+        }
+    }
+
+    let message = format!("younger than {}", request.max_age);
+    if age > request.max_age.duration() {
+        checks.push(Check::failed(
+            CHECK_FRESH,
+            message,
+            format!("run: auberge backup sync --host {}", request.host),
+        ));
+        return Verdict::new(Status::CheckFailed, checks, summary);
+    }
+    checks.push(Check::passed(CHECK_FRESH, message));
+
+    Verdict::new(Status::Verified, checks, summary)
+}
+
+struct HostSnapshot<'a> {
+    snapshot: &'a Snapshot,
+    root: &'a str,
+}
+
+/// Newest snapshot belonging to `host`.
+fn latest_for_host<'a>(snapshots: &'a [Snapshot], host: &str) -> Option<HostSnapshot<'a>> {
+    snapshots
+        .iter()
+        .filter_map(|snapshot| host_snapshot(snapshot, host))
+        .max_by_key(|candidate| candidate.snapshot.time)
+}
+
+/// A snapshot belongs to a Host if `backup push` tagged it with the Host name,
+/// or — for snapshots pushed before tagging landed — if its path carries the
+/// Host segment. The same tag is what `backup prune` groups retention by.
+fn host_snapshot<'a>(snapshot: &'a Snapshot, host: &str) -> Option<HostSnapshot<'a>> {
+    let by_path = snapshot
+        .paths
+        .iter()
+        .find(|path| host_from_path(path) == Some(host));
+
+    if by_path.is_none() && !snapshot.tags.iter().any(|tag| tag == host) {
+        return None;
+    }
+
+    let root = by_path.or_else(|| snapshot.paths.first())?;
+    Some(HostSnapshot {
+        snapshot,
+        root: root.as_str(),
+    })
+}
+
+/// `…/backups/<host>/<timestamp>` → `<host>`.
+fn host_from_path(path: &str) -> Option<&str> {
+    let mut segments = path.trim_end_matches('/').rsplit('/');
+    let _timestamp = segments.next()?;
+    let host = segments.next()?;
+    (segments.next()? == "backups").then_some(host)
+}
+
+/// Names the hosts the repository does hold snapshots for, by the same rule
+/// membership uses, so the hint never contradicts the check above it.
+fn missing_snapshot_remediation(snapshots: &[Snapshot], host: &str) -> String {
+    let mut hosts: Vec<&str> = snapshots
+        .iter()
+        .flat_map(|snapshot| {
+            snapshot
+                .paths
+                .iter()
+                .filter_map(|path| host_from_path(path))
+                .chain(snapshot.tags.iter().map(String::as_str))
+        })
+        .collect();
+    hosts.sort_unstable();
+    hosts.dedup();
+
+    match hosts.is_empty() {
+        true => {
+            format!("repository holds no auberge backups — run: auberge backup sync --host {host}")
+        }
+        false => format!(
+            "repository holds snapshots for {} — run: auberge backup sync --host {host}",
+            hosts.join(", ")
+        ),
+    }
+}
+
+fn format_age(age: TimeDelta) -> String {
+    if age < TimeDelta::zero() {
+        return format!("-{}", format_age(-age));
+    }
+
+    let seconds = age.num_seconds();
+    match seconds {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s if s < 86_400 => format!("{}h", s / 3600),
+        s => match ((s % 86_400) / 3600, s / 86_400) {
+            (0, days) => format!("{days}d"),
+            (hours, days) => format!("{days}d {hours}h"),
+        },
+    }
+}
+
+/// Keeps the last three segments: `…/myserver/2026-07-29_03-00-00/bichon`.
+fn abbreviate(path: &str) -> String {
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    match segments.len() > 3 {
+        true => format!("…/{}", segments[segments.len() - 3..].join("/")),
+        false => path.to_string(),
+    }
+}
+
+/// Collapses restic's multi-line diagnostics into one checklist line.
+fn one_line(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROOT: &str = "/home/op/.local/share/auberge/backups";
+
+    fn now() -> DateTime<Utc> {
+        "2026-07-29T09:00:00Z".parse().unwrap()
+    }
+
+    fn snapshots_json(entries: &[(&str, &str, &str)]) -> String {
+        let entries: Vec<String> = entries
+            .iter()
+            .map(|(id, time, path)| {
+                format!(r#"{{"id":"{id}","time":"{time}","paths":["{path}"]}}"#)
+            })
+            .collect();
+        format!("[{}]", entries.join(","))
+    }
+
+    fn tagged_snapshots_json(entries: &[(&str, &str, &str, &str)]) -> String {
+        let entries: Vec<String> = entries
+            .iter()
+            .map(|(id, time, path, tag)| {
+                format!(r#"{{"id":"{id}","time":"{time}","paths":["{path}"],"tags":["{tag}"]}}"#)
+            })
+            .collect();
+        format!("[{}]", entries.join(","))
+    }
+
+    fn myserver_snapshots() -> String {
+        snapshots_json(&[(
+            "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+            "2026-07-29T03:00:00Z",
+            &format!("{ROOT}/myserver/2026-07-29_03-00-00"),
+        )])
+    }
+
+    fn request<'a>(host: &'a str, app: Option<&'a str>, max_age: &'a MaxAge) -> VerifyRequest<'a> {
+        VerifyRequest {
+            host,
+            app,
+            max_age,
+            now: now(),
+        }
+    }
+
+    fn max_age(input: &str) -> MaxAge {
+        MaxAge::parse(input).unwrap()
+    }
+
+    fn check<'a>(verdict: &'a Verdict, name: &str) -> Option<&'a Check> {
+        verdict.checks.iter().find(|c| c.name == name)
+    }
+
+    #[test]
+    fn max_age_parses_every_unit() {
+        assert_eq!(max_age("45s").duration(), TimeDelta::seconds(45));
+        assert_eq!(max_age("90m").duration(), TimeDelta::minutes(90));
+        assert_eq!(max_age("24h").duration(), TimeDelta::hours(24));
+        assert_eq!(max_age("2d").duration(), TimeDelta::days(2));
+    }
+
+    #[test]
+    fn max_age_keeps_the_operators_spelling() {
+        assert_eq!(max_age("90m").label(), "90m");
+        assert_eq!(max_age(" 24h ").to_string(), "24h");
+    }
+
+    #[test]
+    fn max_age_zero_is_allowed() {
+        assert_eq!(max_age("0h").duration(), TimeDelta::zero());
+    }
+
+    #[test]
+    fn max_age_rejects_malformed_input() {
+        for input in ["", "24", "h", "abc", "-1h", "24x", "1.5h", "24 h"] {
+            assert!(
+                MaxAge::parse(input).is_err(),
+                "expected '{input}' to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn max_age_rejects_multibyte_unit_without_panicking() {
+        assert!(MaxAge::parse("24é").is_err());
+    }
+
+    #[test]
+    fn max_age_rejects_overflowing_value() {
+        assert!(MaxAge::parse("9999999999999999999d").is_err());
+    }
+
+    #[test]
+    fn host_from_path_reads_the_host_segment() {
+        assert_eq!(
+            host_from_path(&format!("{ROOT}/myserver/2026-07-29_03-00-00")),
+            Some("myserver")
+        );
+    }
+
+    #[test]
+    fn host_from_path_ignores_a_trailing_slash() {
+        assert_eq!(
+            host_from_path(&format!("{ROOT}/myserver/2026-07-29_03-00-00/")),
+            Some("myserver")
+        );
+    }
+
+    #[test]
+    fn host_from_path_requires_a_backups_grandparent() {
+        assert_eq!(host_from_path("/srv/mybackups/myserver/ts"), None);
+        assert_eq!(host_from_path("/srv/other/myserver/ts"), None);
+        assert_eq!(host_from_path("/backups/myserver"), None);
+    }
+
+    #[test]
+    fn latest_for_host_picks_the_newest_regardless_of_array_order() {
+        let json = snapshots_json(&[
+            (
+                "aaa",
+                "2026-07-28T03:00:00Z",
+                &format!("{ROOT}/myserver/2026-07-28_03-00-00"),
+            ),
+            (
+                "ccc",
+                "2026-07-29T03:00:00Z",
+                &format!("{ROOT}/myserver/2026-07-29_03-00-00"),
+            ),
+            (
+                "bbb",
+                "2026-07-27T03:00:00Z",
+                &format!("{ROOT}/myserver/2026-07-27_03-00-00"),
+            ),
+        ]);
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
+
+        let latest = latest_for_host(&snapshots, "myserver").unwrap();
+
+        assert_eq!(latest.snapshot.id, "ccc");
+        assert_eq!(latest.root, format!("{ROOT}/myserver/2026-07-29_03-00-00"));
+    }
+
+    #[test]
+    fn latest_for_host_ignores_other_hosts() {
+        let json = snapshots_json(&[
+            (
+                "aaa",
+                "2026-07-29T03:00:00Z",
+                &format!("{ROOT}/other/2026-07-29_03-00-00"),
+            ),
+            (
+                "bbb",
+                "2026-07-28T03:00:00Z",
+                &format!("{ROOT}/myserver/2026-07-28_03-00-00"),
+            ),
+        ]);
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            latest_for_host(&snapshots, "myserver").unwrap().snapshot.id,
+            "bbb"
+        );
+        assert!(latest_for_host(&snapshots, "absent").is_none());
+    }
+
+    #[test]
+    fn latest_for_host_matches_the_push_tag() {
+        let json = tagged_snapshots_json(&[(
+            "aaa",
+            "2026-07-29T03:00:00Z",
+            "/srv/staging/2026-07-29_03-00-00",
+            "myserver",
+        )]);
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
+
+        let latest = latest_for_host(&snapshots, "myserver").unwrap();
+
+        assert_eq!(latest.snapshot.id, "aaa");
+        assert_eq!(latest.root, "/srv/staging/2026-07-29_03-00-00");
+    }
+
+    #[test]
+    fn latest_for_host_ignores_a_tag_naming_another_host() {
+        let json = tagged_snapshots_json(&[(
+            "aaa",
+            "2026-07-29T03:00:00Z",
+            "/srv/staging/2026-07-29_03-00-00",
+            "other",
+        )]);
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
+
+        assert!(latest_for_host(&snapshots, "myserver").is_none());
+    }
+
+    #[test]
+    fn latest_for_host_prefers_the_host_path_as_root_when_both_agree() {
+        let json = tagged_snapshots_json(&[(
+            "aaa",
+            "2026-07-29T03:00:00Z",
+            &format!("{ROOT}/myserver/2026-07-29_03-00-00"),
+            "myserver",
+        )]);
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            latest_for_host(&snapshots, "myserver").unwrap().root,
+            format!("{ROOT}/myserver/2026-07-29_03-00-00")
+        );
+    }
+
+    #[test]
+    fn latest_for_host_reads_untagged_snapshots_pushed_before_tagging() {
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&myserver_snapshots()).unwrap();
+
+        assert!(snapshots[0].tags.is_empty());
+        assert!(latest_for_host(&snapshots, "myserver").is_some());
+    }
+
+    #[test]
+    fn short_id_is_the_first_eight_characters() {
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&myserver_snapshots()).unwrap();
+        assert_eq!(snapshots[0].short_id(), "a1b2c3d4");
+    }
+
+    #[test]
+    fn snapshot_time_keeps_sub_second_precision() {
+        let json = snapshots_json(&[(
+            "aaa",
+            "2026-07-29T03:00:00.123456789Z",
+            &format!("{ROOT}/myserver/2026-07-29_03-00-00"),
+        )]);
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            (now() - snapshots[0].time).num_seconds(),
+            6 * 3600 - 1,
+            "age truncates toward zero"
+        );
+    }
+
+    #[test]
+    fn snapshot_time_with_offset_is_normalised_to_utc() {
+        let json = snapshots_json(&[(
+            "aaa",
+            "2026-07-29T05:00:00+02:00",
+            &format!("{ROOT}/myserver/2026-07-29_03-00-00"),
+        )]);
+        let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            snapshots[0].time,
+            "2026-07-29T03:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+    }
+
+    #[test]
+    fn verdict_passes_when_snapshot_is_fresh() {
+        let age = max_age("24h");
+        let verdict = verdict(
+            &request("myserver", None, &age),
+            &myserver_snapshots(),
+            |_, _| panic!("containment must not be probed without an app"),
+        );
+
+        assert_eq!(verdict.status, Status::Verified);
+        assert_eq!(verdict.status.exit_code(), 0);
+        assert!(verdict.is_verified());
+        assert!(verdict.checks.iter().all(|c| c.passed));
+        assert_eq!(
+            verdict.checks.iter().map(|c| c.name).collect::<Vec<_>>(),
+            vec![CHECK_REACHABLE, CHECK_SNAPSHOT, CHECK_FRESH]
+        );
+    }
+
+    #[test]
+    fn verdict_reports_snapshot_id_time_and_age() {
+        let age = max_age("24h");
+        let verdict = verdict(
+            &request("myserver", None, &age),
+            &myserver_snapshots(),
+            |_, _| Ok(true),
+        );
+
+        assert_eq!(
+            check(&verdict, CHECK_SNAPSHOT).unwrap().message,
+            "latest snapshot for myserver: a1b2c3d4 (2026-07-29T03:00Z, 6h ago)"
+        );
+        let summary = verdict.snapshot.unwrap();
+        assert_eq!(summary.short_id, "a1b2c3d4");
+        assert_eq!(summary.age_seconds, 6 * 3600);
+    }
+
+    #[test]
+    fn verdict_probes_the_app_directory_of_the_resolved_snapshot() {
+        let age = max_age("24h");
+        let verdict = verdict(
+            &request("myserver", Some("bichon"), &age),
+            &myserver_snapshots(),
+            |snapshot, path| {
+                assert_eq!(snapshot.short_id(), "a1b2c3d4");
+                assert_eq!(path, format!("{ROOT}/myserver/2026-07-29_03-00-00/bichon"));
+                Ok(true)
+            },
+        );
+
+        assert_eq!(verdict.status, Status::Verified);
+        assert_eq!(
+            check(&verdict, CHECK_CONTAINS_APP).unwrap().message,
+            "contains bichon (…/myserver/2026-07-29_03-00-00/bichon)"
+        );
+    }
+
+    #[test]
+    fn verdict_fails_when_the_app_is_absent_from_the_snapshot() {
+        let age = max_age("24h");
+        let verdict = verdict(
+            &request("myserver", Some("bichon"), &age),
+            &myserver_snapshots(),
+            |_, _| Ok(false),
+        );
+
+        assert_eq!(verdict.status, Status::CheckFailed);
+        assert_eq!(verdict.status.exit_code(), 1);
+        let failed = check(&verdict, CHECK_CONTAINS_APP).unwrap();
+        assert!(!failed.passed);
+        assert_eq!(
+            failed.remediation.as_deref(),
+            Some("run: auberge backup sync --host myserver --apps bichon")
+        );
+    }
+
+    #[test]
+    fn verdict_stops_before_the_freshness_check_when_the_app_is_absent() {
+        let age = max_age("1s");
+        let verdict = verdict(
+            &request("myserver", Some("bichon"), &age),
+            &myserver_snapshots(),
+            |_, _| Ok(false),
+        );
+
+        assert!(check(&verdict, CHECK_FRESH).is_none());
+    }
+
+    #[test]
+    fn verdict_fails_when_the_snapshot_is_older_than_max_age() {
+        let age = max_age("5h");
+        let verdict = verdict(
+            &request("myserver", None, &age),
+            &myserver_snapshots(),
+            |_, _| Ok(true),
+        );
+
+        assert_eq!(verdict.status, Status::CheckFailed);
+        let failed = check(&verdict, CHECK_FRESH).unwrap();
+        assert!(!failed.passed);
+        assert_eq!(failed.message, "younger than 5h");
+        assert_eq!(
+            failed.remediation.as_deref(),
+            Some("run: auberge backup sync --host myserver")
+        );
+    }
+
+    #[test]
+    fn verdict_accepts_a_snapshot_exactly_at_max_age() {
+        let age = max_age("6h");
+        let verdict = verdict(
+            &request("myserver", None, &age),
+            &myserver_snapshots(),
+            |_, _| Ok(true),
+        );
+
+        assert_eq!(verdict.status, Status::Verified);
+    }
+
+    #[test]
+    fn verdict_fails_when_no_snapshot_exists_for_the_host() {
+        let age = max_age("24h");
+        let json = snapshots_json(&[(
+            "aaa",
+            "2026-07-29T03:00:00Z",
+            &format!("{ROOT}/other/2026-07-29_03-00-00"),
+        )]);
+
+        let verdict = verdict(&request("myserver", None, &age), &json, |_, _| Ok(true));
+
+        assert_eq!(verdict.status, Status::CheckFailed);
+        assert!(verdict.snapshot.is_none());
+        let failed = check(&verdict, CHECK_SNAPSHOT).unwrap();
+        assert_eq!(failed.message, "latest snapshot for myserver");
+        assert_eq!(
+            failed.remediation.as_deref(),
+            Some("repository holds snapshots for other — run: auberge backup sync --host myserver")
+        );
+    }
+
+    #[test]
+    fn verdict_names_tagged_hosts_in_the_remediation() {
+        let age = max_age("24h");
+        let json = tagged_snapshots_json(&[(
+            "aaa",
+            "2026-07-29T03:00:00Z",
+            "/srv/staging/2026-07-29_03-00-00",
+            "other",
+        )]);
+
+        let verdict = verdict(&request("myserver", None, &age), &json, |_, _| Ok(true));
+
+        assert_eq!(
+            check(&verdict, CHECK_SNAPSHOT)
+                .unwrap()
+                .remediation
+                .as_deref(),
+            Some("repository holds snapshots for other — run: auberge backup sync --host myserver")
+        );
+    }
+
+    #[test]
+    fn verdict_fails_on_an_empty_repository() {
+        let age = max_age("24h");
+        let verdict = verdict(&request("myserver", None, &age), "[]", |_, _| Ok(true));
+
+        assert_eq!(verdict.status, Status::CheckFailed);
+        assert_eq!(
+            check(&verdict, CHECK_SNAPSHOT)
+                .unwrap()
+                .remediation
+                .as_deref(),
+            Some("repository holds no auberge backups — run: auberge backup sync --host myserver")
+        );
+    }
+
+    #[test]
+    fn verdict_is_operational_when_the_snapshot_list_is_unreadable() {
+        let age = max_age("24h");
+        let verdict = verdict(&request("myserver", None, &age), "not json", |_, _| {
+            Ok(true)
+        });
+
+        assert_eq!(verdict.status, Status::OperationalError);
+        assert_eq!(verdict.status.exit_code(), 2);
+        assert_eq!(verdict.checks.len(), 1);
+        assert!(!verdict.checks[0].passed);
+        assert_eq!(verdict.checks[0].name, CHECK_REACHABLE);
+    }
+
+    #[test]
+    fn verdict_is_operational_when_the_containment_probe_fails() {
+        let age = max_age("24h");
+        let verdict = verdict(
+            &request("myserver", Some("bichon"), &age),
+            &myserver_snapshots(),
+            |_, _| Err(eyre!("restic ls failed (exit status: 1)")),
+        );
+
+        assert_eq!(verdict.status, Status::OperationalError);
+        assert_eq!(
+            check(&verdict, CHECK_CONTAINS_APP).unwrap().message,
+            "contains bichon: restic ls failed (exit status: 1)"
+        );
+        assert!(check(&verdict, CHECK_FRESH).is_none());
+    }
+
+    #[test]
+    fn unreachable_verdict_collapses_multiline_restic_errors() {
+        let verdict = Verdict::unreachable(
+            "Fatal: repository does not exist\nIs there a repository at the following location?",
+        );
+
+        assert_eq!(verdict.status, Status::OperationalError);
+        assert_eq!(
+            verdict.checks[0].message,
+            "repository reachable: Fatal: repository does not exist Is there a repository at the following location?"
+        );
+    }
+
+    #[test]
+    fn every_failed_check_carries_remediation() {
+        let age = max_age("1s");
+        let verdicts = [
+            verdict(&request("myserver", None, &age), "[]", |_, _| Ok(true)),
+            verdict(
+                &request("myserver", None, &age),
+                &myserver_snapshots(),
+                |_, _| Ok(true),
+            ),
+            verdict(
+                &request("myserver", Some("bichon"), &age),
+                &myserver_snapshots(),
+                |_, _| Ok(false),
+            ),
+            Verdict::unreachable("boom"),
+        ];
+
+        for verdict in verdicts {
+            for failed in verdict.checks.iter().filter(|c| !c.passed) {
+                assert!(
+                    failed.remediation.is_some(),
+                    "check '{}' failed without remediation",
+                    failed.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn format_age_scales_the_unit() {
+        assert_eq!(format_age(TimeDelta::seconds(30)), "30s");
+        assert_eq!(format_age(TimeDelta::minutes(5)), "5m");
+        assert_eq!(format_age(TimeDelta::hours(6)), "6h");
+        assert_eq!(format_age(TimeDelta::hours(47)), "1d 23h");
+        assert_eq!(format_age(TimeDelta::days(2)), "2d");
+    }
+
+    #[test]
+    fn format_age_marks_snapshots_dated_in_the_future() {
+        assert_eq!(format_age(TimeDelta::hours(-3)), "-3h");
+    }
+
+    #[test]
+    fn abbreviate_keeps_the_last_three_segments() {
+        assert_eq!(
+            abbreviate(&format!("{ROOT}/myserver/2026-07-29_03-00-00/bichon")),
+            "…/myserver/2026-07-29_03-00-00/bichon"
+        );
+    }
+
+    #[test]
+    fn abbreviate_leaves_short_paths_alone() {
+        assert_eq!(abbreviate("/a/b"), "/a/b");
+    }
+
+    #[test]
+    fn status_strings_are_stable() {
+        assert_eq!(Status::Verified.as_str(), "verified");
+        assert_eq!(Status::CheckFailed.as_str(), "check_failed");
+        assert_eq!(Status::OperationalError.as_str(), "operational_error");
+    }
+}


### PR DESCRIPTION
Answers "is my app's backup actually offsite, and how fresh?" in one read-only command. That question is the gate before destructive downstream work — expunging mail already captured in the *Email Archive* — and until now it took a four-step `restic` + `jq` incantation.

```console
$ auberge backup verify --app bichon
✓ repository reachable
✓ latest snapshot for myserver: a1b2c3d4 (2026-07-29T03:00Z, 6h ago)
✓ contains bichon (…/myserver/2026-07-29_03-00-00/bichon)
✓ younger than 24h
verified
```

Exit `0` verified · `1` a check failed · `2` operational error, so `auberge backup verify --app bichon || exit 1` is the whole gate.

> [!TIP]
> Gate 1 of `examples/bichon-expunge.sh` on master already shells out to `auberge backup verify --host … --app bichon` and probes `verify --help` to refuse an auberge too old to have it. That contract — flag names, exit codes, combined output as evidence — is satisfied as written; nothing in #376 needs changing.

## Checks

Fail-fast, in order. Alias `v`, joining `c`/`s`/`ls`/`p`.

| # | Check | On failure |
|---|-------|------------|
| 1 | `restic snapshots --json` answers | `2` |
| 2 | ≥1 snapshot for the host | `1` |
| 3 | Latest snapshot contains the app (`--app` only) | `1` |
| 4 | Latest snapshot younger than `--max-age` (default `24h`) | `1` |

Checklist and `--output json` go to stdout; remediation for the failed check goes to stderr, per CONTEXT.md stdout discipline.

## Host identity

A snapshot belongs to a Host by **the tag `backup push` writes** — the same tag `backup prune` groups retention by since #372, so verify and prune agree on which snapshots are a host's. Snapshots pushed before tagging landed carry no `tags` field at all, so they are matched by their `…/backups/<host>/<timestamp>` path and an existing repository verifies without a re-push. The failure hint that lists "hosts the repository does hold snapshots for" uses the same two-signal rule, so it can never contradict the check above it.

## Where the logic lives

| Concern | File |
| ------- | ---- |
| Verdict — pure, snapshots JSON → checklist | `src/services/backup/verify.rs` |
| restic adapter — env, protocol, read probes | `src/services/backup/restic.rs` |
| Flags, rendering, exit-code mapping | `src/commands/backup.rs` |

53 new unit tests (37 verdict, 10 restic adapter, 6 command), 400 total. `verdict()` takes the containment probe as a `FnOnce`, so every check, remediation string and exit code is asserted without invoking restic.

> [!NOTE]
> The `refactor(backup)` commit is purely mechanical: push, init and prune each repeated the three env lines a restic call needs, including the `env_remove("RESTIC_PASSWORD_COMMAND")` that stops an operator's exported password command from resolving the wrong password. My own shell has that variable set, which is how I confirmed it is load-bearing rather than defensive. It composes with #372's `backup_args`/`forget_args` rather than replacing them.

## Deliberate choices worth a second opinion

- **`--host` is not validated against `hosts.toml`**, so snapshots of a retired Host stay verifiable. A typo lands on check 2, whose remediation lists the hosts that _do_ have snapshots.
- **Never prompts**, unlike `backup push`: it runs in scripts and timers. A single configured Host is implied; several make `--host` required (`2`).
- **`Snapshot` lives in `verify.rs`**, not beside the other restic protocol types, to keep `snapshots_json() -> String` as the pure test seam the verdict is built on.
- **`restic ls <id> <dir>` with a dir filter**, streamed and stopped at the first hit: an app subtree can hold hundreds of thousands of files. Confirmed against restic 0.19.1 that a filtered `ls` exits `0` whether or not the dir exists, so absence is a check failure (`1`), not an error (`2`).
- **`Backup Verdict` in CONTEXT.md** and a `verify` pointer in `sync.md` — beyond the issue's docs list, but the module introduces vocabulary (verdict, check, remediation) and sync is where an operator learns the backup "succeeded" without the repository ever being read back.

ADR-0007 amended. Alternative (γ) rejected verification tooling because every path it needed was filesystem-readable from `config.toml`. That still holds for the Email Archive; it does not hold for the restic repository — password `!command` indirection, host↔snapshot attribution, and `RESTIC_PASSWORD_COMMAND` are auberge's own knowledge. A verifier that gets those subtly wrong prints a green check against the wrong snapshot, which is a silent failure and exactly what that ADR's principle forbids. Coverage-check against the *Upstream Mailbox* stays out of scope.

## Test plan

- [x] `cargo nextest run` — 400 pass, 53 new
- [x] `cargo clippy --all-targets` — no new warnings (6 pre-existing in `bichon/reconcile.rs`, 1 in `config.rs`)
- [x] `dprint check`, `check-stdout-discipline.sh`, `hk run pre-commit --all` (now incl. shellcheck/shfmt) green
- [x] Every commit builds warning-free — checked out and built one by one
- [x] Manual against scratch restic repos (0.19.1), each exiting as specified: verified · stale · app absent · unknown host · empty repository · repository shared with non-auberge snapshots · wrong password · missing repository · restic off `PATH` · two configured hosts · malformed `--max-age`
- [x] Tag identity end-to-end: snapshot tagged `myserver` under a staging path with no host segment verifies; a snapshot tagged for another host does not; untagged legacy snapshots still verify
- [x] `-o json` shape and stdout/stderr split checked with redirection
- [x] Early-break probe on a 20 002-file snapshot: 1.4s, same as the absent-app case

Also corrects `docs/backup-restore/overview.md`, found while checking docs currency: its tree showed `backups/<host>/<app>/<timestamp>` (the real layout, and the one verify reads, is `<host>/<timestamp>/<app>`) and it described a `latest` symlink that nothing has ever created. Separate commit — drop it if you'd rather keep this PR to the feature.

> [!NOTE]
> CodeQL alert #22 (`rust/hard-coded-cryptographic-value`, critical) fires on the `"s3cret"` literal in `restic.rs`'s unit test, traced into `.env("RESTIC_PASSWORD", …)`. Dismissed as a false positive with a reason, the same way #21 was, rather than excluding the rule in `codeql-config.yml` — a constant password in *production* code should keep failing the build.

Rebased onto `master` at v0.14.6 (#372, #376).

Closes #374

https://claude.ai/code/session_015AWVbf2T4cGECup15PpZG8
