### PR TITLE
build(renovate): automate Pinned version bumps in role defaults

### DIFF
--- a/.github/scripts/recompute-checksums.sh
+++ b/.github/scripts/recompute-checksums.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# recompute-checksums.sh — recompute co-pinned sha256 literals after a bump.
+#
+# Renovate bumps a version variable but cannot know the new release asset's
+# digest, and fetching an upstream checksum file is not an option: gokapi
+# publishes none (its digest was computed by hand), and a checksum fetched
+# alongside the asset proves nothing — an attacker who can swap the asset can
+# swap the checksum file beside it. So this script downloads the asset and
+# computes the digest itself.
+#
+# A digest variable <prefix>_sha256 / <prefix>_checksum pairs with the
+# <prefix>_url variable in the same defaults file. The digest is recomputed
+# only when the rendered URL changed against the base ref: the URL is a pure
+# function of the file's own variables, so an unchanged URL means the digest
+# must not move — its immutability after merge is what detects an upstream
+# re-tag (ADR-0017).
+#
+# Exit codes:
+#   0 — every stale digest recomputed (files modified in place) or none stale
+#   1 — a URL failed to render or an asset failed to download
+#
+# Usage:
+#   ./.github/scripts/recompute-checksums.sh origin/master
+
+set -euo pipefail
+
+WORKDIR="$(mktemp -d)"
+readonly WORKDIR
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+emit_error() {
+  local message="${1}"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::error::${message}" >&2
+  else
+    echo "error: ${message}" >&2
+  fi
+}
+
+# Substitute {{ var }} references with assignments found in the same file.
+render_url() {
+  local file="${1}" value="${2}"
+  local iterations=0 var sub
+  while [[ "${value}" == *'{{'* ]]; do
+    if ((iterations >= 10)); then
+      emit_error "unresolved template after 10 passes: ${value}"
+      return 1
+    fi
+    iterations=$((iterations + 1))
+    var="$(grep -oP '\{\{ \K[a-z0-9_]+(?= \}\})' <<<"${value}" | head -1 || true)"
+    if [[ -z "${var}" ]]; then
+      emit_error "cannot parse template reference in: ${value}"
+      return 1
+    fi
+    sub="$(grep -oP "^${var}: \"?\K[^\"]+" "${file}" | head -1 || true)"
+    if [[ -z "${sub}" ]]; then
+      emit_error "cannot resolve {{ ${var} }} from ${file}"
+      return 1
+    fi
+    value="${value//"{{ ${var} }}"/${sub}}"
+  done
+  printf '%s\n' "${value}"
+}
+
+# Extract the raw (unrendered) value of a variable from a defaults file.
+raw_value() {
+  local file="${1}" var="${2}"
+  grep -oP "^${var}: \"?\K[^\"]+" "${file}" | head -1 || true
+}
+
+recompute_digest() {
+  local file="${1}" base_file="${2}" var_name="${3}" old_digest="${4}"
+  local url_var="${var_name%_*}_url"
+  local head_tmpl head_url base_tmpl base_url new_digest asset
+
+  head_tmpl="$(raw_value "${file}" "${url_var}")"
+  if [[ -z "${head_tmpl}" ]]; then
+    emit_error "${file}: ${var_name} has no paired ${url_var}"
+    return 1
+  fi
+  head_url="$(render_url "${file}" "${head_tmpl}")" || return 1
+
+  if [[ -n "${base_file}" ]]; then
+    base_tmpl="$(raw_value "${base_file}" "${url_var}")"
+    if [[ -n "${base_tmpl}" ]]; then
+      base_url="$(render_url "${base_file}" "${base_tmpl}")" || base_url=""
+      if [[ "${base_url}" == "${head_url}" ]]; then
+        echo "${file}: ${url_var} unchanged, leaving ${var_name} alone"
+        return 0
+      fi
+    fi
+  fi
+
+  asset="${WORKDIR}/asset"
+  if ! curl -fsSL --retry 3 --retry-delay 5 -o "${asset}" "${head_url}"; then
+    emit_error "${file}: failed to download ${head_url}"
+    return 1
+  fi
+  new_digest="$(sha256sum "${asset}" | cut -d' ' -f1)"
+
+  if [[ "${new_digest}" == "${old_digest}" ]]; then
+    echo "${file}: ${var_name} already matches ${head_url}"
+    return 0
+  fi
+
+  sed -i -E "s|^(${var_name}: .*)${old_digest}|\1${new_digest}|" "${file}"
+  echo "${file}: ${var_name} ${old_digest:0:8}… -> ${new_digest:0:8}… (${head_url})"
+}
+
+process_file() {
+  local base_ref="${1}" file="${2}"
+  local status=0 base_file line var_name old_digest
+
+  base_file="${WORKDIR}/base-$(basename "$(dirname "$(dirname "${file}")")")"
+  if ! git show "${base_ref}:${file}" >"${base_file}" 2>/dev/null; then
+    base_file=""
+  fi
+
+  while IFS= read -r line; do
+    var_name="${line%%:*}"
+    old_digest="$(grep -oP '[0-9a-f]{64}' <<<"${line}")"
+    recompute_digest "${file}" "${base_file}" "${var_name}" "${old_digest}" \
+      || status=1
+  done < <(grep -E '^[a-z0-9_]+_(sha256|checksum): "(sha256:)?[0-9a-f]{64}"$' "${file}" || true)
+  return "${status}"
+}
+
+main() {
+  local base_ref="${1:?usage: recompute-checksums.sh <base-ref>}"
+  local status=0 file
+  while IFS= read -r file; do
+    process_file "${base_ref}" "${file}" || status=1
+  done < <(git diff --name-only "${base_ref}...HEAD" -- 'ansible/roles/*/defaults/main.yml')
+  exit "${status}"
+}
+
+main "$@"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,6 +20,7 @@ jobs:
           files: |
             .github/workflows/master.yml
             src/**/*.rs
+            tests/**/*.rs
             Cargo.toml
             Cargo.lock
             ansible/**

--- a/.github/workflows/renovate-checksums.yml
+++ b/.github/workflows/renovate-checksums.yml
@@ -1,0 +1,39 @@
+name: renovate-checksums
+# Renovate bumps version variables but cannot recompute the co-pinned sha256
+# literals next to them. This job downloads the bumped asset, computes the
+# digest (some upstreams, e.g. gokapi, publish no checksum file at all), and
+# pushes the fix onto the same branch. A bump whose digest cannot be computed
+# stays red and does not merge. See ADR-0017.
+permissions:
+  contents: write
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  recompute:
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          # A PAT rather than GITHUB_TOKEN: pushes made with GITHUB_TOKEN
+          # trigger no workflows, so the digest commit would sit on the PR
+          # with no CI runs on it.
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Recompute co-pinned checksums
+        run: ./.github/scripts/recompute-checksums.sh "origin/${{ github.base_ref }}"
+
+      - name: Push updated digests
+        run: |
+          if git diff --quiet; then
+            echo "digests unchanged"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "build(deps): recompute co-pinned sha256 digests"
+          git push origin "HEAD:${{ github.head_ref }}"

--- a/ansible/roles/actual/defaults/main.yml
+++ b/ansible/roles/actual/defaults/main.yml
@@ -5,6 +5,7 @@ actual_subdomain: actual
 actual_domain: "{{ actual_subdomain }}.{{ domain }}"
 actual_install_dir: /opt/actual
 actual_data_dir: /var/lib/actual
+# renovate: datasource=npm depName=@actual-app/sync-server
 actual_version: "26.8.0"
 actual_node_major: 22
 actual_nodesource_key_url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key

--- a/ansible/roles/bichon/defaults/main.yml
+++ b/ansible/roles/bichon/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+# renovate: datasource=github-releases depName=rustmailer/bichon
 bichon_version: "0.3.7"
 bichon_port: 15630
 bichon_sys_user: bichon

--- a/ansible/roles/blocky/defaults/main.yml
+++ b/ansible/roles/blocky/defaults/main.yml
@@ -7,6 +7,10 @@ blocky_github_api_latest_release_url: "https://api.github.com/repos/{{ blocky_gi
 blocky_target_arch: "Linux_x86_64"
 blocky_binary_file_extension: "tar.gz"
 
+blocky_lego_version: "4.23.1"
+blocky_lego_url: "https://github.com/go-acme/lego/releases/download/v{{ blocky_lego_version }}/lego_v{{ blocky_lego_version }}_linux_amd64.tar.gz"
+blocky_lego_sha256: "1fd60b1fd59c239bed22719a5de402cb745d1f933540cb1ec196e2c03e6e8882"
+
 blocky_dot_port: 853
 
 blocky_cert_dir: "{{ blocky_config_path }}/certificates"

--- a/ansible/roles/blocky/defaults/main.yml
+++ b/ansible/roles/blocky/defaults/main.yml
@@ -7,6 +7,7 @@ blocky_github_api_latest_release_url: "https://api.github.com/repos/{{ blocky_gi
 blocky_target_arch: "Linux_x86_64"
 blocky_binary_file_extension: "tar.gz"
 
+# renovate: datasource=github-releases depName=go-acme/lego extractVersion=^v(?<version>.+)$
 blocky_lego_version: "4.23.1"
 blocky_lego_url: "https://github.com/go-acme/lego/releases/download/v{{ blocky_lego_version }}/lego_v{{ blocky_lego_version }}_linux_amd64.tar.gz"
 blocky_lego_sha256: "1fd60b1fd59c239bed22719a5de402cb745d1f933540cb1ec196e2c03e6e8882"

--- a/ansible/roles/blocky/tasks/main.yml
+++ b/ansible/roles/blocky/tasks/main.yml
@@ -24,11 +24,11 @@
 
 - name: Download Lego binary
   ansible.builtin.get_url:
-    url: "https://github.com/go-acme/lego/releases/download/v4.23.1/lego_v4.23.1_linux_amd64.tar.gz"
+    url: "{{ blocky_lego_url }}"
     dest: "/tmp/lego.tar.gz"
     mode: "0644"
   args:
-    checksum: "sha256:1fd60b1fd59c239bed22719a5de402cb745d1f933540cb1ec196e2c03e6e8882"
+    checksum: "sha256:{{ blocky_lego_sha256 }}"
 
 - name: Unarchive Lego binary
   ansible.builtin.unarchive:

--- a/ansible/roles/caddy/defaults/main.yml
+++ b/ansible/roles/caddy/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
+# renovate: datasource=go depName=github.com/mholt/caddy-l4
 caddy_l4_version: "v0.1.0"
+# renovate: datasource=go depName=github.com/caddy-dns/cloudflare
 caddy_cloudflare_plugin_version: "v0.2.4"
 
 caddy_binary: /usr/local/bin/caddy

--- a/ansible/roles/colporteur/defaults/main.yml
+++ b/ansible/roles/colporteur/defaults/main.yml
@@ -5,6 +5,7 @@ colporteur_data_dir: /var/lib/colporteur
 colporteur_feeds_dir: /var/lib/colporteur/feeds
 colporteur_config_dir: /etc/colporteur
 colporteur_domain: "{{ colporteur_subdomain }}.{{ domain }}"
+# renovate: datasource=github-releases depName=sripwoud/colporteur extractVersion=^v(?<version>.+)$
 colporteur_version: "0.5.0"
 colporteur_binary_url: "https://github.com/sripwoud/colporteur/releases/download/v{{ colporteur_version }}/colporteur-x86_64-unknown-linux-gnu.tar.gz"
 colporteur_checksum_url: "https://github.com/sripwoud/colporteur/releases/download/v{{ colporteur_version }}/colporteur-x86_64-unknown-linux-gnu.sha256"

--- a/ansible/roles/freshrss/defaults/main.yml
+++ b/ansible/roles/freshrss/defaults/main.yml
@@ -3,6 +3,7 @@ freshrss_sys_user: freshrss
 freshrss_sys_group: freshrss
 freshrss_port: 8084
 freshrss_domain: "{{ freshrss_subdomain }}.{{ domain }}"
+# renovate: datasource=github-releases depName=FreshRSS/FreshRSS
 freshrss_version: edge
 freshrss_data_dir: /var/lib/freshrss
 freshrss_db_type: sqlite

--- a/ansible/roles/gokapi/defaults/main.yml
+++ b/ansible/roles/gokapi/defaults/main.yml
@@ -8,6 +8,7 @@ gokapi_domain: "{{ gokapi_subdomain }}.{{ domain }}"
 gokapi_redirect_url: "/admin"
 gokapi_max_file_size_mb: 102400
 gokapi_max_memory_mb: 50
+# renovate: datasource=github-releases depName=Forceu/Gokapi extractVersion=^v(?<version>.+)$
 gokapi_version: "2.2.4"
 gokapi_archive_url: "https://github.com/Forceu/Gokapi/releases/download/v{{ gokapi_version }}/gokapi-{{ gokapi_version }}_linux-amd64.zip"
 gokapi_archive_sha256: "51dbf724c94f8afa0b40fb1ef63a1fe418e7996e7b9536e1f0a5da695b8e18ef"

--- a/ansible/roles/grimmory/defaults/main.yml
+++ b/ansible/roles/grimmory/defaults/main.yml
@@ -14,6 +14,7 @@ grimmory_admin_name: "{{ grimmory_admin_user }}"
 grimmory_admin_email: "{{ grimmory_admin_user }}@{{ domain }}"
 
 grimmory_github_repo: grimmory-tools/grimmory
+# renovate: datasource=github-releases depName=sripwoud/auberge extractVersion=^grimmory/v(?<version>.+)$
 grimmory_version: "2.3.0"
 grimmory_jar_url: "https://github.com/sripwoud/auberge/releases/download/grimmory/v{{ grimmory_version }}/grimmory-api.jar"
 grimmory_jvm_opts: "-Xmx768m -XX:+UseShenandoahGC -XX:+ExitOnOutOfMemoryError"

--- a/ansible/roles/headscale/defaults/main.yml
+++ b/ansible/roles/headscale/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+# renovate: datasource=github-releases depName=juanfont/headscale extractVersion=^v(?<version>.+)$
 headscale_version: "0.25.1"
 headscale_port: 8080
 headscale_metrics_port: 9091

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
+# renovate: datasource=github-releases depName=NousResearch/hermes-agent versioning=loose
 hermes_version: "v2026.4.13"
+# renovate: datasource=github-releases depName=astral-sh/uv
 hermes_uv_version: "0.7.0"
 hermes_user: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"
 hermes_group: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"

--- a/ansible/roles/paperless/defaults/main.yml
+++ b/ansible/roles/paperless/defaults/main.yml
@@ -1,3 +1,4 @@
+# renovate: datasource=github-releases depName=paperless-ngx/paperless-ngx extractVersion=^v(?<version>.+)$
 paperless_version: "2.20.10"
 paperless_install_path: /opt/paperless
 paperless_sys_user: paperless

--- a/ansible/roles/tgtg/defaults/main.yml
+++ b/ansible/roles/tgtg/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 tgtg_repo: "https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot.git"
+# renovate: datasource=github-releases depName=TorbenStriegel/TooGoodToGo-TelegramBot
 tgtg_version: "v2.0.2"
+# renovate: datasource=github-releases depName=astral-sh/uv
 tgtg_uv_version: "0.7.0"
 
 tgtg_sys_user: tgtg

--- a/ansible/roles/tgtg/defaults/main.yml
+++ b/ansible/roles/tgtg/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 tgtg_repo: "https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot.git"
-tgtg_version: "c8bfe46"
+tgtg_version: "v2.0.2"
 tgtg_uv_version: "0.7.0"
 
 tgtg_sys_user: tgtg

--- a/ansible/roles/yourls/defaults/main.yml
+++ b/ansible/roles/yourls/defaults/main.yml
@@ -2,6 +2,7 @@ yourls_install_path: /var/www/yourls
 yourls_sys_user: www-data
 yourls_sys_group: www-data
 yourls_domain: "{{ yourls_subdomain }}.{{ domain }}"
+# renovate: datasource=github-releases depName=YOURLS/YOURLS
 yourls_version: "1.10.2"
 
 yourls_db_name: yourls

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["custom.regex"],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "build",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Version variables in role defaults, each driven by its own `# renovate:` annotation",
+      "managerFilePatterns": ["/^ansible/roles/[^/]+/defaults/main\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\n[a-z0-9_]+_version: \"?(?<currentValue>[^\"\\n]+)\"?\\n"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "semanticCommitScope": "{{replace 'ansible/roles/(.+)/defaults/main\\.yml' '$1' packageFile}}",
+      "commitMessageAction": "bump",
+      "commitMessageTopic": "",
+      "commitMessageExtra": "to {{newValue}}"
+    },
+    {
+      "description": "hermes_uv_version and tgtg_uv_version are the same dep and must move together",
+      "matchDepNames": ["astral-sh/uv"],
+      "groupName": "uv",
+      "semanticCommitScope": "uv"
+    },
+    {
+      "description": "grimmory is auberge's own build output (build-grimmory.yml), not a dependency",
+      "matchDepNames": ["sripwoud/auberge"],
+      "enabled": false
+    }
+  ]
+}

--- a/tests/version_annotations.rs
+++ b/tests/version_annotations.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn roles_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ansible/roles")
+}
+
+fn is_version_variable(line: &str) -> Option<&str> {
+    let (key, _) = line.split_once(':')?;
+    (key.ends_with("_version")
+        && key
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'))
+    .then_some(key)
+}
+
+#[test]
+fn test_every_version_variable_carries_a_renovate_annotation() {
+    let mut checked = 0;
+    let mut violations = Vec::new();
+
+    for entry in fs::read_dir(roles_dir()).expect("ansible/roles must exist") {
+        let defaults = entry.unwrap().path().join("defaults/main.yml");
+        if !defaults.exists() {
+            continue;
+        }
+        let content = fs::read_to_string(&defaults).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+
+        for (i, line) in lines.iter().enumerate() {
+            let Some(key) = is_version_variable(line) else {
+                continue;
+            };
+            checked += 1;
+            let annotated = i > 0
+                && lines[i - 1].starts_with("# renovate: datasource=")
+                && lines[i - 1].contains(" depName=");
+            if !annotated {
+                violations.push(format!("{}: {key}", defaults.display()));
+            }
+        }
+    }
+
+    assert!(
+        checked >= 16,
+        "expected at least 16 version variables, found {checked} — did the roles layout move?"
+    );
+    assert!(
+        violations.is_empty(),
+        "version variables missing a `# renovate: datasource=… depName=…` annotation \
+         (see renovate.json customManagers):\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
Every Pinned version variable in `ansible/roles/*/defaults/main.yml` now carries its upstream coordinates in a `# renovate:` annotation, read by one `customManagers` regex — a new upstream release becomes a reviewable PR instead of silent drift. `headscale_version` sat four minor versions stale (`0.25.1` vs `0.29.3`) and nothing noticed; that PR now opens itself. Bumps land as `build(<app>): …`, matching `release_commits` in `release-plz.toml`, so each merged bump cuts a release.

Closes #408. First increment of ADR-0017; the Playbook Meta schema migration is #409, `auberge versions` is #410, Floating/Latest-at-Deploy conversion is #411.

## Annotations (16 variables, 13 files)

| quirk | variables |
|---|---|
| `extractVersion=^v(?<version>.+)$` | colporteur, gokapi, headscale, paperless, lego — upstream tags `vX.Y.Z`, variable stores `X.Y.Z` |
| `versioning=loose` | hermes — CalVer `v2026.4.13` can grow a 4th component strict semver drops |
| `datasource=go` | caddy `l4` + `cloudflare` plugins — xcaddy consumes Go modules; caddy-dns/cloudflare has no GitHub releases, only tags |
| grouped as `uv` | `hermes_uv_version` + `tgtg_uv_version` — same dep at `0.7.0`, moves in one PR |
| annotated but disabled | grimmory — auberge's own build output (`build-grimmory.yml`), in schema scope but out of Renovate scope |
| inert | freshrss — `edge` is not a valid version, so Renovate skips it; stays Floating until #411 |

## Misfit fixes

- lego `v4.23.1` was inline twice in a blocky task URL plus a sha256 literal → lifted to `blocky_lego_version` / `blocky_lego_url` / `blocky_lego_sha256`
- `tgtg_version` was a bare commit sha `c8bfe46`, strictly behind `v2.0.2` (ahead 0, behind 2) → repinned to the tag; gains an aiohttp security update and a startup-403 fix

## Enforcement

- `tests/version_annotations.rs` — every `<role>_version:` in role defaults must carry an annotation; a new role cannot silently sit outside the regime (same shape as `test_all_committed_playbooks_have_meta_files`)
- `renovate-checksums.yml` — on `renovate/**` branches, downloads the bumped asset and computes sha256 itself: gokapi publishes no checksum file upstream, and a checksum fetched beside the asset proves nothing regardless. Recomputes only when the rendered `<prefix>_url` changed against base, so untouched digests keep immutability-after-merge (re-tag detection). Pushes with `RELEASE_PLZ_TOKEN` because `GITHUB_TOKEN` pushes trigger no workflows.

## Test plan

- [x] `renovate-config-validator` (renovate 44.18.0) passes
- [x] regex extraction simulated over all defaults files: 16/16 deps with correct datasource / versioning / extractVersion
- [x] checksum script live-tested: lego digest re-verified from the real asset; simulated headscale `0.25.1→0.26.1` recompute matches upstream `checksums.txt`
- [x] 438 Rust tests, shell tests, ansible-lint, dprint, shellcheck/shfmt green
- [ ] post-merge acceptance: Renovate opens headscale `0.29.3` PR; single uv PR touching both roles; no grimmory PR