### PR TITLE
feat(backup): verify the newest snapshot holding the app

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,7 @@ The Rust module that orchestrates multiple Recipe Executor invocations across a 
 _Avoid_: Backup job, backup workflow
 
 **Backup Verdict**:
-The verdict `auberge backup verify` reaches about the newest offsite restic snapshot for a Host, as a fail-fast checklist — repository reachable → a snapshot exists → it contains an App → it is younger than a threshold — carried by the exit code (0 verified, 1 a check failed, 2 operational error). A pure function of `restic snapshots --json` plus one containment probe, so the whole decision is unit-tested without invoking restic. Asserts the "backup is current" half of ADR-0007's boundary; it says nothing about the **Upstream Mailbox**, which would be coverage-check and stays out of scope.
+The verdict `auberge backup verify` reaches about a Host's newest offsite restic snapshot — or, with `-a`, the newest snapshot _holding that App_, which a partial sync can leave behind an App-less newer push — as a fail-fast checklist: repository reachable → a snapshot exists → it contains an App → it is younger than a threshold, carried by the exit code (0 verified, 1 a check failed, 2 operational error). A pure function of `restic snapshots --json` plus one containment probe per candidate snapshot, so the whole decision is unit-tested without invoking restic. Asserts the "backup is current" half of ADR-0007's boundary; it says nothing about the **Upstream Mailbox**, which would be coverage-check and stays out of scope.
 _Avoid_: Health check, audit, validation, integrity check (restic's own `check` verifies repository integrity — a different question).
 
 **Email Archive**:

--- a/docs/cli-reference/backup/verify.md
+++ b/docs/cli-reference/backup/verify.md
@@ -1,6 +1,6 @@
 # auberge backup verify
 
-Assert that the latest offsite restic snapshot is fresh and holds an app's backup. Read-only — it never writes to the repository. Alias: `auberge b v`.
+Assert that an offsite restic snapshot is fresh — for a host, or for one app's backup. Read-only — it never writes to the repository. Alias: `auberge b v`.
 
 ```bash
 auberge backup verify [OPTIONS]
@@ -8,12 +8,12 @@ auberge backup verify [OPTIONS]
 
 ## Options
 
-| Option                | Description                                    | Default                                       |
-| --------------------- | ---------------------------------------------- | --------------------------------------------- |
-| `-H, --host HOST`     | Host whose snapshots to check                  | The sole configured host; required if several |
-| `-a, --app APP`       | Also assert this app is in the latest snapshot | No app check                                  |
-| `--max-age DURATION`  | Freshness threshold, `<number><s\|m\|h\|d>`    | `24h`                                         |
-| `-o, --output FORMAT` | `human` or `json`                              | `human`                                       |
+| Option                | Description                                 | Default                                       |
+| --------------------- | ------------------------------------------- | --------------------------------------------- |
+| `-H, --host HOST`     | Host whose snapshots to check               | The sole configured host; required if several |
+| `-a, --app APP`       | Check the newest snapshot holding this app  | No app check                                  |
+| `--max-age DURATION`  | Freshness threshold, `<number><s\|m\|h\|d>` | `24h`                                         |
+| `-o, --output FORMAT` | `human` or `json`                           | `human`                                       |
 
 Verify never prompts, so it is safe in scripts and timers.
 
@@ -23,27 +23,39 @@ Fail-fast, in order:
 
 1. The restic repository answers `restic snapshots --json`.
 2. At least one snapshot exists for the host.
-3. The latest snapshot contains the app's directory — only with `--app`.
-4. The latest snapshot is younger than `--max-age`.
+3. A snapshot contains the app's directory — only with `--app`.
+4. The selected snapshot is younger than `--max-age`.
+
+Without `--app` the selected snapshot is the host's newest. With `--app` it is the newest snapshot **holding that app**, which need not be the newest push: a partial sync (`backup sync --apps paperless`) leaves a snapshot holding only `paperless`, and every other app is still verified against the full sync that holds it. The walk stops at the first snapshot holding the app, so a repository synced in full costs one containment probe.
 
 ```bash
 $ auberge backup verify --app bichon
 ✓ repository reachable
-✓ latest snapshot for myserver: a1b2c3d4 (2026-07-29T03:00Z, 6h ago)
+✓ latest snapshot containing bichon: a1b2c3d4 (2026-07-29T03:00Z, 6h ago)
 ✓ contains bichon (…/myserver/2026-07-29_03-00-00/bichon)
 ✓ younger than 24h
 verified
+```
+
+When no snapshot holds the app, that line names the host's newest push instead and `contains` fails:
+
+```bash
+$ auberge backup verify --app bichon
+✓ repository reachable
+✓ latest snapshot for myserver: 4b461b62 (2026-07-29T12:11Z, 3h ago)
+✗ contains bichon
+not verified
 ```
 
 The checklist is data on stdout; remediation for a failed check goes to stderr.
 
 ## Exit codes
 
-| Code | Meaning                                                                                               |
-| ---- | ----------------------------------------------------------------------------------------------------- |
-| `0`  | Verified — every check passed                                                                         |
-| `1`  | A check failed — no snapshot for the host, app missing, or snapshot older than `--max-age`            |
-| `2`  | Operational error — restic not installed, repository unreachable, config keys or `--max-age` unusable |
+| Code | Meaning                                                                                                             |
+| ---- | ------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Verified — every check passed                                                                                       |
+| `1`  | A check failed — no snapshot for the host, no snapshot holds the app, or the selected one is older than `--max-age` |
+| `2`  | Operational error — restic not installed, repository unreachable, config keys or `--max-age` unusable               |
 
 Gate a destructive step on it:
 
@@ -97,19 +109,19 @@ Same as [backup push](cli-reference/backup/push.md) — requires `restic_reposit
 }
 ```
 
-| Field                  | Type           | Description                                                             |
-| ---------------------- | -------------- | ----------------------------------------------------------------------- |
-| `verified`             | boolean        | `true` only when every check passed                                     |
-| `status`               | string         | `verified`, `check_failed`, or `operational_error`                      |
-| `host`                 | string         | Host the snapshots were filtered by                                     |
-| `app`                  | string \| null | App asserted with `--app`; `null` when omitted                          |
-| `max_age`              | string         | Threshold as passed on the command line                                 |
-| `snapshot`             | object \| null | Resolved snapshot; `null` when none was found                           |
-| `snapshot.short_id`    | string         | First 8 characters of `snapshot.id`, as restic displays it              |
-| `snapshot.age_seconds` | number         | Snapshot age at the time of the check                                   |
-| `checks`               | array          | Checks that ran, in order — fail-fast, so it stops at the first failure |
-| `checks[].name`        | string         | `repository_reachable`, `snapshot_exists`, `contains_app`, or `fresh`   |
-| `checks[].remediation` | string \| null | Command to fix a failed check; `null` when it passed                    |
+| Field                  | Type           | Description                                                                                            |
+| ---------------------- | -------------- | ------------------------------------------------------------------------------------------------------ |
+| `verified`             | boolean        | `true` only when every check passed                                                                    |
+| `status`               | string         | `verified`, `check_failed`, or `operational_error`                                                     |
+| `host`                 | string         | Host the snapshots were filtered by                                                                    |
+| `app`                  | string \| null | App asserted with `--app`; `null` when omitted                                                         |
+| `max_age`              | string         | Threshold as passed on the command line                                                                |
+| `snapshot`             | object \| null | Snapshot the verdict is about — with `--app`, the newest one holding it; `null` when the host has none |
+| `snapshot.short_id`    | string         | First 8 characters of `snapshot.id`, as restic displays it                                             |
+| `snapshot.age_seconds` | number         | Snapshot age at the time of the check                                                                  |
+| `checks`               | array          | Checks that ran, in order — fail-fast, so it stops at the first failure                                |
+| `checks[].name`        | string         | `repository_reachable`, `snapshot_exists`, `contains_app`, or `fresh`                                  |
+| `checks[].remediation` | string \| null | Command to fix a failed check; `null` when it passed                                                   |
 
 JSON goes to stdout; human-format chrome goes to stderr.
 

--- a/meta/adr/0007-auberge-folder-reconcile-scope.md
+++ b/meta/adr/0007-auberge-folder-reconcile-scope.md
@@ -65,8 +65,9 @@ The deciding principle is **asymmetric automation along the silent-vs-loud failu
 ## Amendment (2026-07-29): offsite snapshot verification moves into the binary
 
 `auberge backup verify [-H <host>] [-a <app>] [--max-age <duration>]` ships as a read-only
-command: it asserts that the newest restic snapshot for a Host exists, contains an App's backup,
-and is younger than a freshness threshold. Exit `0` verified, `1` a check failed, `2` operational
+command: it asserts that a restic snapshot for a Host exists and is younger than a freshness
+threshold — with `-a`, the newest snapshot **holding that App's backup**, so one partial sync
+cannot false-alarm every other App (#380). Exit `0` verified, `1` a check failed, `2` operational
 error, so it composes as a gate in a script.
 
 This does **not** reopen alternative (γ). Coverage-check compares the **Email Archive** against the

--- a/src/services/backup/verify.rs
+++ b/src/services/backup/verify.rs
@@ -188,12 +188,17 @@ pub struct VerifyRequest<'a> {
 /// Fail-fast checklist: snapshot list readable, a snapshot exists for the host,
 /// it contains the app (only with `app`), and it is younger than `max_age`.
 ///
-/// `contains_app` receives the resolved snapshot and the app path to look for;
-/// it is the only step that needs a second restic call.
+/// Without `app` the verdict is about the newest snapshot for the host. With
+/// `app` it is about the newest snapshot that holds the app, which a partial
+/// sync (`backup sync --apps X`) can leave behind an app-less newer push.
+///
+/// `contains_app` receives a candidate snapshot and the app path to look for;
+/// it is the only step that needs a second restic call, once per candidate
+/// until the app is found.
 pub fn verdict(
     request: &VerifyRequest<'_>,
     snapshots_json: &str,
-    contains_app: impl FnOnce(&Snapshot, &str) -> Result<bool>,
+    mut contains_app: impl FnMut(&Snapshot, &str) -> Result<bool>,
 ) -> Verdict {
     let snapshots: Vec<Snapshot> = match serde_json::from_str(snapshots_json) {
         Ok(snapshots) => snapshots,
@@ -205,7 +210,8 @@ pub fn verdict(
         "repository reachable".to_string(),
     )];
 
-    let Some(host_snapshot) = latest_for_host(&snapshots, request.host) else {
+    let candidates = host_snapshots_newest_first(&snapshots, request.host);
+    let Some(newest) = candidates.first() else {
         checks.push(Check::failed(
             CHECK_SNAPSHOT,
             format!("latest snapshot for {}", request.host),
@@ -214,7 +220,17 @@ pub fn verdict(
         return Verdict::new(Status::CheckFailed, checks, None);
     };
 
-    let snapshot = host_snapshot.snapshot;
+    let held = match request.app {
+        None => Ok(None),
+        Some(app) => newest_holding_app(&candidates, app, &mut contains_app),
+    };
+
+    // Falls back to the newest push whenever the app could not be located, so a
+    // failing checklist still names a snapshot and reports its age.
+    let snapshot = match &held {
+        Ok(Some(held)) => held.snapshot,
+        _ => newest.snapshot,
+    };
     let age = request.now - snapshot.time;
     let summary = Some(SnapshotSummary {
         id: snapshot.id.clone(),
@@ -223,11 +239,16 @@ pub fn verdict(
         age_seconds: age.num_seconds(),
     });
 
+    // Says what the snapshot was selected for: with `--app` it may be older than
+    // the newest push, and a line claiming otherwise would misread as stale.
+    let selected_for = match (request.app, &held) {
+        (Some(app), Ok(Some(_))) => format!("latest snapshot containing {app}"),
+        _ => format!("latest snapshot for {}", request.host),
+    };
     checks.push(Check::passed(
         CHECK_SNAPSHOT,
         format!(
-            "latest snapshot for {}: {} ({}, {} ago)",
-            request.host,
+            "{selected_for}: {} ({}, {} ago)",
             snapshot.short_id(),
             snapshot.time.format("%Y-%m-%dT%H:%MZ"),
             format_age(age),
@@ -235,8 +256,7 @@ pub fn verdict(
     ));
 
     if let Some(app) = request.app {
-        let app_path = format!("{}/{}", host_snapshot.root.trim_end_matches('/'), app);
-        match contains_app(snapshot, &app_path) {
+        match held {
             Err(e) => {
                 checks.push(Check::failed(
                     CHECK_CONTAINS_APP,
@@ -245,7 +265,7 @@ pub fn verdict(
                 ));
                 return Verdict::new(Status::OperationalError, checks, summary);
             }
-            Ok(false) => {
+            Ok(None) => {
                 checks.push(Check::failed(
                     CHECK_CONTAINS_APP,
                     format!("contains {app}"),
@@ -256,9 +276,9 @@ pub fn verdict(
                 ));
                 return Verdict::new(Status::CheckFailed, checks, summary);
             }
-            Ok(true) => checks.push(Check::passed(
+            Ok(Some(held)) => checks.push(Check::passed(
                 CHECK_CONTAINS_APP,
-                format!("contains {app} ({})", abbreviate(&app_path)),
+                format!("contains {app} ({})", abbreviate(&held.app_path)),
             )),
         }
     }
@@ -282,12 +302,42 @@ struct HostSnapshot<'a> {
     root: &'a str,
 }
 
-/// Newest snapshot belonging to `host`.
-fn latest_for_host<'a>(snapshots: &'a [Snapshot], host: &str) -> Option<HostSnapshot<'a>> {
-    snapshots
+/// The snapshot an app was found in, and the path that proved it.
+struct HeldApp<'a> {
+    snapshot: &'a Snapshot,
+    app_path: String,
+}
+
+/// Snapshots belonging to `host`, newest first.
+fn host_snapshots_newest_first<'a>(snapshots: &'a [Snapshot], host: &str) -> Vec<HostSnapshot<'a>> {
+    let mut candidates: Vec<HostSnapshot<'a>> = snapshots
         .iter()
         .filter_map(|snapshot| host_snapshot(snapshot, host))
-        .max_by_key(|candidate| candidate.snapshot.time)
+        .collect();
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.snapshot.time));
+    candidates
+}
+
+/// Newest candidate holding `app`.
+///
+/// The walk stops at the first hit, so a repository synced in full costs one
+/// probe. A probe error aborts it instead of falling through to an older
+/// snapshot: a repository that cannot be read must not read as "app missing".
+fn newest_holding_app<'a>(
+    candidates: &[HostSnapshot<'a>],
+    app: &str,
+    contains_app: &mut impl FnMut(&Snapshot, &str) -> Result<bool>,
+) -> Result<Option<HeldApp<'a>>> {
+    for candidate in candidates {
+        let app_path = format!("{}/{}", candidate.root.trim_end_matches('/'), app);
+        if contains_app(candidate.snapshot, &app_path)? {
+            return Ok(Some(HeldApp {
+                snapshot: candidate.snapshot,
+                app_path,
+            }));
+        }
+    }
+    Ok(None)
 }
 
 /// A snapshot belongs to a Host if `backup push` tagged it with the Host name,
@@ -379,6 +429,7 @@ fn one_line(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
 
     const ROOT: &str = "/home/op/.local/share/auberge/backups";
 
@@ -412,6 +463,40 @@ mod tests {
             "2026-07-29T03:00:00Z",
             &format!("{ROOT}/myserver/2026-07-29_03-00-00"),
         )])
+    }
+
+    /// A full sync at 00:00 holding every app, then a 06:00 partial sync holding
+    /// only `paperless` — the shape that used to false-alarm every other app.
+    fn partial_sync_snapshots() -> String {
+        snapshots_json(&[
+            (
+                "part2222bbbb",
+                "2026-07-29T06:00:00Z",
+                &format!("{ROOT}/myserver/2026-07-29_06-00-00"),
+            ),
+            (
+                "full1111aaaa",
+                "2026-07-29T00:00:00Z",
+                &format!("{ROOT}/myserver/2026-07-29_00-00-00"),
+            ),
+        ])
+    }
+
+    /// Answers the containment probe from the full sync only, and records the
+    /// order candidates were probed in.
+    fn bichon_in_full_sync(
+        probed: &RefCell<Vec<String>>,
+    ) -> impl FnMut(&Snapshot, &str) -> Result<bool> + '_ {
+        |snapshot, path| {
+            probed.borrow_mut().push(snapshot.short_id().to_string());
+            Ok(path == format!("{ROOT}/myserver/2026-07-29_00-00-00/bichon"))
+        }
+    }
+
+    fn newest_for_host<'a>(snapshots: &'a [Snapshot], host: &str) -> Option<HostSnapshot<'a>> {
+        host_snapshots_newest_first(snapshots, host)
+            .into_iter()
+            .next()
     }
 
     fn request<'a>(host: &'a str, app: Option<&'a str>, max_age: &'a MaxAge) -> VerifyRequest<'a> {
@@ -494,7 +579,7 @@ mod tests {
     }
 
     #[test]
-    fn latest_for_host_picks_the_newest_regardless_of_array_order() {
+    fn host_snapshots_are_ordered_newest_first_regardless_of_array_order() {
         let json = snapshots_json(&[
             (
                 "aaa",
@@ -514,14 +599,23 @@ mod tests {
         ]);
         let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
 
-        let latest = latest_for_host(&snapshots, "myserver").unwrap();
+        let candidates = host_snapshots_newest_first(&snapshots, "myserver");
 
-        assert_eq!(latest.snapshot.id, "ccc");
-        assert_eq!(latest.root, format!("{ROOT}/myserver/2026-07-29_03-00-00"));
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|c| c.snapshot.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ccc", "aaa", "bbb"]
+        );
+        assert_eq!(
+            candidates[0].root,
+            format!("{ROOT}/myserver/2026-07-29_03-00-00")
+        );
     }
 
     #[test]
-    fn latest_for_host_ignores_other_hosts() {
+    fn host_snapshots_ignore_other_hosts() {
         let json = snapshots_json(&[
             (
                 "aaa",
@@ -537,14 +631,14 @@ mod tests {
         let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
 
         assert_eq!(
-            latest_for_host(&snapshots, "myserver").unwrap().snapshot.id,
+            newest_for_host(&snapshots, "myserver").unwrap().snapshot.id,
             "bbb"
         );
-        assert!(latest_for_host(&snapshots, "absent").is_none());
+        assert!(host_snapshots_newest_first(&snapshots, "absent").is_empty());
     }
 
     #[test]
-    fn latest_for_host_matches_the_push_tag() {
+    fn host_snapshot_matches_the_push_tag() {
         let json = tagged_snapshots_json(&[(
             "aaa",
             "2026-07-29T03:00:00Z",
@@ -553,14 +647,14 @@ mod tests {
         )]);
         let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
 
-        let latest = latest_for_host(&snapshots, "myserver").unwrap();
+        let latest = newest_for_host(&snapshots, "myserver").unwrap();
 
         assert_eq!(latest.snapshot.id, "aaa");
         assert_eq!(latest.root, "/srv/staging/2026-07-29_03-00-00");
     }
 
     #[test]
-    fn latest_for_host_ignores_a_tag_naming_another_host() {
+    fn host_snapshot_ignores_a_tag_naming_another_host() {
         let json = tagged_snapshots_json(&[(
             "aaa",
             "2026-07-29T03:00:00Z",
@@ -569,11 +663,11 @@ mod tests {
         )]);
         let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
 
-        assert!(latest_for_host(&snapshots, "myserver").is_none());
+        assert!(newest_for_host(&snapshots, "myserver").is_none());
     }
 
     #[test]
-    fn latest_for_host_prefers_the_host_path_as_root_when_both_agree() {
+    fn host_snapshot_prefers_the_host_path_as_root_when_both_agree() {
         let json = tagged_snapshots_json(&[(
             "aaa",
             "2026-07-29T03:00:00Z",
@@ -583,17 +677,17 @@ mod tests {
         let snapshots: Vec<Snapshot> = serde_json::from_str(&json).unwrap();
 
         assert_eq!(
-            latest_for_host(&snapshots, "myserver").unwrap().root,
+            newest_for_host(&snapshots, "myserver").unwrap().root,
             format!("{ROOT}/myserver/2026-07-29_03-00-00")
         );
     }
 
     #[test]
-    fn latest_for_host_reads_untagged_snapshots_pushed_before_tagging() {
+    fn host_snapshot_reads_untagged_snapshots_pushed_before_tagging() {
         let snapshots: Vec<Snapshot> = serde_json::from_str(&myserver_snapshots()).unwrap();
 
         assert!(snapshots[0].tags.is_empty());
-        assert!(latest_for_host(&snapshots, "myserver").is_some());
+        assert!(newest_for_host(&snapshots, "myserver").is_some());
     }
 
     #[test]
@@ -686,6 +780,129 @@ mod tests {
             check(&verdict, CHECK_CONTAINS_APP).unwrap().message,
             "contains bichon (…/myserver/2026-07-29_03-00-00/bichon)"
         );
+    }
+
+    #[test]
+    fn verdict_probes_only_the_newest_snapshot_when_it_holds_the_app() {
+        let age = max_age("24h");
+        let probed = RefCell::new(Vec::new());
+
+        let verdict = verdict(
+            &request("myserver", Some("paperless"), &age),
+            &partial_sync_snapshots(),
+            |snapshot, _| {
+                probed.borrow_mut().push(snapshot.short_id().to_string());
+                Ok(true)
+            },
+        );
+
+        assert_eq!(verdict.status, Status::Verified);
+        assert_eq!(*probed.borrow(), vec!["part2222"]);
+    }
+
+    #[test]
+    fn verdict_verifies_the_newest_snapshot_holding_the_app_after_a_partial_sync() {
+        let age = max_age("24h");
+        let probed = RefCell::new(Vec::new());
+
+        let verdict = verdict(
+            &request("myserver", Some("bichon"), &age),
+            &partial_sync_snapshots(),
+            bichon_in_full_sync(&probed),
+        );
+
+        assert_eq!(verdict.status, Status::Verified);
+        assert_eq!(*probed.borrow(), vec!["part2222", "full1111"]);
+        assert_eq!(
+            check(&verdict, CHECK_SNAPSHOT).unwrap().message,
+            "latest snapshot containing bichon: full1111 (2026-07-29T00:00Z, 9h ago)"
+        );
+        assert_eq!(
+            check(&verdict, CHECK_CONTAINS_APP).unwrap().message,
+            "contains bichon (…/myserver/2026-07-29_00-00-00/bichon)"
+        );
+        let summary = verdict.snapshot.unwrap();
+        assert_eq!(summary.short_id, "full1111");
+        assert_eq!(summary.age_seconds, 9 * 3600);
+    }
+
+    #[test]
+    fn verdict_measures_freshness_against_the_snapshot_holding_the_app() {
+        let age = max_age("5h");
+        let probed = RefCell::new(Vec::new());
+
+        let verdict = verdict(
+            &request("myserver", Some("bichon"), &age),
+            &partial_sync_snapshots(),
+            bichon_in_full_sync(&probed),
+        );
+
+        assert_eq!(verdict.status, Status::CheckFailed);
+        assert!(check(&verdict, CHECK_CONTAINS_APP).unwrap().passed);
+        let failed = check(&verdict, CHECK_FRESH).unwrap();
+        assert!(!failed.passed, "the 9h-old bichon snapshot is stale at 5h");
+        assert_eq!(verdict.snapshot.unwrap().short_id, "full1111");
+    }
+
+    #[test]
+    fn verdict_names_the_newest_push_when_no_snapshot_holds_the_app() {
+        let age = max_age("24h");
+        let probed = RefCell::new(Vec::new());
+
+        let verdict = verdict(
+            &request("myserver", Some("absent"), &age),
+            &partial_sync_snapshots(),
+            bichon_in_full_sync(&probed),
+        );
+
+        assert_eq!(verdict.status, Status::CheckFailed);
+        assert_eq!(*probed.borrow(), vec!["part2222", "full1111"]);
+        assert_eq!(
+            check(&verdict, CHECK_SNAPSHOT).unwrap().message,
+            "latest snapshot for myserver: part2222 (2026-07-29T06:00Z, 3h ago)"
+        );
+        assert_eq!(
+            check(&verdict, CHECK_CONTAINS_APP)
+                .unwrap()
+                .remediation
+                .as_deref(),
+            Some("run: auberge backup sync --host myserver --apps absent")
+        );
+    }
+
+    #[test]
+    fn verdict_ignores_older_snapshots_without_an_app() {
+        let age = max_age("24h");
+        let verdict = verdict(
+            &request("myserver", None, &age),
+            &partial_sync_snapshots(),
+            |_, _| panic!("containment must not be probed without an app"),
+        );
+
+        assert_eq!(verdict.status, Status::Verified);
+        assert_eq!(
+            check(&verdict, CHECK_SNAPSHOT).unwrap().message,
+            "latest snapshot for myserver: part2222 (2026-07-29T06:00Z, 3h ago)"
+        );
+        assert_eq!(verdict.snapshot.unwrap().short_id, "part2222");
+    }
+
+    #[test]
+    fn verdict_is_operational_when_a_later_candidate_probe_fails() {
+        let age = max_age("24h");
+
+        let verdict = verdict(
+            &request("myserver", Some("bichon"), &age),
+            &partial_sync_snapshots(),
+            |snapshot, _| match snapshot.short_id() {
+                "part2222" => Ok(false),
+                _ => Err(eyre!("restic ls failed (exit status: 1)")),
+            },
+        );
+
+        assert_eq!(verdict.status, Status::OperationalError);
+        assert_eq!(verdict.status.exit_code(), 2);
+        assert!(check(&verdict, CHECK_FRESH).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes #380.

A partial sync used to invalidate every other app's verification. `backup sync --apps paperless` leaves a snapshot holding only `paperless`, and `verify -a bichon` asserted bichon was in *that* snapshot — so it failed, and told the operator to sync an app that was already backed up 8h earlier.

`-a <app>` now answers "is this app's offsite backup fresh?" instead of "did the most recent push happen to include this app?". It walks the host's snapshots newest-first and verifies the newest one **holding the app**; `--max-age` is measured against that snapshot. Without `-a`, nothing changes.

Live repro from the issue, host `auberge` (`52b70296` = 06:51 full sync, `4b461b62` = 12:11 paperless-only partial):

```
$ auberge backup verify -H auberge -a bichon        # before: ✗ contains bichon / exit 1
✓ repository reachable
✓ latest snapshot containing bichon: 52b70296 (2026-07-29T06:51Z, 9h ago)
✓ contains bichon (…/auberge/2026-07-29_06-50-05/bichon)
✓ younger than 24h
verified                                            # exit 0
```

## Selection

`snapshot_exists` prints before `contains_app`, but under the new semantics the probe is what *chooses* the snapshot. So selection runs before any check is emitted, and the checklist line names what it was selected for:

| Case | `snapshot_exists` line | Verdict |
| --- | --- | --- |
| no `-a` | `latest snapshot for <host>: …` | newest push, unchanged |
| `-a`, app found | `latest snapshot containing <app>: …` | that snapshot's age |
| `-a`, app in no snapshot | `latest snapshot for <host>: …` | `✗ contains <app>`, exit 1 |
| `-a`, probe errored | `latest snapshot for <host>: …` | exit 2 |

The walk stops at the first hit, so a fully-synced repository still costs one `restic ls`. A probe error **aborts** the walk rather than continuing to an older candidate — an unreadable repository must not read as "app missing".

## Anchors

| Change | File | Why |
| --- | --- | --- |
| `FnOnce` → `FnMut` probe | `src/services/backup/verify.rs:201` | one probe per candidate, not one total |
| `latest_for_host` → `host_snapshots_newest_first` | `src/services/backup/verify.rs:312` | selection needs the ordered candidate list, not just the max |
| `newest_holding_app` | `src/services/backup/verify.rs:326` | the walk; returns the snapshot **and** the path that proved it |
| ADR-0007 amendment | `meta/adr/0007-auberge-folder-reconcile-scope.md:68` | pinned "the newest restic snapshot … contains an App's backup" |
| Backup Verdict entry | `CONTEXT.md:68` | same wording in the glossary |

> [!NOTE]
> `verdict()` stays a pure function of `restic snapshots --json` plus an injected probe, so all 43 verify tests run without restic.

## Test plan

Unit — 43 verify tests (6 new), 406 total, `cargo nextest run`:

- [x] `-a` verifies the older app-holding snapshot when the newest push lacks the app
- [x] freshness measured against the app-holding snapshot, not the newest push
- [x] `contains_app` fails with the existing remediation when no snapshot holds the app
- [x] no `-a` → newest push, probe never called
- [x] probe error on a *later* candidate → exit 2, no `fresh` check
- [x] full-sync repository probes exactly one candidate

Against the live repository in the issue:

- [x] `-a bichon` → exit 0 on `52b70296`, was exit 1
- [x] no `-a` → `4b461b62`, byte-for-byte as before
- [x] `-a paperless` → `4b461b62` (newest push holds it), exit 0
- [x] `-a nosuchapp` → `✗ contains nosuchapp`, names `4b461b62`, exit 1, existing remediation
- [x] `-o json` `snapshot` object carries `52b70296` / `age_seconds: 32754`

Out of scope, per ADR-0007: coverage-check against the Upstream Mailbox, prune/retention, retro-tagging untagged snapshots.

https://claude.ai/code/session_01W8uLxUFGgu7AfHNzU1V6XP
