### PR TITLE
feat(actual): deploy the Actual Budget sync server

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,7 +117,7 @@ The relay-and-blob-store role Actual's server component plays: clients push and 
 _Avoid_: API server, backend, master copy.
 
 **Enable Banking**:
-The PSD2 open-banking aggregator Actual's bank sync uses on this deployment, chosen because GoCardless closed Bank Account Data to new signups in July 2025 (ADR-0016). Covers the operator's bank, C24 (AIS + PIS since October 2024). Configured once in Actual's UI — application ID plus credential file from Enable Banking's control panel; the credentials persist in **Actual**'s `account.sqlite`, inside the Backup Recipe and outside the Key Registry.
+The PSD2 open-banking aggregator Actual's bank sync uses on this deployment, chosen because GoCardless closed Bank Account Data to new signups in July 2025 (ADR-0016). Covers the operator's bank, C24 (AIS + PIS since October 2024). Configured once in Actual's UI — application ID plus credential file from Enable Banking's control panel; the credentials persist in **Actual**'s `account.sqlite`, inside the Backup Recipe and outside the Key Registry. Deliberately outside Actual's end-to-end encryption too: the server performs the bank pulls, so the credentials and in-flight transactions are server-readable by design — E2E protects the budget ledger at rest, not the bank-sync plumbing.
 _Avoid_: bank API (unqualified), Nordigen/GoCardless successor (a distinct product, not a rebrand).
 
 **Progress**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,6 +108,18 @@ _Avoid_: Account sync, account update, account migration.
 A privacy-sanitized iCalendar feed of the operator's busy intervals, derived from the operator's Host-side calendar sources — **Baikal**'s calendar data plus, optionally, a read-only external CalDAV calendar (e.g. iCloud) fetched on the Host — by a host-side script on a systemd timer and served publicly behind a secret token. Contains only opaque `Busy` `VEVENT`s (UTC start/end + a hashed per-instance UID); never event titles, locations, guests, descriptions, or the source UID. Sanitization happens on the Host, so no personal event content (and no external CalDAV credential) ever leaves the VPS — the feed is the privacy boundary. A **Busy Feed** is a tool-agnostic artifact like the **Email Archive**: auberge produces and serves it but does not ship its consumers (see ADR-0010).
 _Avoid_: Free/busy feed (deliberately not a `VFREEBUSY` component — discrete `VEVENT`s carry per-instance UIDs for diffing), calendar sync, availability export.
 
+**Actual**:
+A Tailnet-only App — the Actual Budget **Sync Server**, deployed bare-metal from npm (`@actual-app/sync-server`, exact version pinned in role defaults, Node 22 from NodeSource; ADR-0016). Not the budget's store of record: every Actual client keeps a full local copy and replays change messages through the server. Its on-disk state (`/var/lib/actual`: `server-files/account.sqlite` for server accounts, password, and bank-sync credentials; `user-files/` for budget blobs) is what the Backup Recipe rsyncs — losing it costs the server password and **Enable Banking** credentials, never the budgets themselves.
+_Avoid_: Actual Budget server (say Sync Server), budget database, budget backend.
+
+**Sync Server**:
+The relay-and-blob-store role Actual's server component plays: clients push and pull ordered change messages (optionally end-to-end encrypted, in which case the server cannot read budget contents) and upload whole-budget blobs for bootstrap of new devices. Syncing is convergence, not authority — any client can rebuild the server's copy by re-uploading.
+_Avoid_: API server, backend, master copy.
+
+**Enable Banking**:
+The PSD2 open-banking aggregator Actual's bank sync uses on this deployment, chosen because GoCardless closed Bank Account Data to new signups in July 2025 (ADR-0016). Covers the operator's bank, C24 (AIS + PIS since October 2024). Configured once in Actual's UI — application ID plus credential file from Enable Banking's control panel; the credentials persist in **Actual**'s `account.sqlite`, inside the Backup Recipe and outside the Key Registry.
+_Avoid_: bank API (unqualified), Nordigen/GoCardless successor (a distinct product, not a rebrand).
+
 **Progress**:
 The trait that runners (`AnsibleRunner`, `Recipe Executor`, `Backup Session`) emit events through. `TerminalProgress` is the production impl; tests use a `MockProgress`. Keeps runners free of terminal-output coupling.
 _Avoid_: Logger, reporter
@@ -127,6 +139,7 @@ _Avoid_: Logger, reporter
 - All runners report through **Progress**; none touch terminal output directly.
 - An **App** is either a **Public App** or a **Tailnet-only App**, determined by the `tailnet_only` flag in its **Playbook Meta**. **DNS Publication** is dispatched accordingly.
 - The **Busy Feed** is derived from **Baikal**'s calendar data — plus, optionally, a read-only external CalDAV calendar fetched Host-side — and served on Baikal's **Public App** site (Google's servers must reach it); auberge produces and serves it but ships no consumer.
+- **Actual** relays sync between clients that each hold the full budget; its Backup Recipe path (`/var/lib/actual`) also carries the **Enable Banking** credentials, so restoring it restores bank sync.
 
 ## Example dialogue
 

--- a/ansible/keys.yml
+++ b/ansible/keys.yml
@@ -1,4 +1,12 @@
 keys:
+  actual_subdomain:
+    secret: false
+    doc: "Subdomain for the Actual Budget sync server"
+
+  actual_tailscale_ip:
+    secret: false
+    doc: "Tailscale IP address of the Actual Budget host"
+
   admin_user_email:
     secret: false
     doc: "Email address for the admin user account"

--- a/ansible/playbooks/actual.meta.yml
+++ b/ansible/playbooks/actual.meta.yml
@@ -1,0 +1,7 @@
+required_keys: []
+tailnet_only: true
+subdomain: actual
+backup:
+  systemd_services: [actual]
+  paths: [/var/lib/actual]
+  owner: [actual, actual]

--- a/ansible/playbooks/apps.yml
+++ b/ansible/playbooks/apps.yml
@@ -3,6 +3,8 @@
   hosts: vps
   become: true
   roles:
+    - role: actual
+      tags: [apps, finance, actual]
     - role: baikal
       tags: [apps, storage, caldav, baikal]
     - role: bichon

--- a/ansible/roles/actual/README.md
+++ b/ansible/roles/actual/README.md
@@ -33,6 +33,8 @@ Deploys the [Actual Budget](https://actualbudget.org) sync server (`@actual-app/
 
 Everything lives in `/var/lib/actual`: `server-files/account.sqlite` (server accounts, file registry) and `user-files/` (budget blobs). The Backup Recipe in `actual.meta.yml` stops the unit and rsyncs the whole directory. Losing it does not lose budgets — clients hold full copies and can re-upload — but it does lose the server password and bank-sync credentials.
 
+With end-to-end encryption enabled (Settings → Encryption, client-side key), budget blobs and sync messages are ciphertext on disk and in restic snapshots. The Enable Banking credentials in `account.sqlite` are not covered: the server performs the bank pulls, so they are server-readable by design.
+
 ## Upload limits
 
 Actual enforces its own limits (20 MB files, 50 MB encrypted sync blobs). The Caddy vhost caps request bodies at 100M — above anything Actual accepts, so the cap is never the binding constraint; Caddy is otherwise unlimited by default.

--- a/ansible/roles/actual/README.md
+++ b/ansible/roles/actual/README.md
@@ -1,0 +1,38 @@
+# Actual Ansible Role
+
+Deploys the [Actual Budget](https://actualbudget.org) sync server (`@actual-app/sync-server`) as a bare-metal npm install behind Caddy, reachable only over the tailnet.
+
+## Features
+
+- Sync relay + encrypted blob store for Actual clients (each client keeps a full local copy of the budget)
+- Bank sync via Enable Banking (credentials entered once in the web UI, stored server-side; see ADR-0016)
+- Node.js from NodeSource (Debian trixie ships Node 20; sync-server requires `>=22`)
+- Loopback-only Node process; Caddy binds the Tailscale IP with DNS-01 TLS
+
+## Variables
+
+| Variable             | Default                               | Description                                  |
+| -------------------- | ------------------------------------- | -------------------------------------------- |
+| `actual_sys_user`    | `actual`                              | System user                                  |
+| `actual_sys_group`   | `actual`                              | System group                                 |
+| `actual_port`        | `5006`                                | Local port for Caddy reverse proxy           |
+| `actual_subdomain`   | `actual`                              | Subdomain (operator override in config.toml) |
+| `actual_domain`      | `{{ actual_subdomain }}.{{ domain }}` | Tailnet hostname                             |
+| `actual_install_dir` | `/opt/actual`                         | npm install prefix (root-owned)              |
+| `actual_data_dir`    | `/var/lib/actual`                     | `server-files/` + `user-files/`              |
+| `actual_version`     | `26.8.0`                              | Pinned `@actual-app/sync-server` release     |
+| `actual_node_major`  | `22`                                  | NodeSource major (minors float via apt)      |
+
+## First deploy
+
+1. Open `https://<actual_domain>` from a tailnet device and set the server password (Actual's own onboarding; no headless bootstrap needed — the first visitor claims the server, and the vhost is tailnet-only).
+2. Create or import a budget; add the same server URL + password on other devices to sync.
+3. Bank sync: More → Bank Sync → Set up Enable Banking (Application ID + credential file from enablebanking.com/cp/applications).
+
+## Data & backup
+
+Everything lives in `/var/lib/actual`: `server-files/account.sqlite` (server accounts, file registry) and `user-files/` (budget blobs). The Backup Recipe in `actual.meta.yml` stops the unit and rsyncs the whole directory. Losing it does not lose budgets — clients hold full copies and can re-upload — but it does lose the server password and bank-sync credentials.
+
+## Upload limits
+
+Actual enforces its own limits (20 MB files, 50 MB encrypted sync blobs). The Caddy vhost caps request bodies at 100M — above anything Actual accepts, so the cap is never the binding constraint; Caddy is otherwise unlimited by default.

--- a/ansible/roles/actual/defaults/main.yml
+++ b/ansible/roles/actual/defaults/main.yml
@@ -1,0 +1,10 @@
+actual_sys_user: actual
+actual_sys_group: actual
+actual_port: 5006
+actual_subdomain: actual
+actual_domain: "{{ actual_subdomain }}.{{ domain }}"
+actual_install_dir: /opt/actual
+actual_data_dir: /var/lib/actual
+actual_version: "26.8.0"
+actual_node_major: 22
+actual_nodesource_key_url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key

--- a/ansible/roles/actual/handlers/main.yml
+++ b/ansible/roles/actual/handlers/main.yml
@@ -1,0 +1,10 @@
+- name: Restart actual
+  ansible.builtin.systemd_service:
+    name: actual
+    state: restarted
+    daemon_reload: true
+
+- name: Restart caddy
+  ansible.builtin.systemd_service:
+    name: caddy
+    state: restarted

--- a/ansible/roles/actual/tasks/main.yml
+++ b/ansible/roles/actual/tasks/main.yml
@@ -74,10 +74,29 @@
         filename: nodesource
         state: present
 
+    - name: Pin NodeSource nodejs above the apt role's stable-release pin (nodistro gets 500, stable gets 900)
+      ansible.builtin.copy:
+        content: |
+          Package: nodejs
+          Pin: origin deb.nodesource.com
+          Pin-Priority: 990
+        dest: /etc/apt/preferences.d/nodesource.pref
+        owner: root
+        group: root
+        mode: "0644"
+
     - name: Install Node.js from NodeSource (Debian's nodejs is older than sync-server's engines requirement)
       ansible.builtin.apt:
         name: nodejs
         state: present
+
+    - name: Verify Node.js satisfies sync-server's engines requirement
+      ansible.builtin.command: node --version
+      register: actual_node_version_check
+      changed_when: false
+      failed_when: >-
+        actual_node_version_check.stdout | regex_replace('^v', '')
+        is version(actual_node_major ~ '.0.0', '<')
 
     - name: Install Actual sync server {{ actual_version }}
       community.general.npm:

--- a/ansible/roles/actual/tasks/main.yml
+++ b/ansible/roles/actual/tasks/main.yml
@@ -1,0 +1,113 @@
+---
+- name: Install and configure Actual sync server
+  block:
+    - name: Get Tailscale status
+      ansible.builtin.command: tailscale status --json
+      register: actual_tailscale_status_raw
+      changed_when: false
+      failed_when: false
+
+    - name: Parse Tailscale status
+      ansible.builtin.set_fact:
+        actual_tailscale_status: "{{ actual_tailscale_status_raw.stdout | from_json }}"
+      when: actual_tailscale_status_raw.rc == 0
+      changed_when: false
+
+    - name: Set Tailscale IPv4 fact
+      ansible.builtin.set_fact:
+        actual_tailscale_ip: "{{ actual_tailscale_status.Self.TailscaleIPs | select('match', '^[0-9]+\\.') | first }}"
+      when:
+        - actual_tailscale_status_raw.rc == 0
+        - actual_tailscale_status is defined
+        - actual_tailscale_status.BackendState | default('') == "Running"
+        - actual_tailscale_status.Self is defined
+        - actual_tailscale_status.Self.TailscaleIPs is defined
+        - actual_tailscale_status.Self.TailscaleIPs | select('match', '^[0-9]+\\.') | list | length > 0
+      changed_when: false
+
+    - name: Fail if Tailscale not available
+      ansible.builtin.fail:
+        msg: "Tailscale is not running or no Tailscale IP available. Actual requires Tailscale."
+      when: actual_tailscale_ip is not defined
+
+    - name: Create Actual system group
+      ansible.builtin.group:
+        name: "{{ actual_sys_group }}"
+        system: true
+        state: present
+
+    - name: Create Actual system user
+      ansible.builtin.user:
+        name: "{{ actual_sys_user }}"
+        group: "{{ actual_sys_group }}"
+        shell: /usr/sbin/nologin
+        home: "{{ actual_data_dir }}"
+        create_home: false
+        system: true
+        state: present
+
+    - name: Create Actual data directory
+      ansible.builtin.file:
+        path: "{{ actual_data_dir }}"
+        state: directory
+        owner: "{{ actual_sys_user }}"
+        group: "{{ actual_sys_group }}"
+        mode: "0750"
+
+    - name: Create Actual installation directory
+      ansible.builtin.file:
+        path: "{{ actual_install_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Download NodeSource signing key
+      ansible.builtin.get_url:
+        url: "{{ actual_nodesource_key_url }}"
+        dest: /etc/apt/keyrings/nodesource.asc
+        mode: "0644"
+
+    - name: Add NodeSource apt repository for Node.js {{ actual_node_major }}
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_{{ actual_node_major }}.x nodistro main"
+        filename: nodesource
+        state: present
+
+    - name: Install Node.js from NodeSource (Debian's nodejs is older than sync-server's engines requirement)
+      ansible.builtin.apt:
+        name: nodejs
+        state: present
+
+    - name: Install Actual sync server {{ actual_version }}
+      community.general.npm:
+        name: "@actual-app/sync-server"
+        version: "{{ actual_version }}"
+        path: "{{ actual_install_dir }}"
+        state: present
+      notify: Restart actual
+
+    - name: Deploy Actual systemd service file
+      ansible.builtin.template:
+        src: templates/actual.service.j2
+        dest: /etc/systemd/system/actual.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart actual
+
+    - name: Enable and start Actual service
+      ansible.builtin.systemd_service:
+        name: actual
+        enabled: true
+        state: started
+        daemon_reload: true
+
+    - name: Deploy Actual Caddyfile
+      ansible.builtin.template:
+        src: templates/actual.caddyfile.j2
+        dest: "/etc/caddy/sites/{{ actual_domain }}.caddyfile"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart caddy

--- a/ansible/roles/actual/templates/actual.caddyfile.j2
+++ b/ansible/roles/actual/templates/actual.caddyfile.j2
@@ -1,0 +1,11 @@
+{{ actual_domain }} {
+	bind {{ actual_tailscale_ip }}
+	tls {
+		dns cloudflare {env.CLOUDFLARE_DNS_API_TOKEN}
+	}
+	reverse_proxy 127.0.0.1:{{ actual_port }}
+
+	request_body {
+		max_size 100M
+	}
+}

--- a/ansible/roles/actual/templates/actual.service.j2
+++ b/ansible/roles/actual/templates/actual.service.j2
@@ -1,0 +1,30 @@
+[Unit]
+Description=Actual Budget sync server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ actual_sys_user }}
+Group={{ actual_sys_group }}
+WorkingDirectory={{ actual_data_dir }}
+Environment=ACTUAL_HOSTNAME=127.0.0.1
+Environment=ACTUAL_PORT={{ actual_port }}
+Environment=ACTUAL_DATA_DIR={{ actual_data_dir }}
+Environment=ACTUAL_TRUSTED_PROXIES=127.0.0.1/32
+ExecStart={{ actual_install_dir }}/node_modules/.bin/actual-server
+Restart=on-failure
+RestartSec=10s
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectControlGroups=true
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ReadWritePaths={{ actual_data_dir }}
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target

--- a/meta/adr.md
+++ b/meta/adr.md
@@ -23,6 +23,7 @@ One number, one file. Every file in `meta/adr/` is listed here; a number that ap
 | 0013 | [Archive message identity is the Message-ID, read from the body](./adr/0013-archive-message-identity-is-the-message-id.md)           |
 | 0014 | [The UIDVALIDITY rebuild alert is a latched failing unit](./adr/0014-uidvalidity-rebuild-alert-is-a-latched-failing-unit.md)         |
 | 0015 | [The Archive publishes a downloaded body only if it is a message](./adr/0015-archive-publishes-a-body-only-if-it-is-a-message.md)    |
+| 0016 | [Actual deploys bare-metal from npm; bank sync uses Enable Banking](./adr/0016-actual-bare-metal-npm-enable-banking.md)              |
 
 ## No Docker
 

--- a/meta/adr/0016-actual-bare-metal-npm-enable-banking.md
+++ b/meta/adr/0016-actual-bare-metal-npm-enable-banking.md
@@ -1,0 +1,45 @@
+# ADR-0016: Actual deploys bare-metal from npm; bank sync uses Enable Banking
+
+## Status
+
+Accepted, 2026-08-03.
+
+## Context
+
+Actual Budget's sync server is distributed two ways: a Docker image and the npm package `@actual-app/sync-server`. Auberge's No-Docker decision (see `meta/adr.md`) leaves npm as the only upstream channel — there is no standalone binary or `.deb` to mirror the navidrome/gokapi install patterns.
+
+Two sub-decisions follow from picking npm:
+
+1. **Node runtime.** sync-server 26.8.0 declares `engines: node >=22`. Debian trixie's apt ships nodejs 20.19 — installing `nodejs`/`npm` from Debian (the `claude_code` role's approach) cannot run the package.
+2. **Version resolution.** The repo has two precedents: navidrome re-resolves the GitHub _latest_ release on every deploy; gokapi pins an exact version plus a sha256 in role defaults.
+
+Separately, bank sync needs a PSD2 aggregator. Actual supports GoCardless, SimpleFIN, Pluggy, and Enable Banking — but GoCardless Bank Account Data stopped accepting new accounts in July 2025 (Actual's own docs: "GoCardless has stopped accepting accounts for this service"), SimpleFIN is US-only, and Pluggy is Brazil-only.
+
+## Decision
+
+- Install `@actual-app/sync-server` at an exact pinned version (role default `actual_version`) into `/opt/actual` via `community.general.npm` with `path`, not `global`.
+- Node comes from the NodeSource `node_22.x` apt repository. The major is pinned by the repo URL; minor/patch security updates flow through normal `apt upgrade`.
+- Bank sync uses Enable Banking. Its application credentials are entered once in Actual's web UI and persist in the sync server's `account.sqlite` — inside the Backup Recipe, outside the Key Registry. Auberge ships no bank credentials.
+
+## Consequences
+
+**Positive:**
+
+- Reproducible deploys: the same role revision installs the same bytes. npm's registry integrity (sha512 + provenance attestation on this package) plays the role gokapi's sha256 pin plays for GitHub archives.
+- Upgrades are deliberate one-line bumps of `actual_version` — wanted for a finance app whose CalVer monthlies can break between releases, and consistent with how a version bump (not a re-deploy) is what triggers reinstall.
+- Enable Banking is the only self-serve option still open to new EU users, is natively supported by sync-server (`app-enablebanking` module), and covers C24 (AIS + PIS integrations since Enable Banking's October 2024 changelog).
+
+**Negative:**
+
+- A NodeSource outage or repo removal blocks first deploys (not restarts). Accepted: same class of third-party-repo risk as Caddy's cloudsmith repo.
+- Node 22 lands on the host for one app. Accepted: ~60 MB, no daemon.
+- Actual flags Enable Banking support as experimental and reserves the right to remove it. Mitigated: bank sync is an enrichment, not the budget's source of truth — manual import always works.
+- No sha256 in role defaults (npm has no stable artifact URL to checksum). Registry-level integrity + provenance is the substitute.
+
+## Alternatives considered
+
+- **Debian's nodejs + npm packages** (claude_code precedent). Rejected: trixie ships 20.19, below the `engines` floor; apt `npm` would also drag in Debian's nodejs alongside NodeSource's.
+- **GitHub-latest-release resolution** (navidrome precedent) via `dist-tags/latest`. Rejected: every deploy could silently jump a CalVer monthly; a budget server should not pick up breaking releases as a side effect of an unrelated deploy.
+- **`npm install --global`.** Rejected: scatters the app into `/usr/lib/node_modules`, couples it to the Node package's own upgrade cycle, and breaks the `/opt/<app>` install-dir convention every other role follows.
+- **GoCardless for bank sync.** Rejected: closed to new signups since July 2025; no account can be created for this deployment.
+- **SimpleFIN / Pluggy.** Rejected: US-only / Brazil-only; the operator's bank (C24) is German.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -54,7 +54,7 @@ pub enum BackupCommands {
             short,
             long,
             value_delimiter = ',',
-            help = "Apps to backup (baikal,bichon,freshrss,gokapi,headscale,navidrome,calibre,yourls,paperless). Default: all"
+            help = "Apps to backup (actual,baikal,bichon,freshrss,gokapi,headscale,navidrome,calibre,yourls,paperless). Default: all"
         )]
         apps: Option<Vec<String>>,
         #[arg(short, long, help = "Backup destination directory")]
@@ -81,7 +81,7 @@ pub enum BackupCommands {
             short,
             long,
             value_delimiter = ',',
-            help = "Apps to backup (baikal,bichon,freshrss,gokapi,headscale,navidrome,calibre,yourls,paperless). Default: all"
+            help = "Apps to backup (actual,baikal,bichon,freshrss,gokapi,headscale,navidrome,calibre,yourls,paperless). Default: all"
         )]
         apps: Option<Vec<String>>,
         #[arg(
@@ -130,7 +130,7 @@ pub enum BackupCommands {
             short,
             long,
             value_delimiter = ',',
-            help = "Apps to restore (baikal,bichon,freshrss,gokapi,headscale,navidrome,calibre,yourls,paperless). Default: all"
+            help = "Apps to restore (actual,baikal,bichon,freshrss,gokapi,headscale,navidrome,calibre,yourls,paperless). Default: all"
         )]
         apps: Option<Vec<String>>,
         #[arg(

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -159,6 +159,26 @@ mod tests {
     }
 
     #[test]
+    fn test_actual_meta_backup_recipe() {
+        let backup = load_meta("actual").backup.unwrap();
+        assert_eq!(backup.systemd_services, vec!["actual"]);
+        assert_eq!(backup.paths, vec!["/var/lib/actual"]);
+        assert_eq!(
+            backup.owner,
+            Some(("actual".to_string(), "actual".to_string()))
+        );
+        assert!(backup.db.is_none());
+    }
+
+    #[test]
+    fn test_actual_meta_is_tailnet_only() {
+        let meta = load_meta("actual");
+        assert!(meta.tailnet_only);
+        assert_eq!(meta.subdomain.as_deref(), Some("actual"));
+        assert!(meta.required_keys.is_empty());
+    }
+
+    #[test]
     fn test_baikal_meta_backup_recipe() {
         let backup = load_meta("baikal").backup.unwrap();
         assert_eq!(backup.paths, vec!["/opt/baikal/Specific"]);

--- a/src/services/backup/recipe.rs
+++ b/src/services/backup/recipe.rs
@@ -76,6 +76,7 @@ mod tests {
     fn test_discover_backuppable_apps_returns_expected_set() {
         let apps = discover_backuppable_apps(&project_playbooks_dir()).unwrap();
         let expected: Vec<String> = [
+            "actual",
             "baikal",
             "bichon",
             "calibre",


### PR DESCRIPTION
Actual Budget's sync server joins the tailnet-only fleet: \`argent.<domain>\`, published via Blocky, invisible in public DNS, backed up by recipe. Bank sync uses Enable Banking — the only PSD2 aggregator still open to new EU signups (GoCardless closed July 2025) — and covers C24. Deployed and verified live on auberge.

## Engineering

| Piece | Detail |
| ----- | ------ |
| Role | \`@actual-app/sync-server\` pinned \`26.8.0\`, npm-installed into \`/opt/actual\` |
| Node | NodeSource 22 (\`engines >=22\`; trixie apt ships 20.19) + apt pin at 990 to beat the apt role's stable=900 pin |
| Unit | loopback-only (\`ACTUAL_HOSTNAME=127.0.0.1\`), trusted proxies narrowed to the Caddy hop, gokapi-grade hardening |
| Caddy | Tailscale-IP bind, DNS-01 TLS, \`request_body\` 100M (Actual's own limits top out at 50 MB) |
| Meta | \`tailnet_only: true\`, backup recipe \`{actual, /var/lib/actual, actual:actual}\` |
| CLI | zero new commands — deploy tags, backup discovery, DNS verify all pick the app up from meta; only stale \`--apps\` help strings touched |
| Docs | ADR-0016 (npm pin + NodeSource + Enable Banking rationale), CONTEXT.md glossary (Actual, Sync Server, Enable Banking) |

## Test plan

- [x] \`cargo test\` — 437 passed (2 new meta tests)
- [x] \`ansible-lint\` production profile clean
- [x] Live deploy: unit \`active\`, ~45 MB cgroup RSS, HTTP 200 loopback
- [x] \`argent.sripwoud.xyz\` → HTTPS 200 over tailnet, valid LE cert
- [x] Public DNS leak check: 0 answers from 1.1.1.1 (ADR-0003 holds)
- [x] Backup recipe: \`backup create -a actual\` stops unit → rsyncs → restarts (68.84 KB)
- [ ] First budget sync from a second device (operator-side)

> [!NOTE]
> First deploy on a host that ran the earlier broken attempt: Debian's nodejs 20.19 was purged manually before the pinned rerun; fresh hosts converge in one pass. A fail-fast task now rejects any host whose node < \`actual_node_major\`.

https://claude.ai/code/session_011DhkbDVmcjfTBahgvSTnPe