### PR TITLE
chore: release v0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.7](https://github.com/sripwoud/auberge/compare/v0.14.6...v0.14.7) - 2026-07-29
+
+### Added
+
+- *(backup)* add verify command for offsite snapshot freshness ([#377](https://github.com/sripwoud/auberge/pull/377))
+
+### Other
+
+- *(deps)* bump quinn-proto from 0.11.14 to 0.11.16 in the cargo group across 1 directory ([#378](https://github.com/sripwoud/auberge/pull/378))
+- *(examples)* make bichon-expunge interactive and guard-railed ([#376](https://github.com/sripwoud/auberge/pull/376))
+
 ## [0.14.6](https://github.com/sripwoud/auberge/compare/v0.14.5...v0.14.6) - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auberge"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.6 -> 0.14.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.7](https://github.com/sripwoud/auberge/compare/v0.14.6...v0.14.7) - 2026-07-29

### Added

- *(backup)* add verify command for offsite snapshot freshness ([#377](https://github.com/sripwoud/auberge/pull/377))

### Other

- *(deps)* bump quinn-proto from 0.11.14 to 0.11.16 in the cargo group across 1 directory ([#378](https://github.com/sripwoud/auberge/pull/378))
- *(examples)* make bichon-expunge interactive and guard-railed ([#376](https://github.com/sripwoud/auberge/pull/376))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).