### PR TITLE
chore: release v0.14.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.10](https://github.com/sripwoud/auberge/compare/v0.14.9...v0.14.10) - 2026-07-31
+
+### Added
+
+- *(bichon)* add rescan command to re-archive backdated mail ([#399](https://github.com/sripwoud/auberge/pull/399))
+- *(bichon)* alert when a mailbox cache rebuild purges the internal store ([#396](https://github.com/sripwoud/auberge/pull/396))
+
+### Fixed
+
+- *(bichon)* refuse to archive a body that is not a message ([#398](https://github.com/sripwoud/auberge/pull/398))
+- *(cli)* re-extract ansible assets when the embedded tree changes ([#397](https://github.com/sripwoud/auberge/pull/397))
+- *(bichon)* key archive dedup on Message-ID, not envelope id ([#391](https://github.com/sripwoud/auberge/pull/391))
+
 ## [0.14.9](https://github.com/sripwoud/auberge/compare/v0.14.8...v0.14.9) - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auberge"
-version = "0.14.9"
+version = "0.14.10"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.9"
+version = "0.14.10"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.9 -> 0.14.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.10](https://github.com/sripwoud/auberge/compare/v0.14.9...v0.14.10) - 2026-07-31

### Added

- *(bichon)* add rescan command to re-archive backdated mail ([#399](https://github.com/sripwoud/auberge/pull/399))
- *(bichon)* alert when a mailbox cache rebuild purges the internal store ([#396](https://github.com/sripwoud/auberge/pull/396))

### Fixed

- *(bichon)* refuse to archive a body that is not a message ([#398](https://github.com/sripwoud/auberge/pull/398))
- *(cli)* re-extract ansible assets when the embedded tree changes ([#397](https://github.com/sripwoud/auberge/pull/397))
- *(bichon)* key archive dedup on Message-ID, not envelope id ([#391](https://github.com/sripwoud/auberge/pull/391))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).