### PR TITLE
fix(cockpit): mask networkd wait-online under NetworkManager renderer

### DIFF
--- a/ansible/roles/cockpit/tasks/main.yml
+++ b/ansible/roles/cockpit/tasks/main.yml
@@ -156,6 +156,27 @@
           retries: 24
           delay: 5
 
+    - name: Neutralise networkd wait-online under the NetworkManager renderer
+      # With the NetworkManager renderer, netplan emits NM profiles instead of
+      # networkd .network files, so networkd manages no links and wait-online never
+      # sees a routable interface. It times out after 120s, leaving the host
+      # permanently degraded and delaying every Wants=network-online.target unit
+      # (caddy, gokapi, headscale, colporteur) by two minutes on each boot.
+      # Masking stops future runs; masking alone does not clear an existing
+      # failure, so reset-failed is needed to bring the host out of degraded.
+      when: cockpit_configure_nm_renderer and cockpit_netplan_bin.stat.exists
+      block:
+        - name: Mask systemd-networkd-wait-online
+          ansible.builtin.systemd_service:
+            name: systemd-networkd-wait-online.service
+            masked: true
+          register: cockpit_wait_online
+
+        - name: Clear systemd-networkd-wait-online failed state
+          ansible.builtin.command: systemctl reset-failed systemd-networkd-wait-online.service
+          when: cockpit_wait_online.status.ActiveState == 'failed'
+          changed_when: true
+
     - name: Validate Cloudflare API token for Caddy DNS-01 challenge
       ansible.builtin.assert:
         that:


### PR DESCRIPTION
Cockpit's NetworkManager renderer left `systemd-networkd-wait-online` failing on every run. The host sat permanently `degraded` — masking any genuine unit failure behind it — and six units ordered after `network-online.target` started ~2 minutes late on each boot.

Already deployed and verified on `auberge`: `is-system-running` went `degraded` → `running`, `systemctl --failed` is now empty.

### Cause

`roles/cockpit/tasks/main.yml` writes `/etc/netplan/99-nm-renderer.yaml` to switch netplan's renderer to NetworkManager, fixing PackageKit's offline detection on Cockpit's updates page. Netplan then emits NM profiles instead of networkd `.network` files, so `systemd-networkd` manages zero links — `networkctl` showed every link `unmanaged`, with NM owning `ens6`. Nothing disabled `systemd-networkd-wait-online`, so it kept waiting for a `routable` link that could never appear, timing out and exiting 1.

Three occurrences on record, each exactly the 120s default timeout:

| Started (UTC) | Failed | Δ |
| --- | --- | --- |
| 2026-05-18 10:36:03 | 10:38:03 | 120s |
| 2026-06-20 16:27:39 | 16:29:39 | 120s |
| 2026-08-03 07:06:12 | 07:08:13 | 121s |

Units delayed behind `network-online.target`: `caddy`, `gokapi`, `headscale`, `colporteur`, `cloud-config`, `cloud-final`.

### Fix

Mask the unit, then `reset-failed`, gated on the same `cockpit_configure_nm_renderer` condition as the renderer switch.

> [!NOTE]
> `mask`, not `disable` — `disable` only drops the `WantedBy=` symlink, which systemd packaging can restore on upgrade.

Two behaviours verified rather than assumed:

| Assumption | How tested | Result |
| --- | --- | --- |
| `systemctl stop` clears a failed oneshot | throwaway `--user` unit | **False** — masking alone leaves the host degraded until reboot, hence the explicit `reset-failed` |
| `systemd_service` returns `status.ActiveState` | ad-hoc module call | True — so the `when` guard is real; dropped a `default('')` that would have silently skipped the reset |

### Test plan

- [x] `ansible-lint` passes at the `production` profile
- [x] Deployed to `auberge` — `hardening`, `infrastructure`, `apps(cockpit)` all succeeded
- [x] `is-system-running`: `degraded` → `running`; `systemctl --failed` empty
- [x] Unit reports `masked` / `inactive`
- [x] `caddy`, `gokapi`, `headscale`, `cockpit.socket` active; `ens6` still connected
- [ ] Removal of the ~2-min boot delay — needs a reboot; uptime runs to 2026-05-18

> [!WARNING]
> The mask is one-directional. If `cockpit_configure_nm_renderer` ever reverts to `false`, the mask persists and `wait-online` stays masked under a networkd renderer, where it would be doing useful work. Kept the diff minimal rather than adding an unmask branch.

> [!IMPORTANT]
> `fix` is release-triggering for release-plz, so merging cuts a new version.

https://claude.ai/code/session_01G2jpYRss91tbFYanhEpS3C
