### PR TITLE
chore: release v0.14.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.11](https://github.com/sripwoud/auberge/compare/v0.14.10...v0.14.11) - 2026-08-03
+
+### Fixed
+
+- *(cockpit)* mask networkd wait-online under NetworkManager renderer ([#401](https://github.com/sripwoud/auberge/pull/401))
+
+### Other
+
+- *(context)* only a Synced Folder is an eligible expunge target
+- *(examples)* expunge only Synced Folders, asked from reconcile
+- *(examples)* pick the expunge folder from a menu, check it early
+
 ## [0.14.10](https://github.com/sripwoud/auberge/compare/v0.14.9...v0.14.10) - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auberge"
-version = "0.14.10"
+version = "0.14.11"
 dependencies = [
  "ansible-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auberge"
-version = "0.14.10"
+version = "0.14.11"
 edition = "2024"
 description = "CLI tool for managing self-hosted infrastructure with Ansible"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `auberge`: 0.14.10 -> 0.14.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.11](https://github.com/sripwoud/auberge/compare/v0.14.10...v0.14.11) - 2026-08-03

### Fixed

- *(cockpit)* mask networkd wait-online under NetworkManager renderer ([#401](https://github.com/sripwoud/auberge/pull/401))

### Other

- *(context)* only a Synced Folder is an eligible expunge target
- *(examples)* expunge only Synced Folders, asked from reconcile
- *(examples)* pick the expunge folder from a menu, check it early
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).