### PR TITLE
refactor(meta): declare App Versions in Playbook Meta, inject at deploy

### DIFF
--- a/.github/scripts/recompute-checksums.sh
+++ b/.github/scripts/recompute-checksums.sh
@@ -12,9 +12,9 @@
 # A digest variable <prefix>_sha256 / <prefix>_checksum pairs with the
 # <prefix>_url variable in the same defaults file. The digest is recomputed
 # only when the rendered URL changed against the base ref: the URL is a pure
-# function of the file's own variables, so an unchanged URL means the digest
-# must not move — its immutability after merge is what detects an upstream
-# re-tag (ADR-0017).
+# function of the file's own variables plus the App Version declared in the
+# App's Playbook Meta (ADR-0017), so an unchanged URL means the digest must
+# not move — its immutability after merge is what detects an upstream re-tag.
 #
 # Exit codes:
 #   0 — every stale digest recomputed (files modified in place) or none stale
@@ -39,8 +39,10 @@ emit_error() {
 }
 
 # Substitute {{ var }} references with assignments found in the same file.
+# The App Version is declared in the Playbook Meta rather than the defaults
+# file (ADR-0017), so {{ <app>_version }} resolves from the meta's `value:`.
 render_url() {
-  local file="${1}" value="${2}"
+  local file="${1}" meta_file="${2}" app="${3}" value="${4}"
   local iterations=0 var sub
   while [[ "${value}" == *'{{'* ]]; do
     if ((iterations >= 10)); then
@@ -54,6 +56,9 @@ render_url() {
       return 1
     fi
     sub="$(grep -oP "^${var}: \"?\K[^\"]+" "${file}" | head -1 || true)"
+    if [[ -z "${sub}" && "${var}" == "${app}_version" && -n "${meta_file}" ]]; then
+      sub="$(grep -oP '^  value: "?\K[^"]+' "${meta_file}" | head -1 || true)"
+    fi
     if [[ -z "${sub}" ]]; then
       emit_error "cannot resolve {{ ${var} }} from ${file}"
       return 1
@@ -70,7 +75,8 @@ raw_value() {
 }
 
 recompute_digest() {
-  local file="${1}" base_file="${2}" var_name="${3}" old_digest="${4}"
+  local file="${1}" base_file="${2}" meta_file="${3}" base_meta_file="${4}"
+  local app="${5}" var_name="${6}" old_digest="${7}"
   local url_var="${var_name%_*}_url"
   local head_tmpl head_url base_tmpl base_url new_digest asset
 
@@ -79,12 +85,12 @@ recompute_digest() {
     emit_error "${file}: ${var_name} has no paired ${url_var}"
     return 1
   fi
-  head_url="$(render_url "${file}" "${head_tmpl}")" || return 1
+  head_url="$(render_url "${file}" "${meta_file}" "${app}" "${head_tmpl}")" || return 1
 
   if [[ -n "${base_file}" ]]; then
     base_tmpl="$(raw_value "${base_file}" "${url_var}")"
     if [[ -n "${base_tmpl}" ]]; then
-      base_url="$(render_url "${base_file}" "${base_tmpl}")" || base_url=""
+      base_url="$(render_url "${base_file}" "${base_meta_file}" "${app}" "${base_tmpl}")" || base_url=""
       if [[ "${base_url}" == "${head_url}" ]]; then
         echo "${file}: ${url_var} unchanged, leaving ${var_name} alone"
         return 0
@@ -110,20 +116,46 @@ recompute_digest() {
 
 process_file() {
   local base_ref="${1}" file="${2}"
-  local status=0 base_file line var_name old_digest
+  local status=0 app base_file meta_file base_meta_file line var_name old_digest
 
-  base_file="${WORKDIR}/base-$(basename "$(dirname "$(dirname "${file}")")")"
+  app="$(basename "$(dirname "$(dirname "${file}")")")"
+
+  base_file="${WORKDIR}/base-${app}"
   if ! git show "${base_ref}:${file}" >"${base_file}" 2>/dev/null; then
     base_file=""
+  fi
+
+  meta_file="ansible/playbooks/${app}.meta.yml"
+  [[ -f "${meta_file}" ]] || meta_file=""
+
+  base_meta_file="${WORKDIR}/base-meta-${app}"
+  if ! git show "${base_ref}:ansible/playbooks/${app}.meta.yml" >"${base_meta_file}" 2>/dev/null; then
+    base_meta_file=""
   fi
 
   while IFS= read -r line; do
     var_name="${line%%:*}"
     old_digest="$(grep -oP '[0-9a-f]{64}' <<<"${line}")"
-    recompute_digest "${file}" "${base_file}" "${var_name}" "${old_digest}" \
+    recompute_digest "${file}" "${base_file}" "${meta_file}" "${base_meta_file}" \
+      "${app}" "${var_name}" "${old_digest}" \
       || status=1
   done < <(grep -E '^[a-z0-9_]+_(sha256|checksum): "(sha256:)?[0-9a-f]{64}"$' "${file}" || true)
   return "${status}"
+}
+
+# A version bump now lands in the App's Playbook Meta, so a changed meta
+# must re-render the digest-bearing defaults file of the same App.
+changed_defaults_files() {
+  local base_ref="${1}" file app
+  {
+    git diff --name-only "${base_ref}...HEAD" -- 'ansible/roles/*/defaults/main.yml'
+    while IFS= read -r file; do
+      app="$(basename "${file}" .meta.yml)"
+      if [[ -f "ansible/roles/${app}/defaults/main.yml" ]]; then
+        echo "ansible/roles/${app}/defaults/main.yml"
+      fi
+    done < <(git diff --name-only "${base_ref}...HEAD" -- 'ansible/playbooks/*.meta.yml')
+  } | sort -u
 }
 
 main() {
@@ -131,7 +163,7 @@ main() {
   local status=0 file
   while IFS= read -r file; do
     process_file "${base_ref}" "${file}" || status=1
-  done < <(git diff --name-only "${base_ref}...HEAD" -- 'ansible/roles/*/defaults/main.yml')
+  done < <(changed_defaults_files "${base_ref}")
   exit "${status}"
 }
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,11 +55,11 @@ _Avoid_: DNS setup, record creation, A-record provisioning
 **Version Resolution**:
 How a Playbook decides _which_ upstream version to install. Three regimes exist, and only one is legible to a dependency-update bot:
 
-- **Pinned** — an exact version literal in the role's `defaults/main.yml` (`<role>_version`), optionally with a co-pinned checksum. The same role revision installs the same bytes; upgrading is a repo edit, reviewed and released like any other change. The default for new roles (ADR-0016).
+- **Pinned** — an exact version literal in the repo, optionally with a co-pinned checksum: an **App Version** in the App's **Playbook Meta** `version:` block, a **Tool Version** in the role's `defaults/main.yml` (ADR-0017). The same role revision installs the same bytes; upgrading is a repo edit, reviewed and released like any other change. The default for new roles (ADR-0016).
 - **Floating** — a moving git ref (freshrss tracks the `edge` branch). Reproducible only by accident.
 - **Latest-at-Deploy** — the role queries `api.github.com/.../releases/latest` at run time (navidrome, baikal, blocky). The repo holds no record of what is installed; two deploys a day apart can differ. Baikal compounds this with a `when: not baikal_installed.stat.exists` guard, so it is latest at _first_ install and frozen thereafter — at a version recorded nowhere.
 
-A Pinned version is legible only if it is a **variable**: blocky's lego is pinned as a literal inside a task URL, so it is Pinned in effect but invisible to anything keyed on `<role>_version`.
+A Pinned version is legible only if it is a **variable**: a literal inside a task URL is Pinned in effect but invisible to anything keyed on `_version` — how lego's pin hid inside blocky's tasks until it was lifted into role defaults.
 Floating and Latest-at-Deploy are being retired — every App converges on Pinned (ADR-0017).
 _Avoid_: "pinning" unqualified (collides with APT pinning — source priority, a different mechanism), version strategy, update policy.
 
@@ -164,7 +164,7 @@ _Avoid_: Logger, reporter
 - An **App** is either a **Public App** or a **Tailnet-only App**, determined by the `tailnet_only` flag in its **Playbook Meta**. **DNS Publication** is dispatched accordingly.
 - The **Busy Feed** is derived from **Baikal**'s calendar data — plus, optionally, a read-only external CalDAV calendar fetched Host-side — and served on Baikal's **Public App** site (Google's servers must reach it); auberge produces and serves it but ships no consumer.
 - **Actual** relays sync between clients that each hold the full budget; its Backup Recipe path (`/var/lib/actual`) also carries the **Enable Banking** credentials, so restoring it restores bank sync.
-- An App's **Version Resolution** is implicit in its Playbook's tasks — unlike `tailnet_only` or the **Backup Recipe**, it is not declared in the **Playbook Meta** and nothing in auberge reads it. That is why the regimes drifted apart unnoticed.
+- An **App Version** is declared in the **Playbook Meta** and injected at deploy; only navidrome, baikal, and blocky still resolve theirs at run time, and freshrss still floats on `edge` (#411 retires both regimes).
 
 ## Example dialogue
 

--- a/ansible/playbooks/actual.meta.yml
+++ b/ansible/playbooks/actual.meta.yml
@@ -1,6 +1,10 @@
 required_keys: []
 tailnet_only: true
 subdomain: actual
+version:
+  value: "26.8.0"
+  datasource: npm
+  depName: "@actual-app/sync-server"
 backup:
   systemd_services: [actual]
   paths: [/var/lib/actual]

--- a/ansible/playbooks/bichon.meta.yml
+++ b/ansible/playbooks/bichon.meta.yml
@@ -1,6 +1,10 @@
 required_keys: []
 tailnet_only: true
 subdomain: bichon
+version:
+  value: "0.3.7"
+  datasource: github-releases
+  depName: "rustmailer/bichon"
 backup:
   systemd_services: [bichon]
   paths: [/var/lib/bichon-archive]

--- a/ansible/playbooks/colporteur.meta.yml
+++ b/ansible/playbooks/colporteur.meta.yml
@@ -1,2 +1,7 @@
 required_keys: []
 subdomain: colporteur
+version:
+  value: "0.5.0"
+  datasource: github-releases
+  depName: "sripwoud/colporteur"
+  extractVersion: "^v(?<version>.+)$"

--- a/ansible/playbooks/freshrss.meta.yml
+++ b/ansible/playbooks/freshrss.meta.yml
@@ -1,5 +1,9 @@
 required_keys: []
 subdomain: freshrss
+version:
+  value: "edge"
+  datasource: github-releases
+  depName: "FreshRSS/FreshRSS"
 backup:
   systemd_services: [freshrss]
   paths: [/var/lib/freshrss, /opt/freshrss/data]

--- a/ansible/playbooks/gokapi.meta.yml
+++ b/ansible/playbooks/gokapi.meta.yml
@@ -2,6 +2,11 @@ required_keys:
   - gokapi_admin_user
   - gokapi_admin_password
 subdomain: share
+version:
+  value: "2.2.4"
+  datasource: github-releases
+  depName: "Forceu/Gokapi"
+  extractVersion: "^v(?<version>.+)$"
 backup:
   systemd_services: [gokapi]
   paths: [/var/lib/gokapi]

--- a/ansible/playbooks/grimmory.meta.yml
+++ b/ansible/playbooks/grimmory.meta.yml
@@ -1,2 +1,7 @@
 required_keys: []
 subdomain: grimmory
+version:
+  value: "2.3.0"
+  datasource: github-releases
+  depName: "sripwoud/auberge"
+  extractVersion: "^grimmory/v(?<version>.+)$"

--- a/ansible/playbooks/headscale.meta.yml
+++ b/ansible/playbooks/headscale.meta.yml
@@ -1,5 +1,10 @@
 required_keys: []
 subdomain: hs
+version:
+  value: "0.25.1"
+  datasource: github-releases
+  depName: "juanfont/headscale"
+  extractVersion: "^v(?<version>.+)$"
 backup:
   systemd_services: [headscale]
   paths: [/var/lib/headscale]

--- a/ansible/playbooks/hermes.meta.yml
+++ b/ansible/playbooks/hermes.meta.yml
@@ -5,3 +5,8 @@ required_keys: [
   hermes_llm_api_key,
   hermes_telegram_bot_token,
 ]
+version:
+  value: "v2026.4.13"
+  datasource: github-releases
+  depName: "NousResearch/hermes-agent"
+  versioning: loose

--- a/ansible/playbooks/paperless.meta.yml
+++ b/ansible/playbooks/paperless.meta.yml
@@ -1,6 +1,11 @@
 required_keys: []
 tailnet_only: true
 subdomain: paperless
+version:
+  value: "2.20.10"
+  datasource: github-releases
+  depName: "paperless-ngx/paperless-ngx"
+  extractVersion: "^v(?<version>.+)$"
 backup:
   systemd_services:
     - paperless-webserver

--- a/ansible/playbooks/tgtg.meta.yml
+++ b/ansible/playbooks/tgtg.meta.yml
@@ -1,5 +1,9 @@
 required_keys:
   - tgtg_telegram_bot_token
+version:
+  value: "v2.0.2"
+  datasource: github-releases
+  depName: "TorbenStriegel/TooGoodToGo-TelegramBot"
 backup:
   systemd_services: [tgtg]
   paths: [/var/lib/tgtg]

--- a/ansible/playbooks/tgtg.meta.yml
+++ b/ansible/playbooks/tgtg.meta.yml
@@ -1,0 +1,6 @@
+required_keys:
+  - tgtg_telegram_bot_token
+backup:
+  systemd_services: [tgtg]
+  paths: [/var/lib/tgtg]
+  owner: [tgtg, tgtg]

--- a/ansible/playbooks/yourls.meta.yml
+++ b/ansible/playbooks/yourls.meta.yml
@@ -1,5 +1,9 @@
 required_keys: []
 subdomain: yourls
+version:
+  value: "1.10.2"
+  datasource: github-releases
+  depName: "YOURLS/YOURLS"
 backup:
   paths: [/var/www/yourls]
   owner: [www-data, www-data]

--- a/ansible/roles/actual/defaults/main.yml
+++ b/ansible/roles/actual/defaults/main.yml
@@ -5,7 +5,5 @@ actual_subdomain: actual
 actual_domain: "{{ actual_subdomain }}.{{ domain }}"
 actual_install_dir: /opt/actual
 actual_data_dir: /var/lib/actual
-# renovate: datasource=npm depName=@actual-app/sync-server
-actual_version: "26.8.0"
 actual_node_major: 22
 actual_nodesource_key_url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key

--- a/ansible/roles/bichon/defaults/main.yml
+++ b/ansible/roles/bichon/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# renovate: datasource=github-releases depName=rustmailer/bichon
-bichon_version: "0.3.7"
 bichon_port: 15630
 bichon_sys_user: bichon
 bichon_sys_group: bichon

--- a/ansible/roles/colporteur/defaults/main.yml
+++ b/ansible/roles/colporteur/defaults/main.yml
@@ -5,8 +5,6 @@ colporteur_data_dir: /var/lib/colporteur
 colporteur_feeds_dir: /var/lib/colporteur/feeds
 colporteur_config_dir: /etc/colporteur
 colporteur_domain: "{{ colporteur_subdomain }}.{{ domain }}"
-# renovate: datasource=github-releases depName=sripwoud/colporteur extractVersion=^v(?<version>.+)$
-colporteur_version: "0.5.0"
 colporteur_binary_url: "https://github.com/sripwoud/colporteur/releases/download/v{{ colporteur_version }}/colporteur-x86_64-unknown-linux-gnu.tar.gz"
 colporteur_checksum_url: "https://github.com/sripwoud/colporteur/releases/download/v{{ colporteur_version }}/colporteur-x86_64-unknown-linux-gnu.sha256"
 colporteur_check_interval: 15min

--- a/ansible/roles/freshrss/defaults/main.yml
+++ b/ansible/roles/freshrss/defaults/main.yml
@@ -3,7 +3,5 @@ freshrss_sys_user: freshrss
 freshrss_sys_group: freshrss
 freshrss_port: 8084
 freshrss_domain: "{{ freshrss_subdomain }}.{{ domain }}"
-# renovate: datasource=github-releases depName=FreshRSS/FreshRSS
-freshrss_version: edge
 freshrss_data_dir: /var/lib/freshrss
 freshrss_db_type: sqlite

--- a/ansible/roles/gokapi/defaults/main.yml
+++ b/ansible/roles/gokapi/defaults/main.yml
@@ -8,8 +8,6 @@ gokapi_domain: "{{ gokapi_subdomain }}.{{ domain }}"
 gokapi_redirect_url: "/admin"
 gokapi_max_file_size_mb: 102400
 gokapi_max_memory_mb: 50
-# renovate: datasource=github-releases depName=Forceu/Gokapi extractVersion=^v(?<version>.+)$
-gokapi_version: "2.2.4"
 gokapi_archive_url: "https://github.com/Forceu/Gokapi/releases/download/v{{ gokapi_version }}/gokapi-{{ gokapi_version }}_linux-amd64.zip"
 gokapi_archive_sha256: "51dbf724c94f8afa0b40fb1ef63a1fe418e7996e7b9536e1f0a5da695b8e18ef"
 gokapi_bootstrap_marker: "{{ gokapi_data_dir }}/.bootstrap_done"

--- a/ansible/roles/grimmory/defaults/main.yml
+++ b/ansible/roles/grimmory/defaults/main.yml
@@ -14,8 +14,6 @@ grimmory_admin_name: "{{ grimmory_admin_user }}"
 grimmory_admin_email: "{{ grimmory_admin_user }}@{{ domain }}"
 
 grimmory_github_repo: grimmory-tools/grimmory
-# renovate: datasource=github-releases depName=sripwoud/auberge extractVersion=^grimmory/v(?<version>.+)$
-grimmory_version: "2.3.0"
 grimmory_jar_url: "https://github.com/sripwoud/auberge/releases/download/grimmory/v{{ grimmory_version }}/grimmory-api.jar"
 grimmory_jvm_opts: "-Xmx768m -XX:+UseShenandoahGC -XX:+ExitOnOutOfMemoryError"
 

--- a/ansible/roles/headscale/defaults/main.yml
+++ b/ansible/roles/headscale/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# renovate: datasource=github-releases depName=juanfont/headscale extractVersion=^v(?<version>.+)$
-headscale_version: "0.25.1"
 headscale_port: 8080
 headscale_metrics_port: 9091
 headscale_stun_port: 3478

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# renovate: datasource=github-releases depName=NousResearch/hermes-agent versioning=loose
-hermes_version: "v2026.4.13"
 # renovate: datasource=github-releases depName=astral-sh/uv
 hermes_uv_version: "0.7.0"
 hermes_user: "{{ admin_user_name | default(ansible_user | default(ansible_ssh_user)) }}"

--- a/ansible/roles/paperless/defaults/main.yml
+++ b/ansible/roles/paperless/defaults/main.yml
@@ -1,5 +1,3 @@
-# renovate: datasource=github-releases depName=paperless-ngx/paperless-ngx extractVersion=^v(?<version>.+)$
-paperless_version: "2.20.10"
 paperless_install_path: /opt/paperless
 paperless_sys_user: paperless
 paperless_sys_group: paperless

--- a/ansible/roles/tgtg/defaults/main.yml
+++ b/ansible/roles/tgtg/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 tgtg_repo: "https://github.com/TorbenStriegel/TooGoodToGo-TelegramBot.git"
-# renovate: datasource=github-releases depName=TorbenStriegel/TooGoodToGo-TelegramBot
-tgtg_version: "v2.0.2"
 # renovate: datasource=github-releases depName=astral-sh/uv
 tgtg_uv_version: "0.7.0"
 

--- a/ansible/roles/yourls/defaults/main.yml
+++ b/ansible/roles/yourls/defaults/main.yml
@@ -2,8 +2,6 @@ yourls_install_path: /var/www/yourls
 yourls_sys_user: www-data
 yourls_sys_group: www-data
 yourls_domain: "{{ yourls_subdomain }}.{{ domain }}"
-# renovate: datasource=github-releases depName=YOURLS/YOURLS
-yourls_version: "1.10.2"
 
 yourls_db_name: yourls
 yourls_db_user: yourls

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,18 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Version variables in role defaults, each driven by its own `# renovate:` annotation",
+      "description": "Tool Versions in role defaults, each driven by its own `# renovate:` annotation",
       "managerFilePatterns": ["/^ansible/roles/[^/]+/defaults/main\\.yml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\n[a-z0-9_]+_version: \"?(?<currentValue>[^\"\\n]+)\"?\\n"
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "App Versions declared as typed `version:` blocks in Playbook Meta (ADR-0017)",
+      "managerFilePatterns": ["/^ansible/playbooks/[^/]+\\.meta\\.yml$/"],
+      "matchStrings": [
+        "version:\\n  value: \"?(?<currentValue>[^\"\\n]+)\"?\\n  datasource: (?<datasource>\\S+)\\n  depName: \"?(?<depName>[^\"\\n]+)\"?\\n(?:  versioning: (?<versioning>\\S+)\\n)?(?:  extractVersion: \"?(?<extractVersion>[^\"\\n]+)\"?\\n)?"
       ]
     }
   ],
@@ -21,6 +29,10 @@
       "commitMessageAction": "bump",
       "commitMessageTopic": "",
       "commitMessageExtra": "to {{newValue}}"
+    },
+    {
+      "matchFileNames": ["ansible/playbooks/*.meta.yml"],
+      "semanticCommitScope": "{{replace 'ansible/playbooks/(.+)\\.meta\\.yml' '$1' packageFile}}"
     },
     {
       "description": "hermes_uv_version and tgtg_uv_version are the same dep and must move together",

--- a/src/commands/ansible.rs
+++ b/src/commands/ansible.rs
@@ -1,5 +1,6 @@
 use crate::config::{Config, Preflight};
 use crate::output;
+use crate::playbook_meta::app_version_vars;
 use crate::prompt::select_item;
 use crate::services::ansible_runner::{InventoryHost, run_bootstrap, run_playbook};
 use crate::services::dependency_resolver::{
@@ -199,6 +200,16 @@ fn run_auto_resolved(
         tags.join(", ")
     ));
 
+    let assets = crate::ansible_assets::AnsibleAssets::prepare()?;
+    let app_versions = app_version_vars(&assets.playbooks_dir())?;
+    let mut extra_vars: Vec<(&str, &str)> = app_versions
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect();
+    if let Some(user) = user {
+        extra_vars.push(("ansible_user", user));
+    }
+
     for run in &runs {
         let playbook_file = run.path.file_name().and_then(|n| n.to_str()).unwrap_or("");
         let playbook_stem = run
@@ -236,8 +247,6 @@ fn run_auto_resolved(
             user: host.vars.bootstrap_user.clone(),
         };
 
-        let extra_vars = user.map(|u| vec![("ansible_user", u)]);
-
         let mut progress = crate::services::progress::TerminalProgress::new("");
         let result = run_playbook(
             &preflight,
@@ -246,7 +255,7 @@ fn run_auto_resolved(
             check,
             run_tags,
             skip_tags,
-            extra_vars.as_deref(),
+            Some(&extra_vars),
             false,
             ask_pass,
             &mut progress,
@@ -360,7 +369,15 @@ fn run_single_playbook(
         user: host.vars.bootstrap_user.clone(),
     };
 
-    let extra_vars = user.map(|u| vec![("ansible_user", u)]);
+    let assets = crate::ansible_assets::AnsibleAssets::prepare()?;
+    let app_versions = app_version_vars(&assets.playbooks_dir())?;
+    let mut extra_vars: Vec<(&str, &str)> = app_versions
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect();
+    if let Some(user) = user {
+        extra_vars.push(("ansible_user", user));
+    }
 
     let mut progress = crate::services::progress::TerminalProgress::new("");
     let result = run_playbook(
@@ -370,7 +387,7 @@ fn run_single_playbook(
         check,
         tags,
         skip_tags,
-        extra_vars.as_deref(),
+        Some(&extra_vars),
         false,
         ask_pass,
         &mut progress,

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -902,6 +902,12 @@ pub fn run_backup_restore(opts: RestoreOptions) -> Result<()> {
                     );
                 }
                 Ok(preflight) => {
+                    let app_versions =
+                        crate::playbook_meta::app_version_vars(&assets.playbooks_dir())?;
+                    let extra_vars: Vec<(&str, &str)> = app_versions
+                        .iter()
+                        .map(|(name, value)| (name.as_str(), value.as_str()))
+                        .collect();
                     let mut progress = crate::services::progress::TerminalProgress::new("");
                     match crate::services::ansible_runner::run_playbook(
                         &preflight,
@@ -910,7 +916,7 @@ pub fn run_backup_restore(opts: RestoreOptions) -> Result<()> {
                         false,
                         Some(&tags),
                         None,
-                        None,
+                        Some(&extra_vars),
                         false,
                         false,
                         &mut progress,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,6 +1,7 @@
 use crate::ansible_assets::AnsibleAssets;
 use crate::config::Config;
 use crate::output;
+use crate::playbook_meta::app_version_vars;
 use crate::prompt::{confirm, select_multi};
 use crate::services::ansible_runner::{InventoryHost, run_playbook};
 use crate::services::dependency_resolver::{
@@ -265,6 +266,12 @@ pub fn run_deploy(cmd: DeployCmd) -> Result<()> {
         user: host.vars.bootstrap_user.clone(),
     };
 
+    let app_versions = app_version_vars(&AnsibleAssets::prepare()?.playbooks_dir())?;
+    let extra_vars: Vec<(&str, &str)> = app_versions
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect();
+
     for (run, preflight) in runs.iter().zip(preflights.iter()) {
         let playbook_name = run
             .path
@@ -292,7 +299,7 @@ pub fn run_deploy(cmd: DeployCmd) -> Result<()> {
             cmd.check,
             run_tags,
             None,
-            None,
+            Some(&extra_vars),
             false,
             false,
             &mut progress,

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -8,11 +8,28 @@ pub struct PlaybookMeta {
     #[serde(default)]
     pub required_keys: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<AppVersion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backup: Option<BackupRecipe>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub tailnet_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subdomain: Option<String>,
+}
+
+/// The App Version: the identity of the deployed App, plus the upstream
+/// coordinates Renovate needs to discover new releases (ADR-0017).
+/// Field names match Renovate's regex manager vocabulary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppVersion {
+    pub value: String,
+    pub datasource: String,
+    pub dep_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub versioning: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extract_version: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -68,6 +85,37 @@ impl PlaybookMeta {
         serde_yaml::from_str(&contents)
             .wrap_err_with(|| format!("Failed to parse Playbook Meta from {}", path.display()))
     }
+}
+
+/// Collect every declared App Version as a `<app>_version` extra-var pair,
+/// sorted by name. Repo-owned data injected at deploy through `run_playbook`'s
+/// `extra_vars` seam — deliberately not part of user `Config` (ADR-0017).
+pub fn app_version_vars(playbooks_dir: &Path) -> Result<Vec<(String, String)>> {
+    let entries = std::fs::read_dir(playbooks_dir).wrap_err_with(|| {
+        format!(
+            "Failed to read playbooks directory {}",
+            playbooks_dir.display()
+        )
+    })?;
+
+    let mut vars = Vec::new();
+    for entry in entries {
+        let path = entry
+            .wrap_err("Failed to read playbooks directory entry")?
+            .path();
+        let Some(app) = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.strip_suffix(".meta.yml"))
+        else {
+            continue;
+        };
+        if let Some(version) = PlaybookMeta::load(&path)?.version {
+            vars.push((format!("{app}_version"), version.value));
+        }
+    }
+    vars.sort();
+    Ok(vars)
 }
 
 #[cfg(test)]
@@ -322,6 +370,95 @@ mod tests {
     fn test_playbook_meta_load_nonexistent_file_returns_error() {
         let result = PlaybookMeta::load(Path::new("/nonexistent/playbook.meta.yml"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_meta_version_block_parses() {
+        let yaml = r#"
+version:
+  value: "26.8.0"
+  datasource: npm
+  depName: "@actual-app/sync-server"
+"#;
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        let version = meta.version.unwrap();
+        assert_eq!(version.value, "26.8.0");
+        assert_eq!(version.datasource, "npm");
+        assert_eq!(version.dep_name, "@actual-app/sync-server");
+        assert!(version.versioning.is_none());
+        assert!(version.extract_version.is_none());
+    }
+
+    #[test]
+    fn test_meta_version_block_with_all_coordinates_parses() {
+        let yaml = r#"
+version:
+  value: "2.3.0"
+  datasource: github-releases
+  depName: "sripwoud/auberge"
+  versioning: loose
+  extractVersion: "^grimmory/v(?<version>.+)$"
+"#;
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        let version = meta.version.unwrap();
+        assert_eq!(version.versioning.as_deref(), Some("loose"));
+        assert_eq!(
+            version.extract_version.as_deref(),
+            Some("^grimmory/v(?<version>.+)$")
+        );
+    }
+
+    #[test]
+    fn test_meta_version_block_round_trips() {
+        let meta = PlaybookMeta {
+            required_keys: vec![],
+            version: Some(AppVersion {
+                value: "0.25.1".to_string(),
+                datasource: "github-releases".to_string(),
+                dep_name: "juanfont/headscale".to_string(),
+                versioning: None,
+                extract_version: Some("^v(?<version>.+)$".to_string()),
+            }),
+            backup: None,
+            tailnet_only: false,
+            subdomain: None,
+        };
+        let yaml = serde_yaml::to_string(&meta).unwrap();
+        let reparsed: PlaybookMeta = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(reparsed, meta);
+    }
+
+    #[test]
+    fn test_meta_without_version_parses_to_none() {
+        let yaml = "required_keys: []\n";
+        let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();
+        assert!(meta.version.is_none());
+    }
+
+    #[test]
+    fn test_app_version_vars_harvests_only_declared_versions() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("beta.meta.yml"),
+            "required_keys: []\nversion:\n  value: \"1.2.3\"\n  datasource: npm\n  depName: \"beta\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("alpha.meta.yml"),
+            "required_keys: []\nversion:\n  value: \"v9\"\n  datasource: github-releases\n  depName: \"a/a\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("gamma.meta.yml"), "required_keys: []\n").unwrap();
+        std::fs::write(dir.path().join("apps.yml"), "---\n- hosts: vps\n").unwrap();
+
+        let vars = app_version_vars(dir.path()).unwrap();
+        assert_eq!(
+            vars,
+            vec![
+                ("alpha_version".to_string(), "v9".to_string()),
+                ("beta_version".to_string(), "1.2.3".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -476,6 +476,28 @@ version:
     }
 
     #[test]
+    fn test_app_version_vars_injects_every_committed_app_version() {
+        let vars = app_version_vars(&playbooks_dir()).unwrap();
+        let names: Vec<&str> = vars.iter().map(|(name, _)| name.as_str()).collect();
+        for expected in [
+            "actual_version",
+            "bichon_version",
+            "colporteur_version",
+            "freshrss_version",
+            "gokapi_version",
+            "grimmory_version",
+            "headscale_version",
+            "hermes_version",
+            "paperless_version",
+            "tgtg_version",
+            "yourls_version",
+        ] {
+            assert!(names.contains(&expected), "missing extra var: {expected}");
+        }
+        assert!(vars.iter().all(|(_, value)| !value.is_empty()));
+    }
+
+    #[test]
     fn test_meta_without_backup_section_parses() {
         let yaml = "required_keys: [foo, bar]\n";
         let meta: PlaybookMeta = serde_yaml::from_str(yaml).unwrap();

--- a/src/playbook_meta.rs
+++ b/src/playbook_meta.rs
@@ -266,6 +266,20 @@ mod tests {
     }
 
     #[test]
+    fn test_tgtg_meta_backup_recipe() {
+        let meta = load_meta("tgtg");
+        assert!(
+            meta.required_keys
+                .contains(&"tgtg_telegram_bot_token".to_string())
+        );
+        let backup = meta.backup.expect("tgtg.meta.yml should declare backup");
+        assert_eq!(backup.systemd_services, vec!["tgtg"]);
+        assert_eq!(backup.paths, vec!["/var/lib/tgtg"]);
+        assert_eq!(backup.owner, Some(("tgtg".to_string(), "tgtg".to_string())));
+        assert!(backup.db.is_none());
+    }
+
+    #[test]
     fn test_headscale_meta_backup_recipe() {
         let backup = load_meta("headscale").backup.unwrap();
         assert_eq!(backup.systemd_services, vec!["headscale"]);

--- a/src/services/ansible_runner.rs
+++ b/src/services/ansible_runner.rs
@@ -41,6 +41,14 @@ pub struct InventoryHost {
     pub user: String,
 }
 
+fn extra_var_args(extra_vars: Option<&[(&str, &str)]>) -> Vec<String> {
+    extra_vars
+        .into_iter()
+        .flatten()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect()
+}
+
 fn write_extra_vars_file(flat_vars: &HashMap<String, String>) -> Result<tempfile::NamedTempFile> {
     let yaml = serde_yaml::to_string(flat_vars).wrap_err("Failed to serialize config to YAML")?;
     let mut tmpfile = tempfile::NamedTempFile::new().wrap_err("Failed to create temp file")?;
@@ -151,10 +159,8 @@ pub fn run_playbook(
         cmd.arg("--skip-tags").arg(skip_tags.join(","));
     }
 
-    if let Some(vars) = extra_vars {
-        for (key, value) in vars {
-            cmd.arg("-e").arg(format!("{}={}", key, value));
-        }
+    for var in extra_var_args(extra_vars) {
+        cmd.arg("-e").arg(var);
     }
 
     let needs_tty = ask_vault_pass || ask_pass || is_fresh_bootstrap;
@@ -329,6 +335,20 @@ mod tests {
         let formatted = format_ansible_task("role : sub : detail");
         assert!(formatted.contains("role:"));
         assert!(formatted.contains("sub : detail"));
+    }
+
+    #[test]
+    fn extra_var_args_formats_each_pair_as_key_equals_value() {
+        let vars = [("actual_version", "26.8.0"), ("ansible_user", "debian")];
+        assert_eq!(
+            extra_var_args(Some(&vars)),
+            vec!["actual_version=26.8.0", "ansible_user=debian"]
+        );
+    }
+
+    #[test]
+    fn extra_var_args_none_yields_no_args() {
+        assert!(extra_var_args(None).is_empty());
     }
 
     #[test]

--- a/src/services/backup/recipe.rs
+++ b/src/services/backup/recipe.rs
@@ -85,6 +85,7 @@ mod tests {
             "headscale",
             "navidrome",
             "paperless",
+            "tgtg",
             "yourls",
         ]
         .into_iter()

--- a/src/services/dns.rs
+++ b/src/services/dns.rs
@@ -405,6 +405,7 @@ mod tests {
         "hermes",
         "infrastructure",
         "remove-radicale",
+        "tgtg",
         "vibecoder",
     ];
 

--- a/tests/version_annotations.rs
+++ b/tests/version_annotations.rs
@@ -1,9 +1,35 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
 
 fn roles_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ansible/roles")
+    repo_root().join("ansible/roles")
 }
+
+fn playbooks_dir() -> PathBuf {
+    repo_root().join("ansible/playbooks")
+}
+
+/// Tool Versions: build/runtime inputs a role needs, not App identities.
+/// They stay in `defaults/main.yml` with a `# renovate:` annotation.
+/// A new `_version:` variable in defaults must either be an App Version
+/// (declare it in the App's `<app>.meta.yml` `version:` block instead) or
+/// be added here as a deliberate Tool Version decision (ADR-0017).
+const TOOL_VERSIONS: &[&str] = &[
+    "blocky_lego_version",
+    "caddy_cloudflare_plugin_version",
+    "caddy_l4_version",
+    "hermes_uv_version",
+    "tgtg_uv_version",
+];
+
+/// Roles that still resolve their own App Version at deploy time via
+/// `set_fact` from the GitHub releases/latest API. Pinned by #411; an
+/// entry removed here must gain a `version:` block in its meta.
+const PENDING_LATEST_AT_DEPLOY: &[&str] = &["blocky", "navidrome"];
 
 fn is_version_variable(line: &str) -> Option<&str> {
     let (key, _) = line.split_once(':')?;
@@ -14,16 +40,85 @@ fn is_version_variable(line: &str) -> Option<&str> {
     .then_some(key)
 }
 
+fn defaults_files() -> Vec<PathBuf> {
+    fs::read_dir(roles_dir())
+        .expect("ansible/roles must exist")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path().join("defaults/main.yml"))
+        .filter(|p| p.exists())
+        .collect()
+}
+
+/// Every `<app>.meta.yml` that declares a `version:` block, as
+/// `(app, version mapping)` pairs.
+fn meta_declared_versions() -> Vec<(String, serde_yaml::Mapping)> {
+    let mut versions = Vec::new();
+    for entry in fs::read_dir(playbooks_dir()).expect("ansible/playbooks must exist") {
+        let path = entry.unwrap().path();
+        let Some(app) = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.strip_suffix(".meta.yml"))
+        else {
+            continue;
+        };
+        let meta: serde_yaml::Value =
+            serde_yaml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        if let Some(version) = meta.get("version") {
+            versions.push((
+                app.to_string(),
+                version
+                    .as_mapping()
+                    .unwrap_or_else(|| panic!("{app}.meta.yml `version:` is not a mapping"))
+                    .clone(),
+            ));
+        }
+    }
+    versions.sort_by(|a, b| a.0.cmp(&b.0));
+    versions
+}
+
+fn contains_token(content: &str, token: &str) -> bool {
+    let is_word = |c: char| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_';
+    content.match_indices(token).any(|(i, _)| {
+        let before_ok = !content[..i].chars().next_back().is_some_and(is_word);
+        let after_ok = !content[i + token.len()..]
+            .chars()
+            .next()
+            .is_some_and(is_word);
+        before_ok && after_ok
+    })
+}
+
+fn role_references(role_dir: &Path, token: &str) -> bool {
+    fn walk(dir: &Path, token: &str) -> bool {
+        for entry in fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if path.is_dir() {
+                if walk(&path, token) {
+                    return true;
+                }
+            } else if let Ok(content) = fs::read_to_string(&path)
+                && contains_token(&content, token)
+            {
+                return true;
+            }
+        }
+        false
+    }
+    walk(role_dir, token)
+}
+
 #[test]
-fn test_every_version_variable_carries_a_renovate_annotation() {
-    let mut checked = 0;
+fn test_every_defaults_version_variable_is_an_annotated_tool_version() {
+    let mut found = Vec::new();
     let mut violations = Vec::new();
 
-    for entry in fs::read_dir(roles_dir()).expect("ansible/roles must exist") {
-        let defaults = entry.unwrap().path().join("defaults/main.yml");
-        if !defaults.exists() {
-            continue;
-        }
+    for defaults in defaults_files() {
         let content = fs::read_to_string(&defaults).unwrap();
         let lines: Vec<&str> = content.lines().collect();
 
@@ -31,24 +126,179 @@ fn test_every_version_variable_carries_a_renovate_annotation() {
             let Some(key) = is_version_variable(line) else {
                 continue;
             };
-            checked += 1;
+            found.push(key.to_string());
+            if !TOOL_VERSIONS.contains(&key) {
+                violations.push(format!(
+                    "{}: {key} is not a known Tool Version — an App Version \
+                     belongs in the App's `<app>.meta.yml` `version:` block (ADR-0017)",
+                    defaults.display()
+                ));
+            }
             let annotated = i > 0
                 && lines[i - 1].starts_with("# renovate: datasource=")
                 && lines[i - 1].contains(" depName=");
             if !annotated {
-                violations.push(format!("{}: {key}", defaults.display()));
+                violations.push(format!(
+                    "{}: {key} is missing a `# renovate: datasource=… depName=…` annotation \
+                     (see renovate.json customManagers)",
+                    defaults.display()
+                ));
             }
         }
     }
 
-    assert!(
-        checked >= 16,
-        "expected at least 16 version variables, found {checked} — did the roles layout move?"
+    found.sort();
+    assert_eq!(
+        found, TOOL_VERSIONS,
+        "Tool Versions in role defaults diverged from the allowlist"
     );
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}
+
+#[test]
+fn test_app_versions_live_only_in_playbook_meta() {
+    let defaults_keys: Vec<String> = defaults_files()
+        .iter()
+        .flat_map(|defaults| {
+            let content = fs::read_to_string(defaults).unwrap();
+            content
+                .lines()
+                .filter_map(|line| is_version_variable(line).map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let duplicated: Vec<String> = meta_declared_versions()
+        .iter()
+        .map(|(app, _)| format!("{app}_version"))
+        .filter(|key| defaults_keys.contains(key))
+        .collect();
+
     assert!(
-        violations.is_empty(),
-        "version variables missing a `# renovate: datasource=… depName=…` annotation \
-         (see renovate.json customManagers):\n{}",
-        violations.join("\n")
+        duplicated.is_empty(),
+        "App Versions declared in a Playbook Meta must not also be defined in role \
+         defaults — the value lives in exactly one file (ADR-0017): {}",
+        duplicated.join(", ")
     );
+}
+
+#[test]
+fn test_every_versioned_role_declares_an_app_version_in_its_meta() {
+    let declared: Vec<String> = meta_declared_versions()
+        .into_iter()
+        .map(|(app, _)| app)
+        .collect();
+    let mut violations = Vec::new();
+
+    for entry in fs::read_dir(roles_dir()).expect("ansible/roles must exist") {
+        let role_dir = entry.unwrap().path();
+        let Some(role) = role_dir.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let version_var = format!("{role}_version");
+        if !role_references(&role_dir, &version_var) {
+            continue;
+        }
+        if PENDING_LATEST_AT_DEPLOY.contains(&role) {
+            continue;
+        }
+        if !declared.contains(&role.to_string()) {
+            violations.push(format!(
+                "role `{role}` references {{{{ {version_var} }}}} but \
+                 {role}.meta.yml declares no `version:` block"
+            ));
+        }
+    }
+
+    for app in &declared {
+        let version_var = format!("{app}_version");
+        if !role_references(&roles_dir().join(app), &version_var) {
+            violations.push(format!(
+                "{app}.meta.yml declares a version but role `{app}` never \
+                 references {{{{ {version_var} }}}}"
+            ));
+        }
+    }
+
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}
+
+#[test]
+fn test_renovate_manager_matches_every_declared_app_version() {
+    let renovate: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(repo_root().join("renovate.json")).unwrap())
+            .unwrap();
+    let manager = renovate["customManagers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| {
+            m["managerFilePatterns"][0]
+                .as_str()
+                .unwrap_or("")
+                .contains("playbooks")
+        })
+        .expect("renovate.json must carry a customManager for playbook metas");
+
+    let file_pattern = manager["managerFilePatterns"][0]
+        .as_str()
+        .unwrap()
+        .trim_matches('/');
+    let file_regex = regex::Regex::new(file_pattern).unwrap();
+    let match_string = regex::Regex::new(manager["matchStrings"][0].as_str().unwrap()).unwrap();
+
+    let versions = meta_declared_versions();
+    assert!(
+        versions.len() >= 11,
+        "expected at least 11 declared App Versions, found {}",
+        versions.len()
+    );
+
+    for (app, declared) in versions {
+        let rel_path = format!("ansible/playbooks/{app}.meta.yml");
+        assert!(
+            file_regex.is_match(&rel_path),
+            "{rel_path} escapes the renovate managerFilePatterns"
+        );
+
+        let content = fs::read_to_string(repo_root().join(&rel_path)).unwrap();
+        let captures = match_string.captures(&content).unwrap_or_else(|| {
+            panic!("{app}.meta.yml `version:` block is invisible to the renovate matchString")
+        });
+
+        let field = |key: &str| {
+            declared
+                .get(serde_yaml::Value::String(key.to_string()))
+                .and_then(|v| v.as_str().map(str::to_string))
+        };
+        assert_eq!(
+            captures
+                .name("currentValue")
+                .map(|m| m.as_str().to_string()),
+            field("value"),
+            "{app}: currentValue capture diverges from `value:`"
+        );
+        assert_eq!(
+            captures.name("datasource").map(|m| m.as_str().to_string()),
+            field("datasource"),
+            "{app}: datasource capture diverges"
+        );
+        assert_eq!(
+            captures.name("depName").map(|m| m.as_str().to_string()),
+            field("depName"),
+            "{app}: depName capture diverges"
+        );
+        assert_eq!(
+            captures.name("versioning").map(|m| m.as_str().to_string()),
+            field("versioning"),
+            "{app}: versioning capture diverges"
+        );
+        assert_eq!(
+            captures
+                .name("extractVersion")
+                .map(|m| m.as_str().to_string()),
+            field("extractVersion"),
+            "{app}: extractVersion capture diverges"
+        );
+    }
 }


### PR DESCRIPTION
Closes #409. Core of ADR-0017. Rebased onto master after #412 squash-merged.

Version Resolution becomes declared data: each App's version moves out of `defaults/main.yml` into a typed `version:` block in its Playbook Meta — value plus Renovate coordinates as serde-validated schema fields — and reaches the role at deploy through `run_playbook`'s `extra_vars` seam (`-e` outranks defaults). 11 App Versions migrated; the 5 Tool Versions (`uv` ×2, `lego`, Caddy's `l4` + `cloudflare` plugins) stay annotated in defaults. tgtg gains the meta it never had, closing its Backup Recipe gap: `/var/lib/tgtg` (bot session state) now enrolls in every Backup Session.

## Engineering

- Each value lives in exactly one file: `test_app_versions_live_only_in_playbook_meta` fails on duplication, `test_every_versioned_role_declares_an_app_version_in_its_meta` on a missing or dead declaration (pending list: `blocky`, `navidrome` → #411).
- All declared versions are injected on every run — any `apps.yml` invocation can execute any app role; Ansible ignores unreferenced vars. App Versions are repo-owned data, not user `Config`: nothing added to `flat_vars()` or the Key Registry.
- Renovate gains a second `customManagers` regex over `ansible/playbooks/*.meta.yml`; `test_renovate_manager_matches_every_declared_app_version` runs the actual matchString from `renovate.json` against every meta, so a field reorder that blinds Renovate fails CI instead of silently dropping an App from the update regime. Commit scope keeps rendering as `build(<app>)`.
- `recompute-checksums.sh` resolves `{{ <app>_version }}` from the meta and re-renders an App's defaults when its meta changes — gokapi and headscale digest bumps stay covered.
- freshrss declares `value: "edge"` (still Floating, inert for Renovate) until #411 pins it.

> [!NOTE]
> `CONTEXT.md` line 62's "lego pinned as a literal inside a task URL" example was already stale after #412 lifted that pin into defaults; fixed here since the surrounding section changed anyway.

## Test plan

- [x] 450 tests pass (`rm -rf ansible/.ansible` first — embedded-cache trap)
- [x] 4 new governance tests in `tests/version_annotations.rs`, 8 new unit tests (`playbook_meta`, `ansible_runner`)
- [x] `ansible-lint`: 0 failures — no objection to roles whose defaults no longer define the referenced variable
- [x] `./.github/scripts/recompute-checksums.sh origin/master`: gokapi + headscale URLs render identically from meta → digests untouched; blocky digest verified by download
- [x] Real deploy: `AUBERGE_DEV=1 auberge deploy actual -H auberge -f` — hardening, infrastructure (headscale role included), apps --tags actual all green; host shows `@actual-app/sync-server` `26.8.0` and `headscale v0.25.1`, matching the metas
- [ ] Renovate opens a PR against a `*.meta.yml` (observable after merge)

https://claude.ai/code/session_01DMYbPASeMj7DXJvqdYthGu