### PR TITLE
chore: release v0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.9](https://github.com/sripwoud/auberge/compare/v0.14.8...v0.14.9) - 2026-07-29
+
+### Added
+
+- *(bichon)* restore archived mail with folders and tags ([#387](https://github.com/sripwoud/auberge/pull/387))
+
+### Fixed
+
+- *(bichon)* make archived files group-readable ([#385](https://github.com/sripwoud/auberge/pull/385))
+
+### Other
+
+- update ADR and context:wq
+- *(examples)* stop bichon-expunge stalling on a himalaya prompt
+- *(examples)* preflight bichon-expunge before it prompts
+
 ## [0.14.8](https://github.com/sripwoud/auberge/compare/v0.14.7...v0.14.8) - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auberge"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.8"
+version = "0.14.9"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.8 -> 0.14.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.9](https://github.com/sripwoud/auberge/compare/v0.14.8...v0.14.9) - 2026-07-29

### Added

- *(bichon)* restore archived mail with folders and tags ([#387](https://github.com/sripwoud/auberge/pull/387))

### Fixed

- *(bichon)* make archived files group-readable ([#385](https://github.com/sripwoud/auberge/pull/385))

### Other

- update ADR and context:wq
- *(examples)* stop bichon-expunge stalling on a himalaya prompt
- *(examples)* preflight bichon-expunge before it prompts
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).