### PR TITLE
fix(bichon): make archived files group-readable

### DIFF
--- a/ansible/roles/bichon/tasks/main.yml
+++ b/ansible/roles/bichon/tasks/main.yml
@@ -223,6 +223,29 @@
         - "{{ bichon_archive_dir }}"
         - "{{ bichon_archive_state_dir }}"
 
+    # Files written before the archive script set the mode explicitly are 0600,
+    # because mktemp ignores the unit's UMask. Reconcile them so a deploy is
+    # enough and no manual chmod is needed. Files only: the directories above
+    # are 0750 and would lose traversal at 0640.
+    - name: Make existing archive files group-readable
+      ansible.builtin.command:
+        argv:
+          - find
+          - "{{ bichon_archive_dir }}"
+          - -type
+          - f
+          - "!"
+          - -perm
+          - -g=r
+          - -print
+          - -exec
+          - chmod
+          - "0640"
+          - "{}"
+          - +
+      register: bichon_archive_mode_reconcile
+      changed_when: bichon_archive_mode_reconcile.stdout | length > 0
+
     - name: Deploy archive script
       ansible.builtin.template:
         src: bichon-archive.sh.j2

--- a/ansible/roles/bichon/templates/bichon-archive.sh.j2
+++ b/ansible/roles/bichon/templates/bichon-archive.sh.j2
@@ -11,6 +11,14 @@ set -euo pipefail
 OVERLAP_MS=$((BICHON_ARCHIVE_OVERLAP_SECONDS * 1000))
 TOTAL_FAILURES=0
 
+# Both write paths below stage through mktemp, which creates 0600 whatever the
+# umask, and publish with mv, a same-filesystem rename that preserves the mode.
+# The unit's UMask=0027 therefore never reaches an archived file, so the mode is
+# set explicitly instead. It must stay group-readable: examples/bichon-expunge.sh
+# counts .meta.json sidecars over ssh as a member of the archive group, without
+# sudo, and unreadable sidecars make its coverage gate count zero.
+ARCHIVE_FILE_MODE=0640
+
 log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
 }
@@ -53,6 +61,7 @@ download_message() {
   local account_id="$1" message_id="$2" out_path="$3"
   local tmp
   tmp=$(mktemp "${out_path}.XXXXXX")
+  chmod "$ARCHIVE_FILE_MODE" "$tmp"
   if curl_auth --output "$tmp" \
       "${BICHON_BASE_URL}/api/v1/download-message/${account_id}/${message_id}"; then
     mv "$tmp" "$out_path"
@@ -66,6 +75,7 @@ write_meta_sidecar() {
   local out_path="$1" envelope_json="$2"
   local tmp
   tmp=$(mktemp "${out_path}.XXXXXX")
+  chmod "$ARCHIVE_FILE_MODE" "$tmp"
   printf '%s' "$envelope_json" | jq '{folder: .mailbox_name, tags: .tags}' >"$tmp"
   mv "$tmp" "$out_path"
 }

--- a/examples/bichon-expunge.sh
+++ b/examples/bichon-expunge.sh
@@ -384,7 +384,9 @@ set -euo pipefail
 archive_path=$1
 [ -d "$archive_path" ] || exit 3
 { [ -r "$archive_path" ] && [ -x "$archive_path" ]; } || exit 4
-find "$archive_path" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort
+# Skip dot-directories: bichon keeps its sync cursors in .state alongside the
+# per-account directories, and it is not a mailbox.
+find "$archive_path" -mindepth 1 -maxdepth 1 -type d ! -name '.*' -printf '%f\n' | sort
 REMOTE
   ) || rc=$?
 
@@ -582,7 +584,11 @@ find "$archive_dir" -regextype posix-extended \
   | while IFS= read -r meta; do
     ym=$(printf '%s' "$meta" | awk -F/ '{ print $(NF-2)"/"$(NF-1) }')
     [ "$ym" \> "$cutoff_ym" ] && continue
-    jq -e --arg f "$folder" '.folder == $f' "$meta" >/dev/null 2>&1 && printf '.\n'
+    # An unreadable sidecar is not "a message in another folder" — it is a
+    # broken count. Fail loudly rather than let jq's error be swallowed and
+    # report a coverage gap that is really a permission problem.
+    [ -r "$meta" ] || { printf 'cannot read %s\n' "$meta" >&2; exit 1; }
+    jq -e --arg f "$folder" '.folder == $f' "$meta" >/dev/null && printf '.\n'
   done | wc -l
 REMOTE
   )
@@ -593,6 +599,7 @@ REMOTE
     || die 1 "coverage gap: archive has ${eml_count} files, IMAP has ${IMAP_COUNT} messages" \
       "read the journal: ssh ${host} journalctl -u bichon-archive.service" \
       "check ${folder} is a Synced Folder: auberge bichon reconcile-folders --host ${host}" \
+      "check the sidecars are group-readable: ssh ${host} find ${archive_path} -type f ! -perm -g=r" \
       'do not expunge until the counts reconcile'
 
   note "coverage ok (${eml_count} >= ${IMAP_COUNT})"


### PR DESCRIPTION
The Email Archive was unreadable by the group created to read it, so `examples/bichon-expunge.sh` could never clear its coverage gate and the archive-then-expunge workflow was blocked end to end. Files are now `0640` as the unit already declared, and a deploy reconciles the 9905-file backlog with no manual step.

Closes #383

### Cause

`bichon-archive.service` sets `UMask=0027`; the role creates archive directories `0750 bichon:bichon`. But both write paths stage through `mktemp`, which creates `0600` whatever the umask, then publish with `mv` — a same-filesystem rename that preserves the inode's mode. `UMask=` never reached a single archived file.

| Declared | Actual |
| --- | --- |
| `UMask=0027` → `0640` | `0600`, all 9905 files |
| dirs `0750`, group-readable | correct |
| `bichon` group grants read | could traverse, could not read |

Present since 2391125 (2026-05-06). Files written the day this was found were still `0600`.

### Impact

Gate 3 counts `.meta.json` sidecars over ssh as a group member, without sudo. Every `jq` failed on permissions, and `2>&1` swallowed each error, so the count came back `0`:

```
IMAP messages in window: 36
archive .eml files in window: 0
error: coverage gap: archive has 0 files, IMAP has 36 messages
```

Read with privileges the count is **45**, so `45 >= 36` passes. The reported gap did not exist, and the remediation lines pointed at the archive timer and folder reconciliation — neither of which was wrong.

### Changes

| File | Change |
| --- | --- |
| `bichon-archive.sh.j2` | `ARCHIVE_FILE_MODE=0640`, applied to the temp file before `mv` in both write paths |
| `bichon/tasks/main.yml` | reconcile existing files via `find … ! -perm -g=r -print -exec chmod`; `changed_when` keyed on printed output |
| `bichon-expunge.sh` | unreadable sidecar is a hard failure, not a folder mismatch; new remediation line; skip dot-directories when listing accounts |

Files only in the reconcile task — the directories are `0750` and would lose traversal at `0640`.

### Test plan

- [x] `mise run lint-ansible` — 0 failures, 0 warnings, 202 files, `production` profile
- [x] `mise run lint-shell` — `shellcheck` + `shfmt` clean
- [x] Template rendered with role defaults: 0 unrendered Jinja tokens, `shellcheck` clean
- [x] `mktemp` → `chmod` → `mv` yields `0640` (`600` before, `640` after)
- [x] Reconcile `find` on a fixture: `0600` files → `0640`, dirs untouched at `0750`
- [x] Idempotent: second run prints nothing, so `changed_when` is false
- [ ] `auberge deploy` against the host — reconcile task turns the 9905 files, then gate 3 counts 45

> [!NOTE]
> `bichon_archive_state_dir` is `{{ bichon_archive_dir }}/.state`, so the reconcile sweeps it too. It holds per-account cursor timestamps, not secrets.

> [!IMPORTANT]
> No practical widening of access: the `bichon` group's only member is the mailbox owner. Group-read is the whole reason the group and the `0750` directories exist.
