### PR TITLE
feat(bichon): alert when a mailbox cache rebuild purges the internal store

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           ./tests/bichon-archive.test.sh
           ./tests/bichon-expunge.test.sh
+          ./tests/bichon-uidvalidity-watch.test.sh
 
   _test:
     needs: changed-files

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,10 @@ _Avoid_: backup (collides with Backup Recipe), dump, export. Never call the `<en
 A per-account `tags.json` beside the **Email Archive**, mapping RFC 5322 `Message-ID` → tags, rewritten in full on every archive run. The mutable-metadata counterpart to the Archive: tags are operator annotations applied _after_ ingestion and revised indefinitely, which an append-only store cannot represent. Keyed on `Message-ID` because Bichon regenerates its own envelope identifier on re-import. Costs one API call per run while no tags exist. See ADR-0012.
 _Avoid_: tag index, label export, metadata sidecar (collides with the Archive's per-message `.meta.json`).
 
+**Rebuild Latch**:
+A file on the bichon Host (`/var/lib/bichon-uidvalidity-watch/rebuilds.log`) holding one line per detected **Internal Store** purge, written by an hourly timer that reads `bichon.service`'s journal from a saved cursor for Bichon's `detected with changed uid_validity` line. **Latched, not edge-triggered**: the unit exits non-zero while the file is non-empty, so the finding is republished every tick and clears only when an operator deletes the file — systemd clears a unit's failed state on the next successful start, so an exit code alone would erase the alert within the hour. The failed unit is the alert surface (`systemctl --failed`, Cockpit → Services); deleting the file is both the acknowledgement and the record that someone saw it. Exit codes match the **Backup Verdict**'s (0 clean, 1 recorded, 2 could not read the journal), so a watch that cannot read the journal is distinguishable from one that found nothing. Carries no delivery channel: it is a condition to be found, not a message that is sent. See ADR-0014.
+_Avoid_: Alert file, flag, sentinel, marker (understates that the unit fails on it), monitor.
+
 **Upstream Mailbox**:
 The third-party IMAP (or Gmail-API) server that Bichon syncs _from_ — e.g. the operator's Gmail, Fastmail, ProtonMail Bridge endpoint. Distinct from the **Email Archive** (Bichon-side, append-only) and from any **Backup Recipe** target. Operations on the Upstream Mailbox (e.g. expunging old mail to reclaim quota) are out-of-scope for `auberge deploy` and `auberge backup`; any future tooling that touches it must treat it as authoritative-but-untrusted.
 _Avoid_: IMAP server, mail provider, source mailbox.
@@ -112,6 +116,7 @@ _Avoid_: Logger, reporter
 - A **Backup Verdict** reads only what a **Backup Session** already pushed, attributing a snapshot to a **Host** by the restic tag push writes (the same tag prune groups retention by).
 - Bichon syncs from an **Upstream Mailbox** into its **Internal Store**; the **Email Archive** and **Tag Snapshot** are derived from the Internal Store; the **Backup Recipe** rsyncs those two and never the Internal Store.
 - Restoring a purged **Internal Store** means replaying the **Email Archive** (bodies, foldered from the sidecars) and then the **Tag Snapshot** (tags), both via `examples/bichon-restore.sh`. Neither the Archive nor the Snapshot is searchable on its own.
+- A purge of the **Internal Store** is announced by the **Rebuild Latch**, which detects it and nothing more: it neither prevents the purge nor triggers the replay.
 - All runners report through **Progress**; none touch terminal output directly.
 - An **App** is either a **Public App** or a **Tailnet-only App**, determined by the `tailnet_only` flag in its **Playbook Meta**. **DNS Publication** is dispatched accordingly.
 - The **Busy Feed** is derived from **Baikal**'s calendar data — plus, optionally, a read-only external CalDAV calendar fetched Host-side — and served on Baikal's **Public App** site (Google's servers must reach it); auberge produces and serves it but ships no consumer.

--- a/ansible/roles/bichon/defaults/main.yml
+++ b/ansible/roles/bichon/defaults/main.yml
@@ -23,3 +23,6 @@ bichon_archive_script_path: /usr/local/bin/bichon-archive
 bichon_archive_env_path: /etc/default/bichon-archive
 bichon_archive_overlap_seconds: 86400
 bichon_archive_page_size: 100
+
+bichon_uidvalidity_watch_script_path: /usr/local/bin/bichon-uidvalidity-watch
+bichon_uidvalidity_watch_state_dir: /var/lib/bichon-uidvalidity-watch

--- a/ansible/roles/bichon/files/bichon-uidvalidity-watch.sh
+++ b/ansible/roles/bichon/files/bichon-uidvalidity-watch.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# bichon-uidvalidity-watch
+#
+# Latches the one Bichon event that costs data silently. On a UIDVALIDITY
+# mismatch Bichon calls rebuild_mailbox_cache, which deletes the folder's
+# envelopes and their blobs from the Internal Store before refetching; mail
+# already expunged from the Upstream Mailbox cannot be refetched, so its
+# searchability and tags are gone until an operator notices and replays the
+# Email Archive (ADR-0012, ADR-0014). Bichon logs the trigger at info level and
+# carries on. Nothing else notices.
+#
+# Reads bichon.service's journal from a saved cursor and appends every match to
+# a latch file. The unit fails while that file is non-empty, so the report is
+# republished on every run and clears only when an operator deletes the file —
+# the failed unit is the alert surface (systemctl --failed, Cockpit → Services).
+#
+# Environment:
+#   BICHON_UIDVALIDITY_STATE_DIR  required — holds the cursor and the latch
+#   BICHON_UIDVALIDITY_UNIT       unit to read (default bichon.service)
+#
+# Exit codes, matching `auberge backup verify`:
+#   0 — no rebuild recorded
+#   1 — a rebuild is recorded and unacknowledged
+#   2 — operational error: the journal could not be read
+#
+# shellcheck shell=bash
+
+set -euo pipefail
+
+: "${BICHON_UIDVALIDITY_STATE_DIR:?required}"
+: "${BICHON_UIDVALIDITY_UNIT:=bichon.service}"
+
+# The coupling point to upstream, and the reason it is a fixed string rather
+# than an operator knob: it must match what Bichon writes, not what an operator
+# guesses. Preferred over the folder status Bichon also sets ("UID validity
+# changed, rebuilding...") because only this one reaches the journal. Unchanged
+# from the deployed 0.3.7 (src/modules/cache/imap/sync/flow.rs:283) through the
+# workspace re-crate refactor that moved the same line to
+# crates/core/src/cache/imap/download/flow.rs:491.
+readonly SIGNAL='detected with changed uid_validity'
+
+readonly CURSOR_FILE="${BICHON_UIDVALIDITY_STATE_DIR}/cursor"
+readonly REBUILD_LOG="${BICHON_UIDVALIDITY_STATE_DIR}/rebuilds.log"
+readonly SELF_UNIT='bichon-uidvalidity-watch.service'
+
+log() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
+}
+
+# journalctl advances the cursor file to the last entry it showed, so a run that
+# reads nothing new still records where it stopped and no entry is read twice.
+# Scoping to one unit also keeps this script's own output — which quotes SIGNAL
+# back when it reports — from ever matching on a later run.
+read_new_entries() {
+  journalctl \
+    --unit="${BICHON_UIDVALIDITY_UNIT}" \
+    --cursor-file="${CURSOR_FILE}" \
+    --output=short-iso-precise \
+    --no-pager \
+    --quiet
+}
+
+# The first run has no cursor and so reads the whole retained journal.
+# Deliberate: a rebuild that already happened is precisely what the operator was
+# never told about, and seeding a silent baseline would bury it.
+#
+# Only the matching line is kept. Bichon formats the uid values with {:#?},
+# which spills them onto continuation lines; the mailbox name and the timestamp
+# are both on the line that matches, and the discarded values name a generation
+# counter nobody acts on.
+record_rebuilds() {
+  local entries matches
+  if ! entries=$(read_new_entries); then
+    log "journal read failed for unit ${BICHON_UIDVALIDITY_UNIT}"
+    return 2
+  fi
+
+  matches=$(printf '%s\n' "${entries}" | grep -F "${SIGNAL}" || true)
+  [[ -z "${matches}" ]] && return 0
+
+  printf '%s\n' "${matches}" >>"${REBUILD_LOG}"
+}
+
+# Latched, not edge-triggered: systemd clears a unit's failed state on the next
+# successful start, so a rebuild announced by exit code alone would be erased by
+# the following hourly tick. The file is the durable signal; the exit code only
+# republishes it.
+report() {
+  [[ -s "${REBUILD_LOG}" ]] || {
+    log "no mailbox cache rebuild recorded"
+    return 0
+  }
+
+  log "MAILBOX CACHE REBUILD DETECTED — the Internal Store dropped envelopes for:"
+  while IFS= read -r line; do
+    log "  ${line}"
+  done <"${REBUILD_LOG}"
+  log "Mail still on the Upstream Mailbox was refetched; mail already expunged there was not."
+  log "Replay the Email Archive with examples/bichon-restore.sh, then acknowledge with:"
+  log "  rm ${REBUILD_LOG} && systemctl start ${SELF_UNIT}"
+  return 1
+}
+
+main() {
+  mkdir -p "${BICHON_UIDVALIDITY_STATE_DIR}"
+
+  local scan_status=0 report_status=0
+  record_rebuilds || scan_status=$?
+  report || report_status=$?
+
+  # An unreadable journal outranks the latch: the run could not answer the
+  # question at all, which is what exit 2 means everywhere else in auberge. The
+  # latch is still printed above, so an operator loses no information to it.
+  if [[ "${scan_status}" -ne 0 ]]; then
+    return "${scan_status}"
+  fi
+  return "${report_status}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/ansible/roles/bichon/files/bichon-uidvalidity-watch.sh
+++ b/ansible/roles/bichon/files/bichon-uidvalidity-watch.sh
@@ -78,14 +78,17 @@ read_new_entries() {
 # Deliberate: a rebuild that already happened is precisely what the operator was
 # never told about, and seeding a silent baseline would bury it.
 #
-# Only the matching line is kept. Bichon formats the uid values with {:#?},
-# which spills them onto continuation lines; the mailbox name and the timestamp
-# are both on the line that matches, and the discarded values name a generation
+# Staged through a file rather than a variable because that first run is
+# unbounded — a VPS journal holding months of bichon.service is hundreds of
+# thousands of lines, and buffering it in the shell costs tens of MB for one
+# grep. Every later run is bounded by the cursor to one tick's worth. The name is
+# fixed, not per-pid, so a crashed run's leftover is overwritten rather than
+# accumulating; systemd will not run this oneshot concurrently with itself.
+#
+# Only the matching line is kept. Bichon formats the uid values with {:#?}, which
+# spills them onto continuation lines; the mailbox name and the timestamp are
+# both on the line that matches, and the discarded values name a generation
 # counter nobody acts on.
-# Staged through a file rather than a variable because the first run is unbounded
-# — a VPS journal holding months of bichon.service is hundreds of thousands of
-# lines, and buffering that in the shell costs tens of MB for a single grep.
-# Every later run is bounded by the cursor to one tick's worth.
 record_rebuilds() {
   local matches
   if ! read_new_entries >"${SCRATCH_FILE}"; then

--- a/ansible/roles/bichon/files/bichon-uidvalidity-watch.sh
+++ b/ansible/roles/bichon/files/bichon-uidvalidity-watch.sh
@@ -42,16 +42,29 @@ readonly SIGNAL='detected with changed uid_validity'
 
 readonly CURSOR_FILE="${BICHON_UIDVALIDITY_STATE_DIR}/cursor"
 readonly REBUILD_LOG="${BICHON_UIDVALIDITY_STATE_DIR}/rebuilds.log"
+readonly SCRATCH_FILE="${BICHON_UIDVALIDITY_STATE_DIR}/journal.scratch"
 readonly SELF_UNIT='bichon-uidvalidity-watch.service'
+
+# The report is republished every tick until acknowledged, so it has to stay
+# bounded: an account thrashing UIDVALIDITY unnoticed for weeks latches thousands
+# of lines, and echoing all of them hourly would spam the journal this unit
+# exists to keep readable. The latch file keeps the complete record.
+readonly REPORT_MAX_LINES=20
 
 log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
 }
 
-# journalctl advances the cursor file to the last entry it showed, so a run that
-# reads nothing new still records where it stopped and no entry is read twice.
-# Scoping to one unit also keeps this script's own output — which quotes SIGNAL
-# back when it reports — from ever matching on a later run.
+# journalctl advances the cursor file to the last entry it examined, so a run
+# that reads nothing new still records where it stopped and no entry is read
+# twice. Scoping to one unit also keeps this script's own output — which quotes
+# SIGNAL back when it reports — from ever matching on a later run.
+#
+# Filtering here with journalctl's own --grep would be the obvious economy, and
+# is wrong: --grep exits 1 when nothing matched, which is the same status an
+# unreadable or misnamed unit returns. A renamed bichon.service would then read
+# as "no rebuild" forever, and silent-vs-loud (ADR-0007 §1) is the whole point
+# of this unit. grep -F downstream keeps journalctl's status unambiguous.
 read_new_entries() {
   journalctl \
     --unit="${BICHON_UIDVALIDITY_UNIT}" \
@@ -69,14 +82,20 @@ read_new_entries() {
 # which spills them onto continuation lines; the mailbox name and the timestamp
 # are both on the line that matches, and the discarded values name a generation
 # counter nobody acts on.
+# Staged through a file rather than a variable because the first run is unbounded
+# — a VPS journal holding months of bichon.service is hundreds of thousands of
+# lines, and buffering that in the shell costs tens of MB for a single grep.
+# Every later run is bounded by the cursor to one tick's worth.
 record_rebuilds() {
-  local entries matches
-  if ! entries=$(read_new_entries); then
+  local matches
+  if ! read_new_entries >"${SCRATCH_FILE}"; then
+    rm -f "${SCRATCH_FILE}"
     log "journal read failed for unit ${BICHON_UIDVALIDITY_UNIT}"
     return 2
   fi
 
-  matches=$(printf '%s\n' "${entries}" | grep -F "${SIGNAL}" || true)
+  matches=$(grep -F "${SIGNAL}" "${SCRATCH_FILE}" || true)
+  rm -f "${SCRATCH_FILE}"
   [[ -z "${matches}" ]] && return 0
 
   printf '%s\n' "${matches}" >>"${REBUILD_LOG}"
@@ -92,10 +111,16 @@ report() {
     return 0
   }
 
-  log "MAILBOX CACHE REBUILD DETECTED — the Internal Store dropped envelopes for:"
+  local total line
+  total=$(wc -l <"${REBUILD_LOG}")
+
+  log "MAILBOX CACHE REBUILD DETECTED — ${total} unacknowledged, the Internal Store dropped:"
   while IFS= read -r line; do
     log "  ${line}"
-  done <"${REBUILD_LOG}"
+  done < <(head -n "${REPORT_MAX_LINES}" "${REBUILD_LOG}")
+  if [[ "${total}" -gt "${REPORT_MAX_LINES}" ]]; then
+    log "  … and $((total - REPORT_MAX_LINES)) more, in ${REBUILD_LOG}"
+  fi
   log "Mail still on the Upstream Mailbox was refetched; mail already expunged there was not."
   log "Replay the Email Archive with examples/bichon-restore.sh, then acknowledge with:"
   log "  rm ${REBUILD_LOG} && systemctl start ${SELF_UNIT}"

--- a/ansible/roles/bichon/handlers/main.yml
+++ b/ansible/roles/bichon/handlers/main.yml
@@ -16,3 +16,9 @@
     name: bichon-archive.timer
     state: restarted
     daemon_reload: true
+
+- name: Restart bichon-uidvalidity-watch timer
+  ansible.builtin.systemd_service:
+    name: bichon-uidvalidity-watch.timer
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/bichon/tasks/main.yml
+++ b/ansible/roles/bichon/tasks/main.yml
@@ -290,6 +290,48 @@
         state: started
         daemon_reload: true
 
+    - name: Create UIDVALIDITY watch state directory
+      ansible.builtin.file:
+        path: "{{ bichon_uidvalidity_watch_state_dir }}"
+        state: directory
+        owner: "{{ bichon_sys_user }}"
+        group: "{{ bichon_sys_group }}"
+        mode: "0750"
+
+    - name: Deploy UIDVALIDITY watch script
+      ansible.builtin.copy:
+        src: bichon-uidvalidity-watch.sh
+        dest: "{{ bichon_uidvalidity_watch_script_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: Restart bichon-uidvalidity-watch timer
+
+    - name: Deploy UIDVALIDITY watch systemd service unit
+      ansible.builtin.template:
+        src: bichon-uidvalidity-watch.service.j2
+        dest: /etc/systemd/system/bichon-uidvalidity-watch.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart bichon-uidvalidity-watch timer
+
+    - name: Deploy UIDVALIDITY watch systemd timer unit
+      ansible.builtin.template:
+        src: bichon-uidvalidity-watch.timer.j2
+        dest: /etc/systemd/system/bichon-uidvalidity-watch.timer
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart bichon-uidvalidity-watch timer
+
+    - name: Enable and start UIDVALIDITY watch timer
+      ansible.builtin.systemd_service:
+        name: bichon-uidvalidity-watch.timer
+        enabled: true
+        state: started
+        daemon_reload: true
+
     - name: Display deployment summary
       ansible.builtin.debug:
         msg:
@@ -306,3 +348,7 @@
           - "  systemctl status bichon"
           - "  systemctl status bichon-archive.timer"
           - "  systemctl list-timers bichon-archive.timer"
+          - ""
+          - "A UIDVALIDITY mailbox cache rebuild shows up as a failed unit:"
+          - "  systemctl --failed"
+          - "  systemctl status bichon-uidvalidity-watch.service"

--- a/ansible/roles/bichon/templates/bichon-uidvalidity-watch.service.j2
+++ b/ansible/roles/bichon/templates/bichon-uidvalidity-watch.service.j2
@@ -1,0 +1,26 @@
+[Unit]
+Description=Watch bichon's journal for a UIDVALIDITY mailbox cache rebuild
+# Deliberately no Requires=bichon.service, unlike bichon-archive.service which
+# calls bichon's API: this unit only reads the journal, and must still republish
+# a latched rebuild while bichon is down.
+
+[Service]
+Type=oneshot
+User={{ bichon_sys_user }}
+Group={{ bichon_sys_group }}
+# bichon.service is a system unit, so journald writes its entries to the system
+# journal, which is readable by root, adm and systemd-journal only. This grants
+# the read without running the watch as root.
+SupplementaryGroups=systemd-journal
+Environment=BICHON_UIDVALIDITY_STATE_DIR={{ bichon_uidvalidity_watch_state_dir }}
+Environment=BICHON_UIDVALIDITY_UNIT=bichon.service
+ExecStart={{ bichon_uidvalidity_watch_script_path }}
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ReadWritePaths={{ bichon_uidvalidity_watch_state_dir }}
+UMask=0027

--- a/ansible/roles/bichon/templates/bichon-uidvalidity-watch.timer.j2
+++ b/ansible/roles/bichon/templates/bichon-uidvalidity-watch.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check hourly for a bichon UIDVALIDITY mailbox cache rebuild
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+Unit=bichon-uidvalidity-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/applications/apps/bichon.md
+++ b/docs/applications/apps/bichon.md
@@ -5,6 +5,7 @@ Email archiving service with continuous IMAP sync and full-text search. Docs: [g
 - **URL**: tailnet only — see [Tailnet-only apps](cli-reference/dns/set-all.md#tailnet-only-apps)
 - **Port**: internal (Caddy proxy)
 - **Data**: `/opt/bichon/data` (internal store), `/var/lib/bichon-archive` (EML mirror, backed up)
+- **Timers**: `bichon-archive.timer` (hourly archive), `bichon-uidvalidity-watch.timer` (hourly [rebuild alert](#uidvalidity-rebuild-alert))
 
 ## Deploy
 
@@ -55,6 +56,36 @@ ssh <hostname> "sudo find /var/lib/bichon-archive -name '*.meta.json' \
 ```
 
 Sidecars written before [ADR-0013](https://github.com/sripwoud/auberge/blob/master/meta/adr/0013-archive-message-identity-is-the-message-id.md) carry no `message_id`. The next `bichon-archive.service` run repairs every one of them and drops the inert `tags` field [ADR-0012](https://github.com/sripwoud/auberge/blob/master/meta/adr/0012-archive-splits-immutable-bodies-from-mutable-metadata.md) left behind; until it has, gate 3 of `bichon-expunge.sh` refuses to run.
+
+## UIDVALIDITY rebuild alert
+
+When an Upstream Mailbox changes a folder's `UIDVALIDITY`, Bichon deletes that folder's envelopes and blobs from the internal store and refetches. Mail already expunged upstream **cannot be refetched** — its searchability and tags are gone until you replay the archive. Bichon logs this at info level and carries on.
+
+`bichon-uidvalidity-watch.timer` reads `bichon.service`'s journal hourly and records every occurrence. It shows up as a failed unit:
+
+```bash
+systemctl --failed
+systemctl status bichon-uidvalidity-watch.service   # names the folder and when
+```
+
+The alert is **latched**: it is reported on every run until you acknowledge it, because systemd would otherwise clear the failed state on the next tick. The full record is `/var/lib/bichon-uidvalidity-watch/rebuilds.log`.
+
+| Exit | Meaning                                  |
+| ---- | ---------------------------------------- |
+| 0    | no rebuild recorded                      |
+| 1    | a rebuild is recorded and unacknowledged |
+| 2    | the journal could not be read            |
+
+To respond: restore the affected folder per **Restore ordering** below, then acknowledge — deleting the file is the acknowledgement.
+
+```bash
+sudo rm /var/lib/bichon-uidvalidity-watch/rebuilds.log
+sudo systemctl start bichon-uidvalidity-watch.service   # exits 0, clears the failed state
+```
+
+!> Acknowledge only after restoring. Nothing else records that a purge happened, so deleting the latch without restoring discards the only notice you get. The first run after deploy reports rebuilds already in the retained journal — that is deliberate, not a false alarm.
+
+See [ADR-0014](https://github.com/sripwoud/auberge/blob/master/meta/adr/0014-uidvalidity-rebuild-alert-is-a-latched-failing-unit.md). The alert is passive by design: it carries no push channel, so it reaches you when you look at the Host or Cockpit.
 
 **Restore ordering** (do not skip steps):
 

--- a/meta/adr.md
+++ b/meta/adr.md
@@ -21,6 +21,7 @@ One number, one file. Every file in `meta/adr/` is listed here; a number that ap
 | 0011 | [Exclude `rust/cleartext-logging` via advanced CodeQL setup](./adr/0011-suppress-codeql-cleartext-logging-on-cli-stdout.md)          |
 | 0012 | [Email Archive splits immutable bodies from mutable metadata](./adr/0012-archive-splits-immutable-bodies-from-mutable-metadata.md)   |
 | 0013 | [Archive message identity is the Message-ID, read from the body](./adr/0013-archive-message-identity-is-the-message-id.md)           |
+| 0014 | [The UIDVALIDITY rebuild alert is a latched failing unit](./adr/0014-uidvalidity-rebuild-alert-is-a-latched-failing-unit.md)         |
 
 ## No Docker
 

--- a/meta/adr/0012-archive-splits-immutable-bodies-from-mutable-metadata.md
+++ b/meta/adr/0012-archive-splits-immutable-bodies-from-mutable-metadata.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted, 2026-07-29. **Amended by ADR-0013**, which adds `message_id` to the sidecar, reverses the backfill rejection below on the grounds that rejection named, and narrows "written once and never revisited" to observations rather than to the file.
+Accepted, 2026-07-29. **Amended by ADR-0013**, which adds `message_id` to the sidecar, reverses the backfill rejection below on the grounds that rejection named, and narrows "written once and never revisited" to observations rather than to the file. **Followed by ADR-0014**, which builds the journal alert this ADR's Consequences name and leave unbuilt.
 
 ## Decision
 
@@ -81,7 +81,7 @@ The hazard that surfaced this: on `UIDVALIDITY` mismatch Bichon calls `rebuild_m
 - `tags.json` is rewritten hourly, so every snapshot holds a new copy. Negligible at realistic tag counts, but it is the first Archive artifact that does not dedup across snapshots.
 - Sidecars written before this ADR carry an inert `tags` field. Harmless but untidy, and a reader who trusts it will conclude the corpus has no tags — which is true today and may not be later.
 - Folder is still captured at first sight. A message moved between folders upstream after archiving keeps its original sidecar value. Accepted: moves are rare, and a message whose upstream folder changed within the 24h overlap window is re-archived under a second envelope id — pre-existing behaviour, unchanged by this ADR.
-- A `UIDVALIDITY` purge still costs searchability until an operator notices and restores. Detection is out of scope here; Bichon logs the trigger at info level (`flow.rs:490`) and sets the folder status to `UID validity changed, rebuilding...`, so a journal alert is the cheap follow-up.
+- A `UIDVALIDITY` purge still costs searchability until an operator notices and restores. Detection is out of scope here; Bichon logs the trigger at info level (`flow.rs:490`) and sets the folder status to `UID validity changed, rebuilding...`, so a journal alert is the cheap follow-up. **Built by ADR-0014** as the **Rebuild Latch**, which watches the journal line rather than the folder status.
 
 ## References
 

--- a/meta/adr/0014-uidvalidity-rebuild-alert-is-a-latched-failing-unit.md
+++ b/meta/adr/0014-uidvalidity-rebuild-alert-is-a-latched-failing-unit.md
@@ -1,0 +1,82 @@
+# ADR-0014: The UIDVALIDITY rebuild alert is a latched failing unit
+
+## Status
+
+Accepted, 2026-07-30. Executes the follow-up ADR-0012's Consequences named and left unbuilt.
+
+## Decision
+
+An hourly timer on the Bichon Host reads `bichon.service`'s journal from a saved cursor, appends every line matching `detected with changed uid_validity` to a **Rebuild Latch** file, and exits non-zero while that file is non-empty. The failed unit is the alert; the file is the state.
+
+```
+/var/lib/bichon-uidvalidity-watch/cursor         journalctl --cursor-file
+/var/lib/bichon-uidvalidity-watch/rebuilds.log   the latch: one line per detected rebuild
+```
+
+- `ansible/roles/bichon/files/bichon-uidvalidity-watch.sh`, deployed to `/usr/local/bin`, driven by `bichon-uidvalidity-watch.timer`.
+- Exit codes match `auberge backup verify` (**Backup Verdict**): `0` no rebuild recorded, `1` a rebuild is recorded and unacknowledged, `2` the journal could not be read.
+- Acknowledgement is `rm rebuilds.log`, then `systemctl start bichon-uidvalidity-watch.service` to clear the failed state immediately rather than waiting a tick.
+- Runs as `bichon` with `SupplementaryGroups=systemd-journal`, not as root.
+- No new Key Registry entries, no network egress, no delivery credential.
+- Out of scope, unchanged from ADR-0012: preventing the rebuild, and automating the restore.
+
+## Why
+
+ADR-0012 made the restore path faithful and closed with the one residual gap it declined to fix: "a `UIDVALIDITY` purge still costs searchability until an operator notices and restores. Detection is out of scope here … so a journal alert is the cheap follow-up." Bichon logs the trigger at info level and carries on. Nothing else noticed.
+
+The signal is worth building on because it is stable and it precedes the damage:
+
+| Property         | Evidence                                                                                                                                                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Emitted pre-loss | logged before `rebuild_mailbox_cache` is called, so it names the folder that is about to be purged                                                                                                                                   |
+| Version-stable   | byte-identical in the deployed 0.3.7 (`src/modules/cache/imap/sync/flow.rs:283`) and at upstream HEAD (`crates/core/src/cache/imap/download/flow.rs:491`) — the workspace re-crate refactor moved the file and left the string alone |
+| Reachable        | `bichon_log_level` defaults to `info`, so the line is in the journal as deployed                                                                                                                                                     |
+
+**The alert has to be latched, not edge-triggered.** This is the decision; everything else follows from it. systemd clears a unit's failed state on the next successful start, so a rebuild announced by exit code alone is erased by the tick that follows it — at hourly cadence the alert would survive under an hour, against a hazard whose failure mode is measured in weeks. Persisting the finding to a file and re-failing on it turns a momentary event into a condition that stays until a human clears it. The operator's acknowledgement is a file deletion, which is also the record that they saw it.
+
+**Why a failing unit rather than a push.** The Host runs Cockpit, so `systemctl --failed` is already a surface an operator sees without new infrastructure. Telegram was the alternative — the operator already provisions bot tokens for `hermes` and `tgtg`, so it would have worked — and was rejected for scope: it costs two Key Registry entries and a delivery credential inside the bichon role, and `meta/roadmap.md` still carries "Alerting (via email or webhook)" as an unbuilt cross-cutting item. A bichon-specific sender would be the thing that design has to unpick later. The latch is the smaller commitment and composes with a push if one is ever built: any notifier can watch one file or one unit state.
+
+**Why not `journalctl --grep`.** It would push the filter into journalctl and remove the staging file, and it destroys the distinction the exit codes exist for: `--grep` exits `1` when nothing matched, which is also what an unreadable or misnamed unit returns. A renamed `bichon.service` would then read as "no rebuild" forever — the silent failure ADR-0007 §1 rejects, in the one unit whose entire job is to be loud. `grep -F` downstream keeps journalctl's status unambiguous, at the cost of staging the read through a file. Verified: `--cursor-file` does advance to the last entry _examined_ even when `--grep` shows nothing, so the cursor is not what rules it out.
+
+**The first run reads the whole retained journal**, because no cursor exists yet. Deliberate: a rebuild that already happened is precisely what the operator was never told about, and seeding a silent baseline would bury it. This is also why the read is staged through a file rather than a shell variable — a VPS journal holding months of `bichon.service` is hundreds of thousands of lines.
+
+## Considered alternatives
+
+- **Telegram (or any push) from the bichon role.** Rejected above on scope, not on merit: it is the only channel that actually reaches an operator who is not looking at the Host. Revisit when the roadmap's shared alerting exists, and drive it from the latch rather than from a second journal reader.
+
+- **A long-running `journalctl --follow` watcher with `Restart=always`.** Rejected. It buys real-time detection against a hazard measured in weeks, and pays for it with a process that can die between restarts and a supervision question the timer does not have. `Persistent=true` on a timer additionally catches up a tick the Host was down for, which a follow cannot.
+
+- **Surface it through the CLI (`auberge bichon verify`, over ssh, on the Backup Verdict pattern).** Rejected for this issue, not on principle — it is the largest diff (Rust, tests, docs, a new subcommand) and it is pull-only, so it answers "is anything wrong?" only when asked. The latch already writes a file an ssh one-liner can read, so this stays available as a later addition rather than a prerequisite.
+
+- **Re-emit at a higher priority with `systemd-cat` and leave it in the journal.** Rejected: it moves the line without making anything notice it, which is the status quo with extra steps.
+
+- **Watch the folder status Bichon also sets (`UID validity changed, rebuilding...`).** Rejected: it lives in the Internal Store and is transient — overwritten when the rebuild finishes — so reading it means polling Bichon's API and racing the thing being detected. The journal line is append-only and outlives the event.
+
+- **Alert on the rebuild by diffing envelope counts.** Rejected: it measures the consequence instead of the trigger, cannot distinguish a purge from an ordinary expunge, and needs a baseline that the purge itself destroys.
+
+## Consequences
+
+**Positive:**
+
+- ADR-0012's last open gap is closed. A purge is announced within the hour instead of at the next restore, "possibly years later."
+- Zero new config: no Key Registry entry, no credential, no egress. The alert cannot fail because a token expired.
+- The latched report names the folder and the timestamp, which is what the restore in ADR-0012 needs as input.
+- A run that cannot read the journal is distinguishable from a run that found nothing (`2` vs `0`), so the watch cannot fail silently.
+- Composes with a future notifier: one file, one unit state, no second journal reader.
+
+**Negative:**
+
+- **Passive.** Nothing reaches the operator's phone. An operator who never runs `systemctl --failed` and never opens Cockpit learns of a rebuild no sooner than before. This is the cost of the scope decision above, and it is the reason to revisit push once shared alerting exists.
+- Detection latency is up to an hour, plus however long until the operator looks.
+- Journal retention bounds what the first run can see. A rebuild older than the retained journal is undetectable, and no baseline records that.
+- The grep target is upstream prose. It has survived one whole-workspace refactor, but a reworded log line silently disables the watch — the failure mode is a unit that keeps passing. Nothing detects that; a canary would need a rebuild to test against.
+- One more unit and timer on the Host, and a state directory that is not backed up (correctly — it is derived from the journal, and the latch is a notice, not a record of mail).
+
+## References
+
+- ADR-0012 — Email Archive splits immutable bodies from mutable metadata. Its Consequences name this follow-up; its restore script is what a latched rebuild sends the operator to.
+- ADR-0007 §1 — the silent-vs-loud asymmetry. It decides the `--grep` question and the "no baseline seeding" question the same way.
+- ADR-0006 — the Internal Store is deliberately not backed up, which is why a purge costs searchability rather than mail.
+- `meta/roadmap.md` — "Alerting (via email or webhook)" under Infrastructure, still unbuilt; the reason this alert ships without a delivery channel.
+- CONTEXT.md — defines **Rebuild Latch**, **Internal Store**, **Email Archive**, **Upstream Mailbox**, **Backup Verdict**.
+- Bichon trigger chain: `flow.rs` UIDVALIDITY comparison → `info!` → `rebuild_mailbox_cache` deletes envelopes and blobs → refetch.

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,7 @@ quiet = true
 run = [
   "./tests/bichon-archive.test.sh",
   "./tests/bichon-expunge.test.sh",
+  "./tests/bichon-uidvalidity-watch.test.sh",
 ]
 quiet = true
 

--- a/tests/bichon-uidvalidity-watch.test.sh
+++ b/tests/bichon-uidvalidity-watch.test.sh
@@ -93,6 +93,11 @@ assert_eq 'unremarkable entries exit 0' '0' \
 
 assert_eq 'and write no latch' '' "$(latch_of quiet)"
 
+# "latch file exists" must mean "a rebuild was recorded", so a clean run may not
+# leave an empty one behind — an operator acknowledges by deleting this file.
+assert_fails 'and create no latch file at all' \
+  test -e "${WORK}/state/quiet/rebuilds.log"
+
 assert_eq 'an empty journal exits 0' '0' "$(run_case empty 0)"
 
 printf '\n== a detected rebuild\n'
@@ -127,12 +132,39 @@ assert_eq 'without duplicating the latched line' '1' "$(latch_of persist | wc -l
 rm "${WORK}/state/persist/rebuilds.log"
 assert_eq 'deleting the latch acknowledges the alert' '0' "$(run_case persist 0)"
 
+printf '\n== the report stays bounded\n'
+
+# The report is republished every tick until acknowledged. An account thrashing
+# UIDVALIDITY unnoticed latches thousands of lines; echoing all of them hourly
+# would spam the journal this unit exists to keep readable.
+flood=()
+for _ in $(seq 25); do flood+=("${SIGNAL_LINE}"); done
+assert_eq '25 latched lines still exit 1' '1' "$(run_case flood 0 "${flood[@]}")"
+
+assert_eq 'all 25 are kept in the latch file' '25' "$(latch_of flood | wc -l)"
+
+assert_eq 'but only 20 are echoed' '20' \
+  "$(grep -cF "${SIGNAL_LINE}" "${WORK}/flood.stderr")"
+
+assert_succeeds 'and the remainder is counted, not dropped silently' \
+  grep -qF 'and 5 more, in' "${WORK}/flood.stderr"
+
+assert_succeeds 'the total is reported' \
+  grep -qF '25 unacknowledged' "${WORK}/flood.stderr"
+
 printf '\n== operational errors\n'
 
 # An unreadable journal must not be reported as "no rebuild": the run could not
 # answer the question, which is exit 2 everywhere else in auberge.
 assert_eq 'an unreadable journal exits 2' '2' "$(run_case unreadable 1)"
 assert_eq 'and writes no latch' '' "$(latch_of unreadable)"
+
+# The journal is staged through a file to bound the unbounded first read. It is
+# scratch, not state: a leftover would be grepped again on the next tick.
+assert_fails 'the journal scratch file is not left behind on failure' \
+  test -e "${WORK}/state/unreadable/journal.scratch"
+
+assert_fails 'nor on success' test -e "${WORK}/state/detect/journal.scratch"
 
 assert_eq 'a rebuild latches' '1' "$(run_case both 0 "${SIGNAL_LINE}")"
 assert_eq 'an unreadable journal then outranks the latch' '2' "$(run_case both 1)"

--- a/tests/bichon-uidvalidity-watch.test.sh
+++ b/tests/bichon-uidvalidity-watch.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# tests/bichon-uidvalidity-watch.test.sh
+#
+# Unit tests for the Rebuild Latch: the journal watcher that reports a Bichon
+# mailbox cache rebuild and keeps reporting it until an operator acknowledges
+# (ADR-0014).
+#
+# No journal, no systemd, no Bichon — journalctl is a stub on PATH whose output
+# and exit code each case stages. The properties worth pinning are the ones a
+# live test could not reproduce on demand: that the latch survives a run which
+# reads nothing new (systemd would otherwise clear the failed state on the next
+# tick), and that an unreadable journal is not reported as "no rebuild".
+#
+# Run: ./tests/bichon-uidvalidity-watch.test.sh
+
+set -euo pipefail
+
+SUITE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname -- "${SUITE_DIR}")"
+readonly SUITE_DIR REPO_ROOT
+readonly SCRIPT="${REPO_ROOT}/ansible/roles/bichon/files/bichon-uidvalidity-watch.sh"
+
+# shellcheck source=./assert.sh disable=SC1091
+source "${SUITE_DIR}/assert.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+readonly BIN="${WORK}/bin"
+readonly STUB_OUT="${WORK}/journal.out"
+readonly STUB_RC="${WORK}/journal.rc"
+readonly STUB_ARGS="${WORK}/journal.args"
+
+mkdir -p "${BIN}" "${WORK}/state"
+cat >"${BIN}/journalctl" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"${STUB_ARGS}"
+cat "${STUB_OUT}"
+exit "\$(cat "${STUB_RC}")"
+STUB
+chmod 0755 "${BIN}/journalctl"
+export PATH="${BIN}:${PATH}"
+
+# One journal line as journalctl --output=short-iso-precise renders it. Bichon
+# formats the uid values with {:#?}, so the entry continues onto the lines staged
+# after it in the multiline case below; the mailbox name and the timestamp are
+# both on this one.
+readonly SIGNAL_LINE="2026-07-30T09:14:02.117431+0000 vps bichon[811]: Account 1: Mailbox 'INBOX' detected with changed uid_validity (local: Some("
+
+stage_journal() {
+  local rc="$1" line
+  shift
+  : >"${STUB_OUT}"
+  for line in "$@"; do printf '%s\n' "${line}" >>"${STUB_OUT}"; done
+  printf '%s' "${rc}" >"${STUB_RC}"
+}
+
+# Runs the watcher against ${WORK}/state/<name>, printing its exit status.
+# Re-running the same name reuses that state dir, which is how the latch and
+# cursor are carried between ticks.
+run_case() {
+  local name="$1" rc="$2"
+  shift 2
+  stage_journal "${rc}" "$@"
+  local status=0
+  BICHON_UIDVALIDITY_STATE_DIR="${WORK}/state/${name}" \
+    bash "${SCRIPT}" >/dev/null 2>>"${WORK}/${name}.stderr" || status=$?
+  printf '%s' "${status}"
+}
+
+# As run_case, against a journal held quiet, for a unit other than the default.
+watch_unit() {
+  local name="$1" unit="$2"
+  stage_journal 0
+  local status=0
+  BICHON_UIDVALIDITY_STATE_DIR="${WORK}/state/${name}" \
+    BICHON_UIDVALIDITY_UNIT="${unit}" \
+    bash "${SCRIPT}" >/dev/null 2>>"${WORK}/${name}.stderr" || status=$?
+  printf '%s' "${status}"
+}
+
+latch_of() {
+  local latch="${WORK}/state/${1}/rebuilds.log"
+  [[ -f "${latch}" ]] || return 0
+  cat "${latch}"
+}
+
+printf '== a clean journal\n'
+
+assert_eq 'unremarkable entries exit 0' '0' \
+  "$(run_case quiet 0 'Account 1: sync finished, 12 new envelopes')"
+
+assert_eq 'and write no latch' '' "$(latch_of quiet)"
+
+assert_eq 'an empty journal exits 0' '0' "$(run_case empty 0)"
+
+printf '\n== a detected rebuild\n'
+
+assert_eq 'the signal exits 1' '1' \
+  "$(run_case detect 0 'Account 1: sync started' "${SIGNAL_LINE}")"
+
+assert_eq 'the matching line is latched verbatim' "${SIGNAL_LINE}" "$(latch_of detect)"
+
+assert_eq 'the continuation lines of the entry are not latched' '1' \
+  "$(
+    run_case multiline 0 "${SIGNAL_LINE}" '    1758268301,' '), remote: Some(' '    1758268999,' ')' \
+      >/dev/null
+    latch_of multiline | wc -l
+  )"
+
+assert_eq 'two rebuilds in one run are both latched' '2' \
+  "$(
+    run_case pair 0 "${SIGNAL_LINE}" 'Account 1: unrelated' "${SIGNAL_LINE}" >/dev/null
+    latch_of pair | wc -l
+  )"
+
+printf '\n== the latch\n'
+
+# The property the whole design turns on. systemd clears a unit's failed state on
+# the next successful start, so a run that reads nothing new must still fail, or
+# the hourly tick after a rebuild would erase the alert.
+assert_eq 'a rebuild latches' '1' "$(run_case persist 0 "${SIGNAL_LINE}")"
+assert_eq 'a later run reading nothing new still fails' '1' "$(run_case persist 0)"
+assert_eq 'without duplicating the latched line' '1' "$(latch_of persist | wc -l)"
+
+rm "${WORK}/state/persist/rebuilds.log"
+assert_eq 'deleting the latch acknowledges the alert' '0' "$(run_case persist 0)"
+
+printf '\n== operational errors\n'
+
+# An unreadable journal must not be reported as "no rebuild": the run could not
+# answer the question, which is exit 2 everywhere else in auberge.
+assert_eq 'an unreadable journal exits 2' '2' "$(run_case unreadable 1)"
+assert_eq 'and writes no latch' '' "$(latch_of unreadable)"
+
+assert_eq 'a rebuild latches' '1' "$(run_case both 0 "${SIGNAL_LINE}")"
+assert_eq 'an unreadable journal then outranks the latch' '2' "$(run_case both 1)"
+assert_succeeds 'but the latch is still reported' \
+  grep -qF 'MAILBOX CACHE REBUILD DETECTED' "${WORK}/both.stderr"
+
+printf '\n== invocation\n'
+
+assert_eq 'a missing state dir is a usage error, not a silent pass' '1' \
+  "$(
+    status=0
+    env -u BICHON_UIDVALIDITY_STATE_DIR bash "${SCRIPT}" >/dev/null 2>&1 || status=$?
+    printf '%s' "${status}"
+  )"
+
+assert_succeeds 'the journal is read from a cursor file' \
+  grep -qF -- "--cursor-file=${WORK}/state/detect/cursor" "${STUB_ARGS}"
+
+assert_succeeds 'the read is scoped to one unit' \
+  grep -qF -- '--unit=bichon.service' "${STUB_ARGS}"
+
+assert_eq 'the watched unit is overridable' '0' \
+  "$(watch_unit override bichon-test.service)"
+
+assert_succeeds 'and the override reaches journalctl' \
+  grep -qF -- '--unit=bichon-test.service' "${STUB_ARGS}"
+
+report 'bichon-uidvalidity-watch'


### PR DESCRIPTION
A `UIDVALIDITY` change makes Bichon delete a folder's envelopes and blobs and refetch. Mail already expunged upstream cannot be refetched — searchability and tags for it are gone. Bichon logged this at info level and carried on; nothing noticed. Now an hourly timer does, and a purge shows up as a failed unit in `systemctl --failed` and Cockpit → Services.

The alert is **latched**: reported on every run until the operator deletes the latch file. That is the whole design constraint — systemd clears a unit's failed state on the next successful start, so an exit code alone would erase the alert within the hour, against a hazard whose failure mode is measured in weeks. Deleting the file is both the acknowledgement and the record that someone saw it.

No new config keys, no credential, no egress. Closes #386.

> [!NOTE]
> Passive by design. Nothing reaches your phone — Telegram was rejected on scope, since `meta/roadmap.md` still carries "Alerting (via email or webhook)" as an unbuilt cross-cutting item and a bichon-specific sender would be the thing that design has to unpick. The latch composes with a push if one is ever built: one file, one unit state.

### Still relevant? Yes

| Check | Finding |
| --- | --- |
| Signal exists in deployed version | `0.3.7` → `src/modules/cache/imap/sync/flow.rs:283` |
| And at upstream HEAD | `crates/core/src/cache/imap/download/flow.rs:491` — the workspace re-crate refactor moved the file and left the string byte-identical |
| Emitted before the damage | logged before `rebuild_mailbox_cache`, so it names the folder about to be purged |
| Reachable as deployed | `bichon_log_level` defaults to `info` |
| Anything already detecting it? | No journal watcher anywhere; alerting is still an unbuilt roadmap item |
| Twin issue #384 | closed as "filed under the wrong account", not resolved |

### Anchors

| Concern | File |
| --- | --- |
| Detection, latch, report | `ansible/roles/bichon/files/bichon-uidvalidity-watch.sh` |
| Journal read privilege | `templates/bichon-uidvalidity-watch.service.j2` |
| 29 assertions | `tests/bichon-uidvalidity-watch.test.sh` |
| Decision record | `meta/adr/0014-uidvalidity-rebuild-alert-is-a-latched-failing-unit.md` |
| Operator runbook | `docs/applications/apps/bichon.md` |

Exit codes reuse the *Backup Verdict* convention: `0` no rebuild, `1` recorded and unacknowledged, `2` the journal could not be read. The third is load-bearing — a watch that cannot read the journal must not report "no rebuild".

Runs as `bichon` with `SupplementaryGroups=systemd-journal`, not root: `bichon.service` is a system unit, so journald writes its entries to the system journal, readable only by root, `adm` and `systemd-journal`. Deliberately **no** `Requires=bichon.service` (unlike `bichon-archive.service`, which calls its API) — the watch must still republish a latched rebuild while bichon is down, which is when an operator is looking.

### Two findings from testing against a live 309k-line journal

Both fixed in `bd05ca2`, both invisible to the unit tests:

- The first read is unbounded — no cursor exists yet — and buffering it in a shell variable cost tens of MB for one grep. Now staged through a file; later runs are cursor-bounded to one tick.
- A probe against a deliberately common pattern latched 8,928 lines and echoed all of them. Since the report republishes hourly, that would spam the journal this unit exists to keep readable. Now echoes 20 and counts the rest.

> [!IMPORTANT]
> `journalctl --grep` would push the filter server-side and remove the staging file. It is wrong here: it exits `1` when nothing matched, the same status an unreadable or misnamed unit returns, so a renamed `bichon.service` would read as "no rebuild" forever. Verified that `--cursor-file` *does* advance even when `--grep` shows nothing, so the cursor is not what rules it out — the exit-code collision is.

### Test plan

- [x] 29 assertions, `journalctl` stubbed — latch persistence across a no-op run, exit-2 precedence over a latch, report cap, scratch cleanup, cursor and unit scoping
- [x] 73 assertions across all three shell suites
- [x] End-to-end against a real system journal with a substituted signal: detect → latch → republish on a run reading nothing new → acknowledge → exit 0, scratch cleaned
- [x] Real-`journalctl` assumptions confirmed: `--cursor-file` created and advanced, `--quiet` still emits entries, `short-iso-precise` matches the test fixture format
- [x] `systemd-analyze verify` on the rendered units; `ansible-lint` production profile; `shellcheck` + `shfmt`; ADR numbering check
- [ ] Live deploy — first run reports rebuilds already in the retained journal, which is deliberate (documented) and worth eyeballing once

> [!WARNING]
> The grep target is upstream prose. It survived a whole-workspace refactor, but a reworded log line silently disables the watch, and the failure mode is a unit that keeps passing. Nothing detects that — a canary would need a real rebuild to test against. Recorded as a negative consequence in ADR-0014.

`feat` rather than `refactor` deliberately: ansible assets only re-extract on a version bump, so this needs a release to reach a Host.
